### PR TITLE
[E4-1][P1] CLI の骨格（引数パース・ヘルプ・終了コード）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,31 +4,148 @@ import { fileURLToPath } from "node:url";
 
 import { readVersion } from "./version.js";
 
+/** 正常終了。 */
+export const EXIT_OK = 0;
+
+/** ユーザー起因のエラー（コマンドの打ち間違い、入力の不備など）。 */
+export const EXIT_USAGE = 1;
+
+/** 内部エラー（想定していない例外）。 */
+export const EXIT_INTERNAL = 2;
+
 /**
- * CLI が外の世界に触る部分。テストから差し替えられるよう引数で受け取る。
+ * ユーザー起因のエラー。
+ *
+ * これを投げたコマンドは終了コード 1 になる。想定外の例外（終了コード 2）と
+ * 区別するために型を分ける。利用者に見せて意味のあるメッセージだけをここに入れる。
  */
-export interface CliDeps {
-  /** 1行を出力する。改行の付与は呼び出し側の責務にしない。 */
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserError";
+  }
+}
+
+/** CLI の入出力。テストから差し替えられるよう引数で受け取る。 */
+export interface CliIo {
+  /** 通常の出力（stdout）。1行ずつ渡す。改行の付与は呼び出し側の責務にしない。 */
   readonly out: (line: string) => void;
+  /** エラーの出力（stderr）。 */
+  readonly err: (line: string) => void;
+}
+
+/**
+ * サブコマンド1つ分。
+ *
+ * 実装は `src/commands/` に置く（#13 以降）。ここでは器の契約だけを定める。
+ */
+export interface Command {
+  /** `tock <name>` で呼ばれる名前。 */
+  readonly name: string;
+  /** `--help` の一覧に出す1行説明。 */
+  readonly summary: string;
+  /**
+   * コマンド名より後ろの引数を受け取って実行する。
+   *
+   * ユーザー起因のエラーは `UserError` を投げる。それ以外の例外は内部エラーとして扱う。
+   */
+  run(argv: readonly string[], io: CliIo): void | Promise<void>;
+}
+
+export interface CliDeps extends CliIo {
   /** 自身のバージョンを返す。 */
   readonly version: () => string;
+  /** 登録されているサブコマンド。 */
+  readonly commands: readonly Command[];
+}
+
+const HELP_FLAGS = new Set(["--help", "-h"]);
+const VERSION_FLAGS = new Set(["--version", "-v"]);
+
+/** 使い方を組み立てる。出力先は呼び出し側が決める（ヘルプなら stdout、エラーなら stderr）。 */
+function usageLines(commands: readonly Command[]): string[] {
+  const lines = ["使い方: tock <command> [args]", "", "コマンド:"];
+
+  if (commands.length === 0) {
+    lines.push("  （利用できるコマンドはまだありません）");
+  } else {
+    const width = Math.max(...commands.map((command) => command.name.length));
+    for (const command of commands) {
+      lines.push(`  ${command.name.padEnd(width)}  ${command.summary}`);
+    }
+  }
+
+  lines.push("", "オプション:", "  -h, --help     この使い方を表示する");
+  lines.push("  -v, --version  バージョンを表示する");
+
+  return lines;
+}
+
+function writeAll(lines: readonly string[], write: (line: string) => void): void {
+  for (const line of lines) {
+    write(line);
+  }
+}
+
+/** 例外から利用者に見せるメッセージを取り出す。Error でない値を投げられても落ちない。 */
+function messageOf(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }
 
 /**
- * CLI の雛形。現時点では `--version` のみを扱う。
+ * CLI の入口。終了コードを返すだけで、`process.exit` は呼ばない。
  *
- * 本格的な引数パース・ヘルプ・終了コードの体系は #12 で入れるため、
- * ここでは意図的に最小限に留めている。
+ * 終了コードを返す形にしているのは、テストからプロセスを終わらせずに検証できるようにする
+ * ため。実際の終了はこのファイル末尾の起動部が行う。
+ *
+ * `Promise` を返すのは、以降のサブコマンドがファイル I/O を伴うため（#13 以降）。
  */
-export function run(argv: readonly string[], deps: CliDeps): number {
-  if (argv.includes("--version") || argv.includes("-v")) {
-    deps.out(deps.version());
-    return 0;
+export async function run(argv: readonly string[], deps: CliDeps): Promise<number> {
+  const [first, ...rest] = argv;
+
+  if (first === undefined) {
+    // コマンド未指定は打ち間違いではなく「何ができるか知りたい」と解釈する
+    writeAll(usageLines(deps.commands), deps.out);
+    return EXIT_OK;
   }
 
-  deps.out("tock — 作業時間トラッカー");
-  return 0;
+  if (HELP_FLAGS.has(first)) {
+    writeAll(usageLines(deps.commands), deps.out);
+    return EXIT_OK;
+  }
+
+  if (VERSION_FLAGS.has(first)) {
+    deps.out(deps.version());
+    return EXIT_OK;
+  }
+
+  const command = deps.commands.find((candidate) => candidate.name === first);
+  if (command === undefined) {
+    deps.err(`不明なコマンドです: ${first}`);
+    deps.err("");
+    writeAll(usageLines(deps.commands), deps.err);
+    return EXIT_USAGE;
+  }
+
+  try {
+    await command.run(rest, { out: deps.out, err: deps.err });
+    return EXIT_OK;
+  } catch (error) {
+    deps.err(messageOf(error));
+    return error instanceof UserError ? EXIT_USAGE : EXIT_INTERNAL;
+  }
 }
+
+/**
+ * 登録されているサブコマンド。
+ *
+ * 実装は #13 以降で追加する。現時点では空なので `tock --help` はコマンドなしと表示する。
+ */
+const commands: readonly Command[] = [];
 
 /**
  * このファイルがプロセスのエントリポイントとして起動されたかを判定する。
@@ -50,10 +167,14 @@ function invokedAsEntryPoint(): boolean {
 }
 
 if (invokedAsEntryPoint()) {
-  process.exitCode = run(process.argv.slice(2), {
+  process.exitCode = await run(process.argv.slice(2), {
     out: (line) => {
       process.stdout.write(`${line}\n`);
     },
+    err: (line) => {
+      process.stderr.write(`${line}\n`);
+    },
     version: readVersion,
+    commands,
   });
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,62 +1,336 @@
 import { describe, expect, it } from "vitest";
 
-import { run } from "../src/cli.js";
+import { type Command, EXIT_INTERNAL, EXIT_OK, EXIT_USAGE, run, UserError } from "../src/cli.js";
 
-/** 出力を配列に集めるだけの `out`。標準出力に書かないためテストが環境を汚さない。 */
-function collector(): { lines: string[]; out: (line: string) => void } {
-  const lines: string[] = [];
-  return { lines, out: (line) => lines.push(line) };
+/** stdout / stderr を別々に集める。混ざっていないことを検証できる。 */
+function collector(): {
+  out: string[];
+  err: string[];
+  io: { out: (line: string) => void; err: (line: string) => void };
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+
+  return {
+    out,
+    err,
+    io: {
+      out: (line) => out.push(line),
+      err: (line) => err.push(line),
+    },
+  };
 }
 
-describe("run", () => {
-  it("--version でバージョンを1行だけ出力し、終了コード 0 を返す", () => {
-    const { lines, out } = collector();
+function command(name: string, summary: string, body?: Command["run"]): Command {
+  return {
+    name,
+    summary,
+    run: body ?? ((): void => undefined),
+  };
+}
 
-    const code = run(["--version"], { out, version: () => "9.9.9" });
+const sampleCommands: readonly Command[] = [
+  command("start", "作業を開始する"),
+  command("stop", "作業を終了する"),
+];
 
-    expect(code).toBe(0);
-    expect(lines).toEqual(["9.9.9"]);
+function deps(
+  io: { out: (line: string) => void; err: (line: string) => void },
+  commands: readonly Command[] = sampleCommands,
+) {
+  return { ...io, version: () => "9.9.9", commands };
+}
+
+describe("--help", () => {
+  it("サブコマンド一覧を出力し、終了コード 0 を返す", async () => {
+    const { out, io } = collector();
+
+    const code = await run(["--help"], deps(io));
+
+    expect(code).toBe(EXIT_OK);
+    const text = out.join("\n");
+    expect(text).toContain("start");
+    expect(text).toContain("作業を開始する");
+    expect(text).toContain("stop");
+    expect(text).toContain("作業を終了する");
   });
 
-  it("-v でも --version と同じ結果になる", () => {
-    const { lines, out } = collector();
+  it("使い方の行を含む", async () => {
+    const { out, io } = collector();
 
-    const code = run(["-v"], { out, version: () => "9.9.9" });
+    await run(["--help"], deps(io));
 
-    expect(code).toBe(0);
-    expect(lines).toEqual(["9.9.9"]);
+    expect(out.join("\n")).toMatch(/tock <command>/);
   });
 
-  it("他の引数と混ざっていても --version を認識する", () => {
-    const { lines, out } = collector();
+  it("-h でも同じ結果になる", async () => {
+    const long = collector();
+    const short = collector();
 
-    run(["start", "--version"], { out, version: () => "9.9.9" });
+    await run(["--help"], deps(long.io));
+    await run(["-h"], deps(short.io));
 
-    expect(lines).toEqual(["9.9.9"]);
+    expect(short.out).toEqual(long.out);
   });
 
-  it("引数が空（境界値）でも終了コード 0 を返す", () => {
-    const { lines, out } = collector();
+  it("stdout にだけ出力し、stderr には何も出さない", async () => {
+    const { out, err, io } = collector();
 
-    const code = run([], { out, version: () => "9.9.9" });
+    await run(["--help"], deps(io));
 
-    expect(code).toBe(0);
-    expect(lines).toHaveLength(1);
+    expect(out.length).toBeGreaterThan(0);
+    expect(err).toEqual([]);
   });
 
-  it("バージョン取得は注入された関数だけを使う（package.json を読まない）", () => {
-    const { lines, out } = collector();
+  it("コマンドが1つも登録されていない場合もエラーにしない（境界）", async () => {
+    const { out, err, io } = collector();
+
+    const code = await run(["--help"], deps(io, []));
+
+    expect(code).toBe(EXIT_OK);
+    expect(out.join("\n")).toMatch(/まだありません/);
+    expect(err).toEqual([]);
+  });
+
+  it("コマンド名のあとに --help があってもコマンドに渡す（全体のヘルプにしない）", async () => {
+    const received: string[][] = [];
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", (argv) => {
+        received.push([...argv]);
+      }),
+    ];
+
+    await run(["start", "--help"], deps(io, commands));
+
+    expect(received).toEqual([["--help"]]);
+  });
+});
+
+describe("--version", () => {
+  it("バージョンを1行だけ出力し、終了コード 0 を返す", async () => {
+    const { out, io } = collector();
+
+    const code = await run(["--version"], deps(io));
+
+    expect(code).toBe(EXIT_OK);
+    expect(out).toEqual(["9.9.9"]);
+  });
+
+  it("-v でも同じ結果になる", async () => {
+    const { out, io } = collector();
+
+    const code = await run(["-v"], deps(io));
+
+    expect(code).toBe(EXIT_OK);
+    expect(out).toEqual(["9.9.9"]);
+  });
+
+  it("stdout にだけ出力する", async () => {
+    const { err, io } = collector();
+
+    await run(["--version"], deps(io));
+
+    expect(err).toEqual([]);
+  });
+
+  it("バージョン取得は注入された関数だけを使う", async () => {
     let called = 0;
+    const { out, io } = collector();
 
-    run(["--version"], {
-      out,
+    await run(["--version"], {
+      ...io,
       version: () => {
         called += 1;
         return "0.0.0-injected";
       },
+      commands: sampleCommands,
     });
 
     expect(called).toBe(1);
-    expect(lines).toEqual(["0.0.0-injected"]);
+    expect(out).toEqual(["0.0.0-injected"]);
+  });
+});
+
+describe("未知のコマンド", () => {
+  it("終了コード 1 を返し、使い方を表示する", async () => {
+    const { err, io } = collector();
+
+    const code = await run(["nope"], deps(io));
+
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join("\n")).toMatch(/tock <command>/);
+  });
+
+  it("エラーメッセージは stderr に出し、stdout には出さない", async () => {
+    const { out, err, io } = collector();
+
+    await run(["nope"], deps(io));
+
+    expect(err.join("\n")).toContain("nope");
+    expect(out).toEqual([]);
+  });
+
+  it("未知のオプションも未知のコマンドとして扱う", async () => {
+    const { err, io } = collector();
+
+    const code = await run(["--nope"], deps(io));
+
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join("\n")).toContain("--nope");
+  });
+
+  it("利用できるコマンド名を案内に含める", async () => {
+    const { err, io } = collector();
+
+    await run(["nope"], deps(io));
+
+    expect(err.join("\n")).toContain("start");
+  });
+});
+
+describe("引数なし", () => {
+  it("使い方を stdout に出し、終了コード 0 を返す", async () => {
+    const { out, err, io } = collector();
+
+    const code = await run([], deps(io));
+
+    expect(code).toBe(EXIT_OK);
+    expect(out.join("\n")).toMatch(/tock <command>/);
+    expect(err).toEqual([]);
+  });
+});
+
+describe("サブコマンドの実行", () => {
+  it("一致したコマンドに残りの引数を渡す", async () => {
+    const received: string[][] = [];
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", (argv) => {
+        received.push([...argv]);
+      }),
+    ];
+
+    const code = await run(["start", "--tag", "work"], deps(io, commands));
+
+    expect(code).toBe(EXIT_OK);
+    expect(received).toEqual([["--tag", "work"]]);
+  });
+
+  it("引数が無いコマンド呼び出しでは空配列を渡す（境界）", async () => {
+    const received: string[][] = [];
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", (argv) => {
+        received.push([...argv]);
+      }),
+    ];
+
+    await run(["start"], deps(io, commands));
+
+    expect(received).toEqual([[]]);
+  });
+
+  it("非同期のコマンドの完了を待つ", async () => {
+    let done = false;
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", async () => {
+        await Promise.resolve();
+        done = true;
+      }),
+    ];
+
+    await run(["start"], deps(io, commands));
+
+    expect(done).toBe(true);
+  });
+
+  it("コマンドの出力は stdout に出る", async () => {
+    const { out, io } = collector();
+    const commands = [
+      command("start", "作業を開始する", (_argv, cmdIo) => {
+        cmdIo.out("開始しました");
+      }),
+    ];
+
+    await run(["start"], deps(io, commands));
+
+    expect(out).toEqual(["開始しました"]);
+  });
+});
+
+describe("終了コード", () => {
+  it("コマンドが UserError を投げたら 1 を返し、メッセージを stderr に出す", async () => {
+    const { out, err, io } = collector();
+    const commands = [
+      command("start", "作業を開始する", () => {
+        throw new UserError("すでに実行中の作業があります");
+      }),
+    ];
+
+    const code = await run(["start"], deps(io, commands));
+
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join("\n")).toContain("すでに実行中の作業があります");
+    expect(out).toEqual([]);
+  });
+
+  it("コマンドが想定外の例外を投げたら 2 を返す", async () => {
+    const { err, io } = collector();
+    const commands = [
+      command("start", "作業を開始する", () => {
+        throw new Error("ディスクが壊れている");
+      }),
+    ];
+
+    const code = await run(["start"], deps(io, commands));
+
+    expect(code).toBe(EXIT_INTERNAL);
+    expect(err.join("\n")).toContain("ディスクが壊れている");
+  });
+
+  it("非同期のコマンドが UserError で reject しても 1 を返す", async () => {
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", async () => {
+        await Promise.resolve();
+        throw new UserError("入力が不正です");
+      }),
+    ];
+
+    expect(await run(["start"], deps(io, commands))).toBe(EXIT_USAGE);
+  });
+
+  it("非同期のコマンドが想定外の例外で reject したら 2 を返す", async () => {
+    const { io } = collector();
+    const commands = [
+      command("start", "作業を開始する", async () => {
+        await Promise.resolve();
+        throw new TypeError("想定外");
+      }),
+    ];
+
+    expect(await run(["start"], deps(io, commands))).toBe(EXIT_INTERNAL);
+  });
+
+  it("文字列を throw されても 2 を返す（Error でない値の境界）", async () => {
+    const { err, io } = collector();
+    const commands = [
+      command("start", "作業を開始する", () => {
+        throw "ただの文字列";
+      }),
+    ];
+
+    const code = await run(["start"], deps(io, commands));
+
+    expect(code).toBe(EXIT_INTERNAL);
+    expect(err.length).toBeGreaterThan(0);
+  });
+
+  it("終了コードの値が仕様どおりである", () => {
+    expect(EXIT_OK).toBe(0);
+    expect(EXIT_USAGE).toBe(1);
+    expect(EXIT_INTERNAL).toBe(2);
   });
 });


### PR DESCRIPTION
## 概要

サブコマンドを追加していける CLI の器を作った。#1 で入れた `cli.ts` は `--version` だけを
扱う雛形で、本格的な引数パース・ヘルプ・終了コードは本 Issue の担当と明記していたため、
ここで置き換えている。

Closes #12

### 終了コードを 0 / 1 / 2 に分ける

```ts
export const EXIT_OK = 0;        // 正常終了
export const EXIT_USAGE = 1;     // ユーザー起因（打ち間違い、入力の不備）
export const EXIT_INTERNAL = 2;  // 内部エラー（想定外の例外）
```

**区別の手段として `UserError` を用意しました。** これを投げたコマンドは 1、それ以外の
例外は 2 になります。区別できないと「打ち間違い」と「不具合」が同じ扱いになり、
スクリプトから呼んだときに再試行すべきかの判断がつきません。

`Error` でない値（文字列など）を `throw` されても落ちないようにしてあります。

### `run` は終了コードを返すだけで `process.exit` を呼ばない

テストからプロセスを終わらせずに検証できるようにするためです。実際の終了は
ファイル末尾の起動部が `process.exitCode` に代入します。

### `run` は `Promise` を返す

以降のサブコマンド（#13 の `start` / `stop`）はファイル I/O を伴います。あとから同期版を
非同期に変えると呼び出し側すべてに波及するので、**器の時点で非同期にしておきました**。
現時点で `await` する処理はありませんが、コマンドの完了を待つ経路はテストで確認しています。

### stdout と stderr を別の関数として注入する

DoD が「エラーメッセージは stderr、通常出力は stdout」を要求しています。1つの `out` に
まとめると分離をテストできないため、`CliIo` として2つ受け取る形にしました。

```ts
export interface CliIo {
  readonly out: (line: string) => void;  // stdout
  readonly err: (line: string) => void;  // stderr
}
```

`--help` は stdout、未知コマンドのエラーと使い方は stderr に出します。

### コマンド名より後ろの引数はコマンドにそのまま渡す

`tock start --help` は **`start` のヘルプであって全体のヘルプではない**ため、先頭以外の
`--help` を骨格側で解釈しません。先頭の引数だけを見て振り分けています。

### 引数なし（`tock` 単体）は終了コード 0

DoD に指定がなく慣習も分かれるため（`git` は 1、`npm` / `docker` は 0）、判断を預けていました。
[レビューで同意をいただいた](https://github.com/okrago10/loop-demo/pull/38#discussion_r3773032469)ので、この形で確定します。

打ち間違いではなく「何ができるか知りたい」という操作だと解釈し、ヘルプと同じ扱い
（使い方を stdout、終了コード 0）に揃えています。未知のコマンドは打ち間違いなので、
stderr + 終了コード 1 で区別します。

### サブコマンドはまだ登録されていない

`Command` インタフェースだけを定め、登録は空配列です。実装は #13 以降の担当なので、
`src/commands/` はこの PR では作っていません。

そのため実際の `tock --help` は「（利用できるコマンドはまだありません）」と表示します。
一覧を組み立てる機構そのものは、テストでコマンドを注入して検証しています。

## 受け入れ条件

- [x] `tock --help` がサブコマンド一覧を出力するテストがある
- [x] 未知のコマンドで終了コード 1 かつ使い方が表示されるテストがある
- [x] エラーメッセージは stderr、通常出力は stdout に出ることがテストされている

### 検証結果

`main`（#34 / #35 のマージ後）を取り込んだ状態で再検証しています。

```
$ npm run check
> npm run typecheck && npm run lint && npm run format:check && npm test
 Test Files  7 passed (7)
      Tests  203 passed (203)
```

**ビルドした実物での確認**

```
$ node dist/cli.js --help
使い方: tock <command> [args]

コマンド:
  （利用できるコマンドはまだありません）

オプション:
  -h, --help     この使い方を表示する
  -v, --version  バージョンを表示する
終了コード: 0

$ node dist/cli.js --version
0.1.0
終了コード: 0

$ node dist/cli.js nope 2>/dev/null     # stdout のみ
（何も出力されない）

$ node dist/cli.js nope 2>&1 >/dev/null # stderr のみ
不明なコマンドです: nope

使い方: tock <command> [args]
終了コード: 1
```

stdout と stderr を実際に分離して確認しています。

## テスト

`tests/cli.test.ts` を25件に増やしました（5件 → 25件）。

| 観点 | ケース |
| --- | --- |
| `--help` | サブコマンド一覧（名前と説明の両方）/ 使い方の行 / `-h` が同一結果 / **stdout だけに出て stderr は空** / **コマンド0件でもエラーにしない** / `start --help` はコマンドに渡す |
| `--version` | 出力とコード 0 / `-v` / stdout のみ / 注入された関数だけを使う |
| 未知のコマンド | **コード 1 かつ使い方を表示** / **stderr のみで stdout は空** / 未知のオプションも同様 / 利用できるコマンド名を案内に含める |
| 引数なし | 使い方を stdout、コード 0（境界） |
| 振り分け | 残りの引数を渡す / **引数なしなら空配列**（境界）/ 非同期コマンドの完了を待つ / コマンドの出力が stdout に出る |
| 終了コード | `UserError` → 1 / 想定外の例外 → 2 / 非同期 reject でも同じ / **`Error` でない値を throw** → 2（境界）/ 定数の値が 0 / 1 / 2 |

## スタック

- base: `main`（**スタックなし**）

作成時に並列で走っていた #34（Issue #6）と #35（Issue #9）は**どちらもマージ済み**です。
`main` を取り込んで CI を取り直しました（`8e88442`）。この PR が唯一の open PR です。

## 依存の追加

**なし。** 引数パースのライブラリは入れていません。先頭の引数を見て振り分けるだけなので
標準機能で足り、CLAUDE.md の「標準ライブラリや既存の依存で代替できないかを先に検討する」
に沿った判断です。各コマンドのオプション解析が複雑になった時点で、改めて検討する余地は
あります（`node:util` の `parseArgs` が候補）。
