### PR TITLE
[E2-2][P1] 期間計算ユーティリティ（長さ・日跨ぎ分割・重複判定）

### DIFF
--- a/src/domain/period.ts
+++ b/src/domain/period.ts
@@ -1,0 +1,210 @@
+import type { Entry } from "./entry.js";
+
+/**
+ * エントリを時間で切り出した断片。
+ *
+ * 分割・切り出しの結果を `Entry` で返すと、同じ `id` を持つ `Entry` が複数生まれる。
+ * それが永続化層（#9）や一覧表示に流れると、同一 id 前提の処理を壊しかねない。
+ * 「元エントリを参照する断片」であることを型で表し、`Entry` と混ざらないようにする。
+ */
+export interface EntrySegment {
+  /** 元になった `Entry` の id。断片同士で重複しうる。 */
+  readonly entryId: string;
+  /** ISO 8601（UTC）。 */
+  readonly start: string;
+  /** ISO 8601（UTC）。断片は必ず終端を持つ。 */
+  readonly end: string;
+  readonly tags: readonly string[];
+  readonly note?: string;
+}
+
+/** 抽出の対象期間。半開区間 `[start, end)` として扱う。 */
+export interface Period {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE;
+
+/**
+ * エントリの終端をミリ秒で得る。実行中なら `undefined`。
+ *
+ * 区間はすべて半開区間 `[start, end)` として扱う。これは DoD の
+ * 「端点が接するだけ（前の end と次の start が同時刻）は非重複」を満たすうえで、
+ * 分割・切り出しにも一貫して使える唯一の解釈のため。
+ */
+function endMs(entry: Entry): number | undefined {
+  return entry.end === undefined ? undefined : Date.parse(entry.end);
+}
+
+function startMs(entry: Entry): number {
+  return Date.parse(entry.start);
+}
+
+/**
+ * エントリの長さをミリ秒で返す。
+ *
+ * 実行中のエントリには終端がないため `asOf` が必要。domain から現在時刻を読まないので、
+ * 呼び出し側が明示的に渡す（CLAUDE.md の「時刻の直接取得を置かない」）。
+ * 完了しているエントリでは `asOf` は使わない。
+ */
+export function durationMs(entry: Entry, asOf?: Date): number {
+  const from = startMs(entry);
+  const to = endMs(entry);
+
+  if (to !== undefined) {
+    return to - from;
+  }
+
+  if (asOf === undefined) {
+    throw new Error("実行中のエントリの長さを求めるには asOf を渡してください");
+  }
+  if (Number.isNaN(asOf.getTime())) {
+    throw new Error("asOf が不正な Date です");
+  }
+  if (asOf.getTime() < from) {
+    throw new Error(`asOf が start より前です: start=${entry.start} asOf=${asOf.toISOString()}`);
+  }
+
+  return asOf.getTime() - from;
+}
+
+/** エントリの長さを秒で返す。端数は丸めない（丸めは #7 の担当）。 */
+export function durationSeconds(entry: Entry, asOf?: Date): number {
+  return durationMs(entry, asOf) / MS_PER_SECOND;
+}
+
+/** エントリの長さを分で返す。端数は丸めない（丸めは #7 の担当）。 */
+export function durationMinutes(entry: Entry, asOf?: Date): number {
+  return durationMs(entry, asOf) / MS_PER_MINUTE;
+}
+
+/** その時刻を含む UTC 日の 00:00:00.000 をミリ秒で返す。 */
+function startOfUtcDayMs(ms: number): number {
+  return Math.floor(ms / MS_PER_DAY) * MS_PER_DAY;
+}
+
+function segmentOf(entry: Entry, startAt: number, endAt: number): EntrySegment {
+  return {
+    entryId: entry.id,
+    start: new Date(startAt).toISOString(),
+    end: new Date(endAt).toISOString(),
+    tags: entry.tags,
+    ...(entry.note === undefined ? {} : { note: entry.note }),
+  };
+}
+
+/**
+ * 日を跨ぐエントリを UTC の日単位に分割する（23:00〜翌01:00 なら 2 件）。
+ *
+ * **境界は UTC 固定。** `Entry` が UTC 正規形で時刻を持つため、追加の情報なしに
+ * 決められる区切りは UTC しかない。利用者の地域時刻で日を区切る話は、
+ * タイムゾーン設定を扱う #22 の担当範囲。
+ *
+ * 半開区間なので、ちょうど日境界で終わるエントリは分割されない。
+ * 0 分エントリは長さ 0 のまま 1 件返す（記録を消さないため）。
+ */
+export function splitByUtcDay(entry: Entry): EntrySegment[] {
+  const to = endMs(entry);
+  if (to === undefined) {
+    throw new Error("実行中のエントリは分割できません（終端が決まらないため）");
+  }
+
+  const from = startMs(entry);
+  const segments: EntrySegment[] = [];
+
+  let cursor = from;
+  // 半開区間なので、境界ちょうどで終わる場合は次の日を作らない
+  while (cursor < to) {
+    const nextBoundary = startOfUtcDayMs(cursor) + MS_PER_DAY;
+    const segmentEnd = Math.min(nextBoundary, to);
+    segments.push(segmentOf(entry, cursor, segmentEnd));
+    cursor = segmentEnd;
+  }
+
+  // 0 分エントリは上のループが 1 度も回らないため、ここで 1 件返す
+  if (segments.length === 0) {
+    segments.push(segmentOf(entry, from, to));
+  }
+
+  return segments;
+}
+
+/**
+ * 2 つのエントリが時間的に重複しているか。
+ *
+ * 半開区間 `[start, end)` で判定するため、**端点が接するだけの場合は非重複**
+ * （前の end と次の start が同時刻）。長さ 0 のエントリは何も含まないため、
+ * どのエントリとも重複しない。二重打刻の検出が目的であり、瞬間の記録は
+ * 二重打刻にならない。
+ *
+ * 実行中のエントリは終端が未定なので、開始以降ずっと続くものとして扱う。
+ */
+export function overlaps(a: Entry, b: Entry): boolean {
+  const aStart = startMs(a);
+  const bStart = startMs(b);
+  const aEnd = endMs(a) ?? Number.POSITIVE_INFINITY;
+  const bEnd = endMs(b) ?? Number.POSITIVE_INFINITY;
+
+  // 長さ 0 の区間は何も含まないため、どの区間とも重ならない。
+  // 半開区間の一般的な判定式 `aStart < bEnd && bStart < aEnd` は退化した区間を
+  // 「点」として扱ってしまうので、先に除外する。
+  if (aStart === aEnd || bStart === bEnd) {
+    return false;
+  }
+
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function assertValidPeriod(period: Period): void {
+  if (Number.isNaN(period.start.getTime()) || Number.isNaN(period.end.getTime())) {
+    throw new Error("期間の境界が不正な Date です");
+  }
+  if (period.end.getTime() < period.start.getTime()) {
+    throw new Error("期間の end が start より前です");
+  }
+}
+
+/**
+ * 指定期間に含まれるエントリを取り出し、部分的にかかるものは期間の幅に切り出す。
+ *
+ * 期間は半開区間 `[start, end)`。端点が接するだけのエントリは含めない。
+ * 実行中のエントリは期間の終わりまでで切り出す。
+ *
+ * ただし**長さ 0 のエントリは、開始が期間内なら残す**。`overlaps` では
+ * 非重複として扱うが、こちらは集計・一覧のための抽出であり、記録された
+ * エントリが黙って消えるほうが利用者にとって不都合が大きい。
+ *
+ * 入力の順序は保ち、渡された配列は書き換えない。
+ */
+export function clipToPeriod(entries: readonly Entry[], period: Period): EntrySegment[] {
+  assertValidPeriod(period);
+
+  const periodStart = period.start.getTime();
+  const periodEnd = period.end.getTime();
+  const segments: EntrySegment[] = [];
+
+  for (const entry of entries) {
+    const from = startMs(entry);
+    const to = endMs(entry) ?? periodEnd;
+
+    if (from === to) {
+      // 長さ 0：開始が期間内（半開区間）なら残す
+      if (from >= periodStart && from < periodEnd) {
+        segments.push(segmentOf(entry, from, to));
+      }
+      continue;
+    }
+
+    const clippedStart = Math.max(from, periodStart);
+    const clippedEnd = Math.min(to, periodEnd);
+
+    if (clippedStart < clippedEnd) {
+      segments.push(segmentOf(entry, clippedStart, clippedEnd));
+    }
+  }
+
+  return segments;
+}

--- a/src/domain/period.ts
+++ b/src/domain/period.ts
@@ -1,4 +1,4 @@
-import type { Entry } from "./entry.js";
+import { endedAt, type Entry, startedAt } from "./entry.js";
 
 /**
  * エントリを時間で切り出した断片。
@@ -34,13 +34,17 @@ const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE;
  * 区間はすべて半開区間 `[start, end)` として扱う。これは DoD の
  * 「端点が接するだけ（前の end と次の start が同時刻）は非重複」を満たすうえで、
  * 分割・切り出しにも一貫して使える唯一の解釈のため。
+ *
+ * ISO 文字列を自前で解釈せず `entry.ts` の変換関数を通す。あちらが
+ * 「計算するときは startedAt / endedAt で Date に変換して扱う」と定めているため、
+ * 時刻の読み取り方をモジュール間で一致させる。
  */
 function endMs(entry: Entry): number | undefined {
-  return entry.end === undefined ? undefined : Date.parse(entry.end);
+  return endedAt(entry)?.getTime();
 }
 
 function startMs(entry: Entry): number {
-  return Date.parse(entry.start);
+  return startedAt(entry).getTime();
 }
 
 /**

--- a/tests/domain/period.test.ts
+++ b/tests/domain/period.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from "vitest";
+
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import {
+  clipToPeriod,
+  durationMinutes,
+  durationMs,
+  durationSeconds,
+  overlaps,
+  splitByUtcDay,
+} from "../../src/domain/period.js";
+
+let counter = 0;
+
+/** テスト用のエントリ。id はテストごとに一意になれば十分。 */
+function entry(start: string, end?: string, tags: readonly string[] = []): Entry {
+  counter += 1;
+  const id = `e${String(counter)}`;
+
+  return createEntry({ start, ...(end === undefined ? {} : { end }), tags }, { newId: () => id });
+}
+
+describe("長さの算出", () => {
+  it("1時間のエントリは 3600 秒 / 60 分", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(durationMs(e)).toBe(3_600_000);
+    expect(durationSeconds(e)).toBe(3600);
+    expect(durationMinutes(e)).toBe(60);
+  });
+
+  it("0分エントリ（同時刻）は 0 になる", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T01:00:00Z");
+
+    expect(durationMs(e)).toBe(0);
+    expect(durationSeconds(e)).toBe(0);
+    expect(durationMinutes(e)).toBe(0);
+  });
+
+  it("日を跨いでも実時間で計算する（23:00〜翌01:00 は 2 時間）", () => {
+    const e = entry("2026-08-12T23:00:00Z", "2026-08-13T01:00:00Z");
+
+    expect(durationMinutes(e)).toBe(120);
+  });
+
+  it("ミリ秒を含む差も落とさない", () => {
+    const e = entry("2026-08-12T01:00:00.000Z", "2026-08-12T01:00:00.500Z");
+
+    expect(durationMs(e)).toBe(500);
+    expect(durationSeconds(e)).toBe(0.5);
+  });
+
+  it("端数のある分は丸めずに返す（丸めは #7 の担当）", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T01:00:30Z");
+
+    expect(durationMinutes(e)).toBe(0.5);
+  });
+
+  it("実行中エントリは asOf を渡せばそこまでの長さを返す", () => {
+    const e = entry("2026-08-12T01:00:00Z");
+
+    expect(durationMinutes(e, new Date("2026-08-12T01:30:00Z"))).toBe(30);
+  });
+
+  it("実行中エントリで asOf を渡さないと失敗する（現在時刻を勝手に読まない）", () => {
+    const e = entry("2026-08-12T01:00:00Z");
+
+    expect(() => durationMs(e)).toThrow(/asOf/);
+  });
+
+  it("完了したエントリでは asOf を無視する", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(durationMinutes(e, new Date("2026-08-12T09:00:00Z"))).toBe(60);
+  });
+
+  it("asOf が start より前なら失敗する（負の長さを作らない）", () => {
+    const e = entry("2026-08-12T01:00:00Z");
+
+    expect(() => durationMs(e, new Date("2026-08-12T00:00:00Z"))).toThrow(/asOf/);
+  });
+
+  it("asOf が start と同時刻なら 0（境界）", () => {
+    const e = entry("2026-08-12T01:00:00Z");
+
+    expect(durationMs(e, new Date("2026-08-12T01:00:00Z"))).toBe(0);
+  });
+
+  it("asOf が Invalid Date なら失敗する", () => {
+    const e = entry("2026-08-12T01:00:00Z");
+
+    expect(() => durationMs(e, new Date("壊れた"))).toThrow(/asOf/);
+  });
+});
+
+describe("日跨ぎの分割", () => {
+  it("同じ日に収まるエントリは 1 件のまま", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z", ["work"]);
+
+    expect(splitByUtcDay(e)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T01:00:00.000Z",
+        end: "2026-08-12T02:00:00.000Z",
+        tags: ["work"],
+      },
+    ]);
+  });
+
+  it("23:00〜翌01:00 は 2 件に分かれる", () => {
+    const e = entry("2026-08-12T23:00:00Z", "2026-08-13T01:00:00Z");
+
+    expect(splitByUtcDay(e)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T23:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+      {
+        entryId: e.id,
+        start: "2026-08-13T00:00:00.000Z",
+        end: "2026-08-13T01:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("3 日に渡ると 3 件になり、中日は 24 時間になる", () => {
+    const e = entry("2026-08-12T22:00:00Z", "2026-08-14T02:00:00Z");
+
+    const segments = splitByUtcDay(e);
+
+    expect(segments.map((s) => [s.start, s.end])).toEqual([
+      ["2026-08-12T22:00:00.000Z", "2026-08-13T00:00:00.000Z"],
+      ["2026-08-13T00:00:00.000Z", "2026-08-14T00:00:00.000Z"],
+      ["2026-08-14T00:00:00.000Z", "2026-08-14T02:00:00.000Z"],
+    ]);
+  });
+
+  it("ちょうど日境界で終わるエントリは分割しない（同時刻境界）", () => {
+    const e = entry("2026-08-12T23:00:00Z", "2026-08-13T00:00:00Z");
+
+    expect(splitByUtcDay(e)).toHaveLength(1);
+  });
+
+  it("日境界に始まり日境界に終わる 1 日ちょうどは 1 件", () => {
+    const e = entry("2026-08-12T00:00:00Z", "2026-08-13T00:00:00Z");
+
+    expect(splitByUtcDay(e)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T00:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("0分エントリは長さ 0 のまま 1 件返す（消えない）", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T01:00:00Z");
+
+    expect(splitByUtcDay(e)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T01:00:00.000Z",
+        end: "2026-08-12T01:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("分割しても合計の長さは元と変わらない", () => {
+    const e = entry("2026-08-12T22:00:00Z", "2026-08-14T02:00:00Z");
+
+    const total = splitByUtcDay(e).reduce(
+      (sum, s) => sum + (Date.parse(s.end) - Date.parse(s.start)),
+      0,
+    );
+
+    expect(total).toBe(durationMs(e));
+  });
+
+  it("tags と note を各断片に引き継ぐ", () => {
+    const e = createEntry(
+      {
+        start: "2026-08-12T23:00:00Z",
+        end: "2026-08-13T01:00:00Z",
+        tags: ["work", "review"],
+        note: "夜間作業",
+      },
+      { newId: () => "fixed" },
+    );
+
+    for (const segment of splitByUtcDay(e)) {
+      expect(segment.tags).toEqual(["work", "review"]);
+      expect(segment.note).toBe("夜間作業");
+      expect(segment.entryId).toBe("fixed");
+    }
+  });
+
+  it("実行中エントリは分割できない（終端が決まらない）", () => {
+    const e = entry("2026-08-12T23:00:00Z");
+
+    expect(() => splitByUtcDay(e)).toThrow(/実行中/);
+  });
+});
+
+describe("重複判定", () => {
+  it("完全に重なるなら true", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T03:00:00Z");
+    const b = entry("2026-08-12T01:30:00Z", "2026-08-12T02:00:00Z");
+
+    expect(overlaps(a, b)).toBe(true);
+  });
+
+  it("部分的に重なるなら true", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const b = entry("2026-08-12T01:30:00Z", "2026-08-12T03:00:00Z");
+
+    expect(overlaps(a, b)).toBe(true);
+  });
+
+  it("端点が接するだけなら非重複（前の end と次の start が同時刻）", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const b = entry("2026-08-12T02:00:00Z", "2026-08-12T03:00:00Z");
+
+    expect(overlaps(a, b)).toBe(false);
+  });
+
+  it("端点が接するだけなら順序を入れ替えても非重複", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const b = entry("2026-08-12T02:00:00Z", "2026-08-12T03:00:00Z");
+
+    expect(overlaps(b, a)).toBe(false);
+  });
+
+  it("1 ミリ秒でも被れば重複（境界）", () => {
+    const a = entry("2026-08-12T01:00:00.000Z", "2026-08-12T02:00:00.001Z");
+    const b = entry("2026-08-12T02:00:00.000Z", "2026-08-12T03:00:00.000Z");
+
+    expect(overlaps(a, b)).toBe(true);
+  });
+
+  it("離れていれば false", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const b = entry("2026-08-12T05:00:00Z", "2026-08-12T06:00:00Z");
+
+    expect(overlaps(a, b)).toBe(false);
+  });
+
+  it("引数の順序を入れ替えても結果は同じ（対称）", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T03:00:00Z");
+    const b = entry("2026-08-12T02:00:00Z", "2026-08-12T04:00:00Z");
+
+    expect(overlaps(a, b)).toBe(overlaps(b, a));
+  });
+
+  it("0分エントリは他のエントリの内側にあっても非重複", () => {
+    const a = entry("2026-08-12T01:00:00Z", "2026-08-12T03:00:00Z");
+    const zero = entry("2026-08-12T02:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(overlaps(a, zero)).toBe(false);
+    expect(overlaps(zero, a)).toBe(false);
+  });
+
+  it("0分エントリ同士も非重複", () => {
+    const a = entry("2026-08-12T02:00:00Z", "2026-08-12T02:00:00Z");
+    const b = entry("2026-08-12T02:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(overlaps(a, b)).toBe(false);
+  });
+
+  it("実行中エントリは開始後のエントリすべてと重複する", () => {
+    const running = entry("2026-08-12T01:00:00Z");
+    const later = entry("2026-08-14T05:00:00Z", "2026-08-14T06:00:00Z");
+
+    expect(overlaps(running, later)).toBe(true);
+  });
+
+  it("実行中エントリは開始より前に閉じたエントリとは重複しない", () => {
+    const running = entry("2026-08-12T05:00:00Z");
+    const earlier = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(overlaps(running, earlier)).toBe(false);
+  });
+
+  it("実行中エントリ同士は重複する", () => {
+    const a = entry("2026-08-12T01:00:00Z");
+    const b = entry("2026-08-12T05:00:00Z");
+
+    expect(overlaps(a, b)).toBe(true);
+  });
+});
+
+describe("期間での抽出と切り出し", () => {
+  const periodStart = new Date("2026-08-12T00:00:00Z");
+  const periodEnd = new Date("2026-08-13T00:00:00Z");
+  const period = { start: periodStart, end: periodEnd };
+
+  it("完全に期間内ならそのまま返す", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z", ["work"]);
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T01:00:00.000Z",
+        end: "2026-08-12T02:00:00.000Z",
+        tags: ["work"],
+      },
+    ]);
+  });
+
+  it("前にはみ出す分は切り落とす", () => {
+    const e = entry("2026-08-11T23:00:00Z", "2026-08-12T01:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T00:00:00.000Z",
+        end: "2026-08-12T01:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("後にはみ出す分は切り落とす", () => {
+    const e = entry("2026-08-12T23:00:00Z", "2026-08-13T01:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T23:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("期間を覆うエントリは期間の幅に切り出す", () => {
+    const e = entry("2026-08-11T00:00:00Z", "2026-08-14T00:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T00:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("期間外のエントリは除外する", () => {
+    const before = entry("2026-08-10T01:00:00Z", "2026-08-10T02:00:00Z");
+    const after = entry("2026-08-20T01:00:00Z", "2026-08-20T02:00:00Z");
+
+    expect(clipToPeriod([before, after], period)).toEqual([]);
+  });
+
+  it("期間の終端に接するだけのエントリは除外する（同時刻境界）", () => {
+    const e = entry("2026-08-13T00:00:00Z", "2026-08-13T01:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([]);
+  });
+
+  it("期間の開始に接して終わるエントリは除外する（同時刻境界）", () => {
+    const e = entry("2026-08-11T23:00:00Z", "2026-08-12T00:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([]);
+  });
+
+  it("0件（空配列）を渡すと空配列を返す", () => {
+    expect(clipToPeriod([], period)).toEqual([]);
+  });
+
+  it("期間内の0分エントリは長さ 0 のまま残す（記録を失わない）", () => {
+    const e = entry("2026-08-12T02:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T02:00:00.000Z",
+        end: "2026-08-12T02:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("期間の開始と同時刻の0分エントリは残す（境界）", () => {
+    const e = entry("2026-08-12T00:00:00Z", "2026-08-12T00:00:00Z");
+
+    expect(clipToPeriod([e], period)).toHaveLength(1);
+  });
+
+  it("期間の終端と同時刻の0分エントリは除外する（境界）", () => {
+    const e = entry("2026-08-13T00:00:00Z", "2026-08-13T00:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([]);
+  });
+
+  it("実行中エントリは期間の終わりまでで切り出す", () => {
+    const e = entry("2026-08-12T22:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T22:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("期間より後に始まった実行中エントリは除外する", () => {
+    const e = entry("2026-08-20T00:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([]);
+  });
+
+  it("入力の順序を保つ", () => {
+    const first = entry("2026-08-12T05:00:00Z", "2026-08-12T06:00:00Z");
+    const second = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(clipToPeriod([first, second], period).map((s) => s.entryId)).toEqual([
+      first.id,
+      second.id,
+    ]);
+  });
+
+  it("渡した配列を書き換えない", () => {
+    const entries = [entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z")];
+    const snapshot = [...entries];
+
+    clipToPeriod(entries, period);
+
+    expect(entries).toEqual(snapshot);
+  });
+
+  it("期間の start と end が同時刻なら何も返さない（幅 0 の期間）", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const empty = { start: periodStart, end: periodStart };
+
+    expect(clipToPeriod([e], empty)).toEqual([]);
+  });
+
+  it("期間が逆順なら失敗する", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(() => clipToPeriod([e], { start: periodEnd, end: periodStart })).toThrow(/期間/);
+  });
+
+  it("期間の境界が Invalid Date なら失敗する", () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    expect(() => clipToPeriod([e], { start: new Date("壊れた"), end: periodEnd })).toThrow(/期間/);
+  });
+});

--- a/tests/domain/period.test.ts
+++ b/tests/domain/period.test.ts
@@ -398,6 +398,30 @@ describe("期間での抽出と切り出し", () => {
     expect(clipToPeriod([e], period)).toEqual([]);
   });
 
+  it("期間より前に始まった実行中エントリは期間の全体に切り出す（前夜から止めていない作業）", () => {
+    const e = entry("2026-08-11T22:00:00Z");
+
+    expect(clipToPeriod([e], period)).toEqual([
+      {
+        entryId: e.id,
+        start: "2026-08-12T00:00:00.000Z",
+        end: "2026-08-13T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("期間より何日も前に始まった実行中エントリでも、長さは期間の幅を超えない", () => {
+    const e = entry("2026-08-01T09:00:00Z");
+
+    const total = clipToPeriod([e], period).reduce(
+      (sum, s) => sum + (Date.parse(s.end) - Date.parse(s.start)),
+      0,
+    );
+
+    expect(total).toBe(periodEnd.getTime() - periodStart.getTime());
+  });
+
   it("実行中エントリは期間の終わりまでで切り出す", () => {
     const e = entry("2026-08-12T22:00:00Z");
 


### PR DESCRIPTION
## 概要

集計（#18 / #19）の土台になる時間計算を、副作用のない純関数として `src/domain/period.ts` に
追加した。ファイル I/O・現在時刻の取得・標準出力への書き込みは含みません。

Closes #6

### 区間はすべて半開区間 `[start, end)` で扱う

これが今回の設計の背骨です。DoD が「端点が接するだけ（前の end と次の start が同時刻）は
非重複」と定めているため、この解釈を**長さ・分割・重複・抽出の4機能すべてに一貫して適用**
しました。片方だけ閉区間にすると、分割した断片の境界が二重に数えられます。

### 長さの算出に `asOf` を渡せるようにした

実行中エントリには終端がありません。CLAUDE.md は `domain/` から現在時刻を直接取得することを
禁じているので、呼び出し側が明示的に渡す形にしています。

```ts
durationMinutes(completed)                              // end - start
durationMinutes(running, new Date("2026-08-12T01:30Z")) // asOf - start
durationMinutes(running)                                // → 失敗（現在時刻を勝手に読まない）
```

`asOf` が `start` より前の場合も失敗させます（負の長さを作らない）。#14 の `status`
コマンドがこの形で経過時間を出せます。

**端数は丸めません。** `durationMinutes` は 30 秒なら `0.5` を返します。丸め単位と
切上/切捨/四捨五入は #7 の担当範囲なので、ここで決めてしまわないようにしました。

### 分割・切り出しの結果は `Entry` ではなく `EntrySegment` で返す

分割結果を `Entry` で返すと、**同じ `id` を持つ `Entry` が複数生まれます**。それが
永続化層（#9）や一覧表示に流れると、「id は一意」という前提の処理を壊しかねません。

```ts
interface EntrySegment {
  readonly entryId: string;  // 元 Entry への参照。断片同士で重複しうる
  readonly start: string;
  readonly end: string;      // 断片は必ず終端を持つ
  readonly tags: readonly string[];
  readonly note?: string;
}
```

`tags` と `note` は各断片に引き継ぐので、タグ別集計はそのまま行えます。

### 日境界は UTC 固定（`splitByUtcDay`）

`Entry` は UTC 正規形で時刻を持つため、**追加の情報なしに決められる区切りは UTC だけ**です。
利用者の地域時刻で日を区切る話はタイムゾーン設定を扱う #22 の担当範囲なので、ここでは
UTC に固定し、**関数名にそれを出して**選択が隠れないようにしました。

推測でオフセット引数を先に足すことはしていません。#22 が設定オブジェクトの形で
タイムゾーンを扱うなら、今ここで足した引数は作り直しになるためです。

> **プロダクト上の注意**（レビューでの指摘）: この判断により、#22 が入るまで「日次」は
> UTC 日付になります。日本時間の 0 時で日を区切りたい利用者には期待と異なる区切りになります。

### 長さ 0 の扱いを用途で分けた

同じ「長さ 0」を、2つの関数で違う扱いにしています。意図的な非対称なので明記します。

| 関数 | 長さ0の扱い | 理由 |
| --- | --- | --- |
| `overlaps` | **非重複**（何とも重ならない） | 目的は二重打刻の検出。瞬間の記録は二重打刻にならない |
| `clipToPeriod` | **開始が期間内なら残す** | 目的は集計・一覧のための抽出。記録が黙って消えるほうが不都合 |

`splitByUtcDay` も長さ 0 のまま1件返します（消えない）。

### 実行中エントリの扱い

| 関数 | 扱い |
| --- | --- |
| `durationMs` / `Seconds` / `Minutes` | `asOf` が必要。なければ失敗 |
| `splitByUtcDay` | **失敗**（終端が決まらないため分割できない） |
| `overlaps` | 開始以降ずっと続くものとして扱う（終端を +∞ と見る） |
| `clipToPeriod` | 期間の終わりまでで切り出す（期間より前に始まっていれば期間の全体） |

### 時刻の読み取りは `entry.ts` の変換関数を通す

`entry.ts` が「計算するときは `startedAt` / `endedAt` で Date に変換して扱う」と定めている
のに対し、当初この PR は `Date.parse` を直接呼んでいました。挙動は同じですが、同じ
リポジトリ内で時刻の読み取り方が食い違うため、[レビュー指摘](https://github.com/okrago10/loop-demo/pull/34#issuecomment-5276495822)を受けて
`c84488c` で `startedAt` / `endedAt` 経由に揃えました。

## 受け入れ条件

- [x] 上記4機能が純関数として実装されている
- [x] 日跨ぎ・同時刻境界・0分エントリの各ケースにテストがある
- [x] 重複判定で「端点が接するだけ（前の end と次の start が同時刻）」を非重複として扱うテストがある

4機能の対応:

| スコープ | 実装 |
| --- | --- |
| エントリの長さ（分・秒）算出 | `durationMs` / `durationSeconds` / `durationMinutes` |
| 日を跨ぐエントリを日付単位に分割 | `splitByUtcDay` |
| 2つのエントリの重複判定 | `overlaps` |
| 指定期間に含まれるエントリの抽出（部分的にかかる場合は切り出す） | `clipToPeriod` |

### 検証結果

```
$ npm run check
> npm run typecheck && npm run lint && npm run format:check && npm test
 Test Files  6 passed (6)
      Tests  134 passed (134)
```

## テスト

`tests/domain/period.test.ts` を52件追加しました（全体 134件）。

DoD が名指しする3種の境界は次のとおりです。

**日跨ぎ**: 23:00〜翌01:00 が2件に分かれる / 3日に渡ると3件で中日が24時間 /
**分割しても合計の長さが元と変わらない** / 日境界に始まり日境界に終わる1日ちょうどは1件

**同時刻境界**: ちょうど日境界で終わるエントリは分割しない / 端点が接するだけの重複は
非重複（順序を入れ替えても） / 1ミリ秒でも被れば重複 / 期間の開始・終端に接するだけの
エントリは抽出から除外 / `asOf` が `start` と同時刻なら 0

**0分エントリ**: 長さは 0 / 分割しても1件残る / 他のエントリの内側にあっても非重複 /
0分同士も非重複 / 期間内なら抽出に残る / 期間の開始と同時刻なら残す / 期間の終端と
同時刻なら除外

**実行中エントリの下限側**（レビュー指摘を受けて `c84488c` で追加）:
**期間より前に始まった実行中エントリは期間の全体に切り出す**（前夜から止めていない作業）/
何日も前に始まっていても切り出し後の長さが期間の幅と一致する

追加したテストが回帰を検知することも実測しました。`?? periodEnd` を `?? from` に改変すると
3件が落ち、戻すと 52 件すべて通ります。

そのほか、`overlaps` の対称性、`clipToPeriod` が入力順を保つこと・渡された配列を
書き換えないこと、幅0の期間、逆順の期間、Invalid Date の期間境界、0件（空配列）も
含めています。

## スタック

- base: `main`（**スタックなし**）

当初は #33（Issue #5）の上に積んでいましたが、#33 がマージされたため base を `main` に
付け替え、`main` を取り込み済みです。#35 / #38 とは独立した並列で、互いのマージを
待ちません。

```
main
 ├─ PR#34 (Issue #6) ← この PR
 ├─ PR#35 (Issue #9)
 └─ PR#38 (Issue #12)
```

## CI

**GitHub Actions は動いています。** #32（CI ワークフロー）が `main` にマージされ、この
ブランチも `main` を取り込んだためです。作成当初は「この系統に CI がない」状態でしたが、
その記述は古くなったので削除しました。

## 依存の追加

**なし。** ランタイム依存も devDependencies も追加していません。
