### PR TITLE
[E3-1][P1] 永続化：ストアのインタフェースと JSONL 実装

### DIFF
--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -8,8 +8,13 @@ import type { Store, StoreRange } from "./store.js";
  * ファイルに書く 1 行の形。
  *
  * 追記のみで状態を表すため、更新と削除も「操作の記録」として追記する。読み出し時に
- * 先頭から畳み込んで現在の状態を作る。既存行を書き換えないので、途中で異常終了しても
- * それまでの記録が壊れない。
+ * 先頭から畳み込んで現在の状態を作る。既存行を書き換えないので、**書き終わった行**は
+ * 途中で異常終了しても壊れない。
+ *
+ * ただし保証はそこまでで、**最後の 1 操作までは守れない**。追記の途中で落ちて行が
+ * 途中で切れると、次の追記がその欠けた行の後ろに続いてしまい、両方まとめて壊れた 1 行
+ * として飛ばされる。1 操作の原子性まで担保するなら追記ではなく別の書き込み方が必要で、
+ * それは #10 / #11 の担当範囲。
  */
 type StoreRecord =
   | { readonly op: "append"; readonly entry: Entry }
@@ -24,7 +29,17 @@ function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
-/** ISO 8601（UTC 正規形）として読めるかを確かめる。 */
+/**
+ * 日時として読めるかを確かめる。
+ *
+ * **`createEntry` より基準は緩い。** あちらはタイムゾーン付き ISO 8601 であることと、
+ * 暦としてその日が実在することまで見るが、ここは `Date.parse` が通るかだけを見る。
+ * つまり手で編集してタイムゾーンなしの日時を書いた行は、書き込み時より甘い基準で
+ * 通過する。
+ *
+ * ここでの役目は「壊れて読めない行を落とす」ことに限る。保存済みデータの妥当性を
+ * どこまで遡って保証するかは #10（スキーマバージョンとマイグレーション）の担当範囲。
+ */
 function asTimestamp(value: unknown): string | undefined {
   const text = asNonEmptyString(value);
   if (text === undefined || Number.isNaN(Date.parse(text))) {

--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -227,8 +227,15 @@ export function createJsonlStore(filePath: string): Store {
       return [...state.values()].filter((entry) => {
         const entryStart = Date.parse(entry.start);
 
-        // 実行中・0 分は幅を持たないため、開始が範囲内かで判定する
-        if (entry.end === undefined || entry.end === entry.start) {
+        // 実行中は終端が未定なので、開始以降ずっと続くものとして扱う。
+        // 開始が範囲の終わりより前なら重なる（#6 の overlaps と同じ扱い）。
+        // 前日から続く未停止の作業を当日の範囲から落とさないため、下限は見ない
+        if (entry.end === undefined) {
+          return entryStart < to;
+        }
+
+        // 0 分は半開区間では幅のない点なので、開始が範囲内かで判定する
+        if (entry.end === entry.start) {
           return entryStart >= from && entryStart < to;
         }
 

--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -1,0 +1,257 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { Entry } from "../domain/entry.js";
+import type { Store, StoreRange } from "./store.js";
+
+/**
+ * ファイルに書く 1 行の形。
+ *
+ * 追記のみで状態を表すため、更新と削除も「操作の記録」として追記する。読み出し時に
+ * 先頭から畳み込んで現在の状態を作る。既存行を書き換えないので、途中で異常終了しても
+ * それまでの記録が壊れない。
+ */
+type StoreRecord =
+  | { readonly op: "append"; readonly entry: Entry }
+  | { readonly op: "update"; readonly entry: Entry }
+  | { readonly op: "delete"; readonly id: string };
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+/** ISO 8601（UTC 正規形）として読めるかを確かめる。 */
+function asTimestamp(value: unknown): string | undefined {
+  const text = asNonEmptyString(value);
+  if (text === undefined || Number.isNaN(Date.parse(text))) {
+    return undefined;
+  }
+
+  return text;
+}
+
+function asTags(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const tags: string[] = [];
+  for (const tag of value) {
+    const text = asNonEmptyString(tag);
+    if (text === undefined) {
+      return undefined;
+    }
+    tags.push(text);
+  }
+
+  return tags;
+}
+
+/**
+ * 読み込んだ値を `Entry` として受け取れるかを確かめる。
+ *
+ * ファイルの中身は外から書き換えられる可能性がある（手で編集する、別バージョンが
+ * 書いた、途中で壊れた）。`createEntry` を通っていない値が domain に流れないよう、
+ * 読み出し側でも形を確かめる。
+ */
+function asEntry(value: unknown): Entry | undefined {
+  if (!isRecordObject(value)) {
+    return undefined;
+  }
+
+  const id = asNonEmptyString(value["id"]);
+  const start = asTimestamp(value["start"]);
+  const tags = asTags(value["tags"]);
+  if (id === undefined || start === undefined || tags === undefined) {
+    return undefined;
+  }
+
+  const rawEnd = value["end"];
+  let end: string | undefined;
+  if (rawEnd !== undefined) {
+    end = asTimestamp(rawEnd);
+    if (end === undefined || Date.parse(end) < Date.parse(start)) {
+      return undefined;
+    }
+  }
+
+  const rawNote = value["note"];
+  let note: string | undefined;
+  if (rawNote !== undefined) {
+    if (typeof rawNote !== "string") {
+      return undefined;
+    }
+    note = rawNote;
+  }
+
+  return {
+    id,
+    start,
+    ...(end === undefined ? {} : { end }),
+    tags,
+    ...(note === undefined ? {} : { note }),
+  };
+}
+
+/** 1 行を操作の記録として読む。読めない行は `undefined`（呼び出し側で飛ばす）。 */
+function parseLine(line: string): StoreRecord | undefined {
+  if (line.trim() === "") {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+
+  if (!isRecordObject(parsed)) {
+    return undefined;
+  }
+
+  const op = parsed["op"];
+
+  if (op === "delete") {
+    const id = asNonEmptyString(parsed["id"]);
+    return id === undefined ? undefined : { op: "delete", id };
+  }
+
+  if (op === "append" || op === "update") {
+    const entry = asEntry(parsed["entry"]);
+    return entry === undefined ? undefined : { op, entry };
+  }
+
+  return undefined;
+}
+
+/**
+ * ファイルの内容を JSONL として読み、現在の状態に畳み込む。
+ *
+ * **読めない行は飛ばす。** 1 行の破損で全記録が読めなくなるほうが損失が大きい。
+ * 破損行の検知と修復は #10（スキーマとマイグレーション）の担当範囲。
+ *
+ * 追加順を保つため Map を使う。更新は元の位置に留まる。
+ */
+async function readState(filePath: string): Promise<Map<string, Entry>> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (isNotFound(error)) {
+      // ファイルが無い状態は「まだ記録がない」と同じ。読み出しでは作らない
+      return new Map();
+    }
+    throw error;
+  }
+
+  const state = new Map<string, Entry>();
+  for (const line of raw.split("\n")) {
+    const record = parseLine(line);
+    if (record === undefined) {
+      continue;
+    }
+
+    if (record.op === "delete") {
+      state.delete(record.id);
+    } else {
+      state.set(record.entry.id, record.entry);
+    }
+  }
+
+  return state;
+}
+
+function isNotFound(error: unknown): boolean {
+  return isRecordObject(error) && error["code"] === "ENOENT";
+}
+
+async function appendRecord(filePath: string, record: StoreRecord): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await appendFile(filePath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+/**
+ * JSONL ファイルによる追記のみのストア。
+ *
+ * 保存先は引数で受け取る。既定の場所を組み立てるのは `resolveStorePath` の役目で、
+ * テストは一時ディレクトリを指したパスを渡せる。
+ *
+ * 同時実行への保護は入れていない（#11 の担当範囲）。
+ */
+export function createJsonlStore(filePath: string): Store {
+  return {
+    async append(entry: Entry): Promise<void> {
+      const state = await readState(filePath);
+      if (state.has(entry.id)) {
+        throw new Error(`同じ id のエントリが既にあります: ${entry.id}`);
+      }
+
+      await appendRecord(filePath, { op: "append", entry });
+    },
+
+    async update(entry: Entry): Promise<void> {
+      const state = await readState(filePath);
+      if (!state.has(entry.id)) {
+        throw new Error(`更新対象のエントリが見つかりません: ${entry.id}`);
+      }
+
+      await appendRecord(filePath, { op: "update", entry });
+    },
+
+    async delete(id: string): Promise<void> {
+      const state = await readState(filePath);
+      if (!state.has(id)) {
+        throw new Error(`削除対象のエントリが見つかりません: ${id}`);
+      }
+
+      await appendRecord(filePath, { op: "delete", id });
+    },
+
+    async listByRange(range: StoreRange): Promise<Entry[]> {
+      const from = range.start.getTime();
+      const to = range.end.getTime();
+      if (Number.isNaN(from) || Number.isNaN(to)) {
+        throw new Error("範囲の境界が不正な Date です");
+      }
+      if (to < from) {
+        throw new Error("範囲の end が start より前です");
+      }
+
+      const state = await readState(filePath);
+
+      return [...state.values()].filter((entry) => {
+        const entryStart = Date.parse(entry.start);
+
+        // 実行中・0 分は幅を持たないため、開始が範囲内かで判定する
+        if (entry.end === undefined || entry.end === entry.start) {
+          return entryStart >= from && entryStart < to;
+        }
+
+        return entryStart < to && Date.parse(entry.end) > from;
+      });
+    },
+
+    async findRunning(): Promise<Entry | undefined> {
+      const state = await readState(filePath);
+
+      let latest: Entry | undefined;
+      for (const entry of state.values()) {
+        if (entry.end !== undefined) {
+          continue;
+        }
+        // 実行中が複数ある状態は本来起きないが、起きたときに stop できないと
+        // 手詰まりになる。最後に開始したものを返して復帰できるようにする
+        if (latest === undefined || Date.parse(entry.start) > Date.parse(latest.start)) {
+          latest = entry;
+        }
+      }
+
+      return latest;
+    },
+  };
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,72 @@
+import { join } from "node:path";
+
+import type { Entry } from "../domain/entry.js";
+
+/**
+ * 列挙する時間の範囲。半開区間 `[start, end)` として扱う。
+ *
+ * `domain/period.ts` の `Period`（#6）と構造的に同じ形にしてあるため、そちらが
+ * 入ったあとは変換なしでそのまま渡せる。store から domain の期間計算を参照すると
+ * 依存の向きが逆になるため、型の共有はしていない。
+ */
+export interface StoreRange {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/**
+ * 記録の永続化。
+ *
+ * 実装は差し替え可能にしてある（テストではファイルを使わない実装や一時ディレクトリを
+ * 指した実装を渡せる）。
+ */
+export interface Store {
+  /** 新しいエントリを追加する。同じ id が既にあれば失敗する。 */
+  append(entry: Entry): Promise<void>;
+
+  /** 既存のエントリを同じ id で置き換える。存在しなければ失敗する。 */
+  update(entry: Entry): Promise<void>;
+
+  /** エントリを削除する。存在しなければ失敗する。 */
+  delete(id: string): Promise<void>;
+
+  /**
+   * 範囲に時間が重なるエントリを列挙する。
+   *
+   * **切り出しは行わない。** 範囲からはみ出す部分を含めたエントリをそのまま返す。
+   * 期間で切り出したいときは `clipToPeriod`（#6）を使う。
+   * 並び順は追加した順で、並べ替えは表示側（#16）の担当。
+   */
+  listByRange(range: StoreRange): Promise<Entry[]>;
+
+  /** 実行中（`end` が未設定）のエントリを返す。なければ `undefined`。 */
+  findRunning(): Promise<Entry | undefined>;
+}
+
+/** 既定の保存先ディレクトリ名。 */
+const DEFAULT_DIR_NAME = ".tock";
+
+/** 保存先を差し替えるための環境変数。 */
+const DIR_ENV_NAME = "TOCK_DIR";
+
+/** 保存するファイル名。 */
+const FILE_NAME = "entries.jsonl";
+
+/**
+ * 保存先のパスを決める。
+ *
+ * 環境変数とホームディレクトリを引数で受け取るので、テストから実際の `~/.tock` を
+ * 触らずに検証できる。
+ */
+export function resolveStorePath(
+  env: Readonly<Record<string, string | undefined>>,
+  homeDir: string,
+): string {
+  const configured = env[DIR_ENV_NAME];
+
+  if (configured !== undefined && configured.trim() !== "") {
+    return join(configured, FILE_NAME);
+  }
+
+  return join(homeDir, DEFAULT_DIR_NAME, FILE_NAME);
+}

--- a/tests/store/jsonl-store.test.ts
+++ b/tests/store/jsonl-store.test.ts
@@ -1,0 +1,449 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { resolveStorePath, type Store } from "../../src/store/store.js";
+
+let dir = "";
+let file = "";
+let store: Store;
+let counter = 0;
+
+/** 実際の ~/.tock を触らないよう、テストごとに一時ディレクトリを作る。 */
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-store-"));
+  file = join(dir, "entries.jsonl");
+  store = createJsonlStore(file);
+  counter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function entry(start: string, end?: string, tags: readonly string[] = []): Entry {
+  counter += 1;
+  const id = `e${String(counter)}`;
+
+  return createEntry({ start, ...(end === undefined ? {} : { end }), tags }, { newId: () => id });
+}
+
+/** 全期間。listByRange で「全件」を得るために使う。 */
+const allTime = {
+  start: new Date("2000-01-01T00:00:00Z"),
+  end: new Date("2100-01-01T00:00:00Z"),
+};
+
+describe("保存先の解決", () => {
+  it("環境変数 TOCK_DIR があればそこを使う", () => {
+    const path = resolveStorePath({ TOCK_DIR: "/tmp/custom" }, "/home/someone");
+
+    expect(path).toBe(join("/tmp/custom", "entries.jsonl"));
+  });
+
+  it("環境変数がなければホームの .tock を使う", () => {
+    const path = resolveStorePath({}, "/home/someone");
+
+    expect(path).toBe(join("/home/someone", ".tock", "entries.jsonl"));
+  });
+
+  it("環境変数が空文字なら未設定として扱う", () => {
+    const path = resolveStorePath({ TOCK_DIR: "" }, "/home/someone");
+
+    expect(path).toBe(join("/home/someone", ".tock", "entries.jsonl"));
+  });
+});
+
+describe("ファイルがまだ無い場合", () => {
+  it("空として扱う（listByRange は 0 件）", async () => {
+    await expect(store.listByRange(allTime)).resolves.toEqual([]);
+  });
+
+  it("空として扱う（findRunning は undefined）", async () => {
+    await expect(store.findRunning()).resolves.toBeUndefined();
+  });
+
+  it("読み出しだけではファイルを作らない", async () => {
+    await store.listByRange(allTime);
+
+    await expect(readFile(file, "utf8")).rejects.toThrow();
+  });
+
+  it("初回の書き込みでファイルが生成される", async () => {
+    await store.append(entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z"));
+
+    const raw = await readFile(file, "utf8");
+
+    expect(raw.trimEnd().split("\n")).toHaveLength(1);
+  });
+
+  it("親ディレクトリが無くても作る", async () => {
+    const nested = createJsonlStore(join(dir, "a", "b", "entries.jsonl"));
+
+    await nested.append(entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z"));
+
+    await expect(nested.listByRange(allTime)).resolves.toHaveLength(1);
+  });
+});
+
+describe("append", () => {
+  it("追記したエントリを読み出せる", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z", ["work"]);
+
+    await store.append(e);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([e]);
+  });
+
+  it("複数件を追記順に読み出す", async () => {
+    const first = entry("2026-08-12T05:00:00Z", "2026-08-12T06:00:00Z");
+    const second = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    await store.append(first);
+    await store.append(second);
+
+    const ids = (await store.listByRange(allTime)).map((e) => e.id);
+
+    expect(ids).toEqual([first.id, second.id]);
+  });
+
+  it("1 件 1 行で書き込む（JSONL）", async () => {
+    await store.append(entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z"));
+    await store.append(entry("2026-08-12T03:00:00Z", "2026-08-12T04:00:00Z"));
+
+    const lines = (await readFile(file, "utf8")).trimEnd().split("\n");
+
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("同じ id を二重に追記したら失敗する", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    await store.append(e);
+
+    await expect(store.append(e)).rejects.toThrow(/id/);
+  });
+
+  it("実行中エントリ（end なし）も保存できる", async () => {
+    const running = entry("2026-08-12T01:00:00Z");
+
+    await store.append(running);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([running]);
+  });
+
+  it("note と tags を保存して復元する", async () => {
+    const e = createEntry(
+      {
+        start: "2026-08-12T01:00:00Z",
+        end: "2026-08-12T02:00:00Z",
+        tags: ["work", "review"],
+        note: "メモ",
+      },
+      { newId: () => "with-note" },
+    );
+
+    await store.append(e);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([e]);
+  });
+});
+
+describe("update", () => {
+  it("同じ id のエントリを置き換える", async () => {
+    const e = entry("2026-08-12T01:00:00Z");
+    await store.append(e);
+
+    const stopped = createEntry(
+      { start: e.start, end: "2026-08-12T02:00:00Z", tags: e.tags },
+      { newId: () => e.id },
+    );
+    await store.update(stopped);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([stopped]);
+  });
+
+  it("追記のみでファイルを書き換えない（append-only）", async () => {
+    const e = entry("2026-08-12T01:00:00Z");
+    await store.append(e);
+    const before = (await readFile(file, "utf8")).trimEnd().split("\n");
+
+    const stopped = createEntry(
+      { start: e.start, end: "2026-08-12T02:00:00Z", tags: e.tags },
+      { newId: () => e.id },
+    );
+    await store.update(stopped);
+    const after = (await readFile(file, "utf8")).trimEnd().split("\n");
+
+    expect(after).toHaveLength(before.length + 1);
+    expect(after.slice(0, before.length)).toEqual(before);
+  });
+
+  it("置き換えても並び順は元の位置を保つ", async () => {
+    const first = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const second = entry("2026-08-12T03:00:00Z", "2026-08-12T04:00:00Z");
+    await store.append(first);
+    await store.append(second);
+
+    const updated = createEntry(
+      { start: first.start, end: "2026-08-12T09:00:00Z", tags: [] },
+      { newId: () => first.id },
+    );
+    await store.update(updated);
+
+    const ids = (await store.listByRange(allTime)).map((e) => e.id);
+
+    expect(ids).toEqual([first.id, second.id]);
+  });
+
+  it("存在しない id を指定したら失敗する", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+
+    await expect(store.update(e)).rejects.toThrow(/見つかりません/);
+  });
+
+  it("削除済みの id を指定したら失敗する", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(e);
+    await store.delete(e.id);
+
+    await expect(store.update(e)).rejects.toThrow(/見つかりません/);
+  });
+});
+
+describe("delete", () => {
+  it("削除したエントリは読み出されない", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(e);
+
+    await store.delete(e.id);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([]);
+  });
+
+  it("他のエントリは残る", async () => {
+    const kept = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const removed = entry("2026-08-12T03:00:00Z", "2026-08-12T04:00:00Z");
+    await store.append(kept);
+    await store.append(removed);
+
+    await store.delete(removed.id);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([kept]);
+  });
+
+  it("追記のみでファイルを書き換えない（append-only）", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(e);
+    const before = (await readFile(file, "utf8")).trimEnd().split("\n");
+
+    await store.delete(e.id);
+    const after = (await readFile(file, "utf8")).trimEnd().split("\n");
+
+    expect(after).toHaveLength(before.length + 1);
+  });
+
+  it("存在しない id を指定したら失敗する", async () => {
+    await expect(store.delete("いない")).rejects.toThrow(/見つかりません/);
+  });
+
+  it("削除したあと同じ id を再度追記できる", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(e);
+    await store.delete(e.id);
+
+    await store.append(e);
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([e]);
+  });
+});
+
+describe("listByRange", () => {
+  const range = {
+    start: new Date("2026-08-12T00:00:00Z"),
+    end: new Date("2026-08-13T00:00:00Z"),
+  };
+
+  it("範囲に重なるエントリを返す", async () => {
+    const inside = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(inside);
+
+    await expect(store.listByRange(range)).resolves.toEqual([inside]);
+  });
+
+  it("範囲外のエントリは返さない", async () => {
+    await store.append(entry("2026-08-10T01:00:00Z", "2026-08-10T02:00:00Z"));
+    await store.append(entry("2026-08-20T01:00:00Z", "2026-08-20T02:00:00Z"));
+
+    await expect(store.listByRange(range)).resolves.toEqual([]);
+  });
+
+  it("部分的に重なるエントリは切り出さずそのまま返す（切り出しは #6 の担当）", async () => {
+    const across = entry("2026-08-11T23:00:00Z", "2026-08-12T01:00:00Z");
+    await store.append(across);
+
+    await expect(store.listByRange(range)).resolves.toEqual([across]);
+  });
+
+  it("日を跨ぐエントリも1件として返す", async () => {
+    const across = entry("2026-08-12T23:00:00Z", "2026-08-13T01:00:00Z");
+    await store.append(across);
+
+    await expect(store.listByRange(range)).resolves.toHaveLength(1);
+  });
+
+  it("範囲の終端に接するだけのエントリは含めない（同時刻境界）", async () => {
+    await store.append(entry("2026-08-13T00:00:00Z", "2026-08-13T01:00:00Z"));
+
+    await expect(store.listByRange(range)).resolves.toEqual([]);
+  });
+
+  it("範囲の開始に接して終わるエントリは含めない（同時刻境界）", async () => {
+    await store.append(entry("2026-08-11T23:00:00Z", "2026-08-12T00:00:00Z"));
+
+    await expect(store.listByRange(range)).resolves.toEqual([]);
+  });
+
+  it("範囲内の0分エントリは含める", async () => {
+    const zero = entry("2026-08-12T02:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(zero);
+
+    await expect(store.listByRange(range)).resolves.toEqual([zero]);
+  });
+
+  it("実行中エントリは開始が範囲内なら含める", async () => {
+    const running = entry("2026-08-12T22:00:00Z");
+    await store.append(running);
+
+    await expect(store.listByRange(range)).resolves.toEqual([running]);
+  });
+
+  it("範囲より後に始まった実行中エントリは含めない", async () => {
+    await store.append(entry("2026-08-20T00:00:00Z"));
+
+    await expect(store.listByRange(range)).resolves.toEqual([]);
+  });
+
+  it("範囲が逆順なら失敗する", async () => {
+    await expect(store.listByRange({ start: range.end, end: range.start })).rejects.toThrow(/範囲/);
+  });
+});
+
+describe("findRunning", () => {
+  it("実行中のエントリを返す", async () => {
+    const running = entry("2026-08-12T01:00:00Z");
+    await store.append(entry("2026-08-11T01:00:00Z", "2026-08-11T02:00:00Z"));
+    await store.append(running);
+
+    await expect(store.findRunning()).resolves.toEqual(running);
+  });
+
+  it("実行中がなければ undefined", async () => {
+    await store.append(entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z"));
+
+    await expect(store.findRunning()).resolves.toBeUndefined();
+  });
+
+  it("停止したあとは undefined になる", async () => {
+    const e = entry("2026-08-12T01:00:00Z");
+    await store.append(e);
+    const stopped = createEntry(
+      { start: e.start, end: "2026-08-12T02:00:00Z", tags: e.tags },
+      { newId: () => e.id },
+    );
+
+    await store.update(stopped);
+
+    await expect(store.findRunning()).resolves.toBeUndefined();
+  });
+
+  it("実行中が複数あれば最後に開始したものを返す（データ破損からの復帰用）", async () => {
+    const older = entry("2026-08-12T01:00:00Z");
+    const newer = entry("2026-08-12T05:00:00Z");
+    await store.append(older);
+    await store.append(newer);
+
+    await expect(store.findRunning()).resolves.toEqual(newer);
+  });
+});
+
+describe("壊れた行への耐性", () => {
+  it("不正 JSON が1行混ざっていても他の行を読み出せる", async () => {
+    const first = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    const second = entry("2026-08-12T03:00:00Z", "2026-08-12T04:00:00Z");
+    await store.append(first);
+    await writeFile(file, "これは JSON ではない\n", { flag: "a" });
+    await store.append(second);
+
+    const ids = (await store.listByRange(allTime)).map((e) => e.id);
+
+    expect(ids).toEqual([first.id, second.id]);
+  });
+
+  it("JSON だが形が違う行は飛ばす", async () => {
+    const valid = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(valid);
+    await writeFile(file, `${JSON.stringify({ op: "append", entry: 42 })}\n`, {
+      flag: "a",
+    });
+    await writeFile(file, `${JSON.stringify({ 未知: true })}\n`, { flag: "a" });
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([valid]);
+  });
+
+  it("start が壊れているエントリの行は飛ばす", async () => {
+    const valid = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(valid);
+    const broken = { op: "append", entry: { id: "x", start: "きのう", tags: [] } };
+    await writeFile(file, `${JSON.stringify(broken)}\n`, { flag: "a" });
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([valid]);
+  });
+
+  it("空行が混ざっていても読み出せる", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await store.append(e);
+    await writeFile(file, "\n\n   \n", { flag: "a" });
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([e]);
+  });
+
+  it("末尾が改行で終わっていなくても最後の行を読める", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z");
+    await writeFile(file, JSON.stringify({ op: "append", entry: e }));
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([e]);
+  });
+
+  it("壊れた行があっても findRunning は動く", async () => {
+    await writeFile(file, "壊れた行\n", { flag: "a" });
+    const running = entry("2026-08-12T01:00:00Z");
+    await store.append(running);
+
+    await expect(store.findRunning()).resolves.toEqual(running);
+  });
+
+  it("全行が壊れていれば 0 件として扱う", async () => {
+    await writeFile(file, "壊れ1\n壊れ2\n");
+
+    await expect(store.listByRange(allTime)).resolves.toEqual([]);
+    await expect(store.findRunning()).resolves.toBeUndefined();
+  });
+});
+
+describe("永続性", () => {
+  it("別のストアインスタンスからも同じ内容が読める（再起動相当）", async () => {
+    const e = entry("2026-08-12T01:00:00Z", "2026-08-12T02:00:00Z", ["work"]);
+    await store.append(e);
+
+    const reopened = createJsonlStore(file);
+
+    await expect(reopened.listByRange(allTime)).resolves.toEqual([e]);
+  });
+});

--- a/tests/store/jsonl-store.test.ts
+++ b/tests/store/jsonl-store.test.ts
@@ -324,6 +324,26 @@ describe("listByRange", () => {
     await expect(store.listByRange(range)).resolves.toEqual([running]);
   });
 
+  it("範囲より前に始まった実行中エントリも含める（前夜から続く作業）", async () => {
+    const running = entry("2026-08-11T22:00:00Z");
+    await store.append(running);
+
+    await expect(store.listByRange(range)).resolves.toEqual([running]);
+  });
+
+  it("実行中エントリは範囲開始と同時刻に始まっていても含める（境界）", async () => {
+    const running = entry("2026-08-12T00:00:00Z");
+    await store.append(running);
+
+    await expect(store.listByRange(range)).resolves.toEqual([running]);
+  });
+
+  it("実行中エントリが範囲終端と同時刻に始まったら含めない（境界）", async () => {
+    await store.append(entry("2026-08-13T00:00:00Z"));
+
+    await expect(store.listByRange(range)).resolves.toEqual([]);
+  });
+
   it("範囲より後に始まった実行中エントリは含めない", async () => {
     await store.append(entry("2026-08-20T00:00:00Z"));
 


### PR DESCRIPTION
## 概要

`Store` インタフェースと、JSONL による追記のみの実装を `src/store/` に追加した。
記録がローカルファイルに残り、再起動後も参照できる。

Closes #9

### 更新・削除も「操作の記録」として追記する

`append-only` を指定どおりに実装するため、`update` / `delete` も既存行を書き換えず
1 行追記し、**読み出し時に先頭から畳み込んで現在の状態を作ります**。

```jsonl
{"op":"append","entry":{"id":"a","start":"...","tags":[]}}
{"op":"update","entry":{"id":"a","start":"...","end":"...","tags":[]}}
{"op":"delete","id":"a"}
```

既存行に触らないので、**書き込み中に異常終了してもそれまでの記録が壊れません**。
ファイルが伸び続ける点は将来コンパクションが必要になりますが、それは今回のスコープ外です。

### 読めない行は飛ばす

DoD が「壊れた行が1行混ざっていても他の行を読み出せる」を求めているため、
**1 行の破損で全記録が読めなくなることを避ける**方針にしました。飛ばす対象は
不正 JSON だけでなく、JSON として読めても形が違う行も含みます。

破損行の検知・報告・修復は #10（スキーマバージョンとマイグレーション）の担当範囲なので、
ここでは黙って飛ばします。

### 読み出し側でも `Entry` の形を確かめる

`~/.tock/entries.jsonl` は**手で編集できる場所**にあります。別バージョンが書いた行や
途中で壊れた行もありえるため、`createEntry` を通っていない値が domain に流れる経路を
塞いでいます（`id` / `start` / `tags` の型と、`end` が `start` より前でないこと）。

domain 側の検証と一部重なりますが、こちらは**デシリアライズの信頼境界**という別の
役割です。

### 保存先の差し替え

Issue のスコープ「環境変数または引数」の両方を用意しました。

```ts
createJsonlStore(filePath)                       // 引数で直接指定（テストが使う）
resolveStorePath(process.env, homedir())         // 既定は ~/.tock/entries.jsonl
resolveStorePath({ TOCK_DIR: "/tmp/x" }, home)   // 環境変数で差し替え
```

`resolveStorePath` は環境変数とホームディレクトリを**引数で受け取る**ので、
テストが実際の `~/.tock` を読み書きすることはありません（CLAUDE.md の要求）。

### `listByRange` は切り出さず、重なるものを返す

範囲に時間が**重なる**エントリをそのまま返します。期間で切り出す処理は domain 側
（#6 の `clipToPeriod`）の役目で、**store が domain の期間計算を参照すると依存の向きが
逆になる**ためです。

そのため範囲の型 `StoreRange` は #6 の `Period` と**構造的に同じ形**にしてあり、
#6 が入ったあとは変換なしでそのまま渡せます。

エントリの種類ごとの判定は次のとおりです。

| 種類 | 判定 |
| --- | --- |
| 完了済み（幅あり） | `start < 範囲end` かつ `end > 範囲start` |
| **実行中**（`end` なし） | `start < 範囲end`（終端を +∞ とみなすため下限は見ない） |
| 0 分（`end === start`） | `範囲start <= start < 範囲end`（半開区間では幅のない点） |

実行中の扱いは当初 0 分と同じ「幅なし」にしており、[レビュー指摘](https://github.com/okrago10/loop-demo/pull/35#discussion_r3771379894)を受けて
`5a224df` で修正しました。**前夜 22:00 に開始して未停止の作業が、当日の範囲から
消える**という不具合でした。#6 の `overlaps` / `clipToPeriod` が実行中の終端を +∞ と
みなすのに対し store 側だけ解釈が違っていたため、#18 が両者を組むと夜間をまたいだ
作業が集計から落ちる状態でした。

並び順は追加した順です（更新しても元の位置に留まる）。並べ替えは表示側（#16）の担当。

### 実行中が複数ある場合の `findRunning`

本来起きない状態ですが、起きたときに `stop` できないと手詰まりになるため、
**最後に開始したものを返して復帰の余地を残します**。同時実行への保護そのものは
#11（ファイルロック）の担当範囲です。

## 受け入れ条件

- [x] 一時ディレクトリを使ったストアのテストがある
- [x] ファイルが存在しない場合に空として扱い、初回書き込みで生成されるテストがある
- [x] 壊れた行（不正 JSON）が1行混ざっていても、他の行を読み出せるテストがある

### 検証結果

```
$ npm run check
> tsc -p tsconfig.json --noEmit     （エラーなし）
> vitest run
 Test Files  4 passed (4)
      Tests  110 passed (110)
```

`npm run check` は初回で通り、**修正試行は 0 回**です（上記の修正はレビュー対応であり、
検証の失敗によるものではありません）。

## テスト

`tests/store/jsonl-store.test.ts` を49件追加しました（合計 61 → 110件）。

**すべてのテストが `mkdtemp` で作った一時ディレクトリを使い、`afterEach` で削除します。**
実際の `~/.tock` は一切触りません。

DoD が名指しする3点:

| DoD | テスト |
| --- | --- |
| 一時ディレクトリ | 全件が `os.tmpdir()` 配下の一時ディレクトリを使用 |
| ファイル未存在 | `listByRange` が0件 / `findRunning` が `undefined` / **読み出しだけではファイルを作らない** / 初回書き込みで生成 / 親ディレクトリが無くても作る |
| 壊れた行 | 不正 JSON が混ざっても他の行を読める / JSON だが形が違う行 / `start` が壊れた行 / 空行 / **末尾が改行で終わらない** / 壊れた行があっても `findRunning` が動く / 全行壊れていれば0件 |

そのほかの観点:

- **append-only の検証**: `update` / `delete` が既存行を書き換えず1行足すだけであること
  （前半の行が変化しないことを確認）
- **境界値**: 範囲の端点に接するだけのエントリは含めない、範囲内の0分エントリは含める、
  実行中エントリが範囲開始と同時刻／範囲終端と同時刻、**範囲より前に始まった実行中
  エントリ（前夜から続く作業）**、日跨ぎエントリ、範囲が逆順なら失敗、0件（空配列）
- **エラー**: 同じ id の二重追記、存在しない id の更新・削除、削除済み id の更新
- **復元**: 別のストアインスタンスから同じ内容が読める（再起動相当）、
  削除したあと同じ id を再追記できる
- **並び順**: 追記順を保つ、更新しても元の位置に留まる

## スタック

- base: `feat/5-entry-domain-model`（PR #33 / Issue #5）
- ※ **この PR は #30 → #33 のマージ後にレビューしてください。** 現在3段目です

依存先が E2-1 のみなので、#34 の上ではなく `feat/5-entry-domain-model` を base に
しました。#34（Issue #6）とは並列で、互いのマージを待ちません。

```
main
 └─ PR#30 (Issue #1)
     ├─ PR#31 (Issue #2) ─ PR#32 (Issue #3)
     └─ PR#33 (Issue #5) ─┬─ PR#34 (Issue #6)
                          └─ PR#35 (Issue #9) ← この PR
```

### CI と lint / format について

この系統には #32 の CI ワークフローがないため **GitHub Actions は起動しません**
（#33 / #34 と同じ理由）。base に oxlint / oxfmt もないため `npm run check` は
typecheck + test のみです。

#31 の設定を一時的に持ち込んで検証しました（設定ファイルはコミットしていません）。

```
oxlint 1.77.0（src / tests 全体）    → 終了コード 0
oxfmt 0.62.0 --check（新規3ファイル） → 終了コード 0
```

なお `oxfmt` を `src` / `tests` 全体にかけると `src/cli.ts` `src/version.ts`
`tests/cli.test.ts` `tests/version.test.ts` が未整形として出ますが、これは **#1 由来の
ファイルで #31 が整形する対象**であり、この PR では触っていません。

## 依存の追加

**なし。** ファイル I/O は Node 標準の `node:fs/promises` と `node:path` のみです。
