### PR TITLE
[E4-2][P1] `start` / `stop` コマンド

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { createStartCommand } from "./commands/start.js";
+import { createStopCommand } from "./commands/stop.js";
+import { randomId } from "./id.js";
+import { createJsonlStore } from "./store/jsonl-store.js";
+import { resolveStorePath } from "./store/store.js";
 import { readVersion } from "./version.js";
 
 /** 正常終了。 */
@@ -141,11 +147,20 @@ export async function run(argv: readonly string[], deps: CliDeps): Promise<numbe
 }
 
 /**
- * 登録されているサブコマンド。
+ * 実際に使うサブコマンドを組み立てる。
  *
- * 実装は #13 以降で追加する。現時点では空なので `tock --help` はコマンドなしと表示する。
+ * 保存先の決定と現在時刻・採番の取得はここでだけ行う。`run` と各コマンドは注入された
+ * ものしか使わないので、テストは一時ディレクトリと固定した時刻で完全に再現できる。
  */
-const commands: readonly Command[] = [];
+function buildCommands(): readonly Command[] {
+  const deps = {
+    store: createJsonlStore(resolveStorePath(process.env, homedir())),
+    now: () => new Date(),
+    newId: randomId,
+  };
+
+  return [createStartCommand(deps), createStopCommand(deps)];
+}
 
 /**
  * このファイルがプロセスのエントリポイントとして起動されたかを判定する。
@@ -175,6 +190,6 @@ if (invokedAsEntryPoint()) {
       process.stderr.write(`${line}\n`);
     },
     version: readVersion,
-    commands,
+    commands: buildCommands(),
   });
 }

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -1,0 +1,108 @@
+import { UserError } from "../cli.js";
+import type { Store } from "../store/store.js";
+
+/**
+ * コマンドが外の世界に触るための依存。
+ *
+ * 現在時刻と id の採番を引数で受け取るので、テストから完全に固定できる。
+ * `Command` の `run` は骨格（#12）が決めた形なので、これらはコマンドを組み立てる
+ * ときに渡す。
+ */
+export interface CommandDeps {
+  readonly store: Store;
+  /** 現在時刻。domain と同じ理由で直接取得しない。 */
+  readonly now: () => Date;
+  readonly newId: () => string;
+}
+
+/** `HH:MM` または `HH:MM:SS`。範囲も式で縛る。 */
+const CLOCK_TIME = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/;
+
+/**
+ * 名前付きオプションの値を取り出し、残りを返す。
+ *
+ * 値を取らないフラグは今のところ無いため扱わない。値が続いていない場合は
+ * 打ち間違いとして扱う。
+ */
+export function takeOption(
+  argv: readonly string[],
+  name: string,
+): { value: string | undefined; rest: string[] } {
+  const index = argv.indexOf(name);
+  if (index === -1) {
+    return { value: undefined, rest: [...argv] };
+  }
+
+  const value = argv[index + 1];
+  if (value === undefined) {
+    throw new UserError(`${name} には値が必要です`);
+  }
+
+  return { value, rest: [...argv.slice(0, index), ...argv.slice(index + 2)] };
+}
+
+/**
+ * `--at "09:30"` を、その日の実際の時刻に解決する。
+ *
+ * **利用者の環境のタイムゾーンで解釈する。** 日付は `now` の日を使う。「9時半」と
+ * 打った人が期待するのはローカルの 9 時半であり、UTC で解釈すると別の時刻になる。
+ * タイムゾーンを設定で選べるようにするのは #22 の担当範囲。
+ *
+ * 日付を跨いだ指定（前日の 23:00 に開始して 01:00 に停止するなど）はできない。
+ * 当日の時刻として解決するため、開始より前になる場合は呼び出し側で弾かれる。
+ */
+export function resolveClockTime(value: string, now: Date): Date {
+  const match = CLOCK_TIME.exec(value);
+  if (match === null) {
+    throw new UserError(`--at は HH:MM または HH:MM:SS で指定してください: ${value}`);
+  }
+
+  const [, hours, minutes, seconds] = match;
+  const at = new Date(now);
+  at.setHours(Number(hours), Number(minutes), Number(seconds ?? "0"), 0);
+
+  return at;
+}
+
+/**
+ * `--at` があればその時刻、なければ `now` を返す。
+ */
+export function resolveAt(argv: readonly string[], now: Date): { at: Date; rest: string[] } {
+  const { value, rest } = takeOption(argv, "--at");
+
+  return { at: value === undefined ? now : resolveClockTime(value, now), rest };
+}
+
+/**
+ * 入力文字列から作業名とタグを取り出す。
+ *
+ * **最小限の抽出しかしない。** 表記の正規化（大文字小文字の統一など）と階層タグの
+ * 分解（`proj/loop-demo` を `proj` でも集計できるようにする）は #8 の担当範囲で、
+ * ここで独自に実装すると二重になる。ここでは `#` で始まる語をタグとして分けるだけ。
+ *
+ * 重複するタグは1つにまとめる。同じタグを2回書いても集計が二重になっては困る。
+ */
+export function parseDescription(text: string): {
+  tags: readonly string[];
+  note: string | undefined;
+} {
+  const words = text.split(/\s+/).filter((word) => word !== "");
+  const tags: string[] = [];
+  const noteWords: string[] = [];
+
+  for (const word of words) {
+    // `#` だけの語はタグ名が空になるため、作業名の一部として扱う
+    if (word.startsWith("#") && word.length > 1) {
+      const tag = word.slice(1);
+      if (!tags.includes(tag)) {
+        tags.push(tag);
+      }
+      continue;
+    }
+    noteWords.push(word);
+  }
+
+  const note = noteWords.join(" ");
+
+  return { tags, note: note === "" ? undefined : note };
+}

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -23,6 +23,13 @@ const CLOCK_TIME = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/;
  *
  * 値を取らないフラグは今のところ無いため扱わない。値が続いていない場合は
  * 打ち間違いとして扱う。
+ *
+ * 次のトークンが別のオプション（`--` 始まり）の場合も「値が無い」とみなす。
+ * `stop --note --at 10:00` を許すと note が `--at` になり、指定したはずの終了時刻が
+ * 黙って無視される。
+ *
+ * 判定を `--` に限っているのは、`--note "-5分の中断あり"` のような値を書けなくしない
+ * ため。`-h` のような短縮形は値としては現れず、余った場合に呼び出し側が弾く。
  */
 export function takeOption(
   argv: readonly string[],
@@ -37,8 +44,41 @@ export function takeOption(
   if (value === undefined) {
     throw new UserError(`${name} には値が必要です`);
   }
+  if (value.startsWith("--")) {
+    throw new UserError(`${name} には値が必要です（${value} が続いています）`);
+  }
 
   return { value, rest: [...argv.slice(0, index), ...argv.slice(index + 2)] };
+}
+
+/**
+ * オプションを取り出した後に余ったトークンを検査し、解釈できないものを弾く。
+ *
+ * 黙って捨てると `tock stop --help` が使い方の表示ではなく打刻の終了として成功する。
+ * ヘルプを見ようとして状態が変わるのは事故なので、保存の前にエラーにする。
+ *
+ * `start` は残りを作業名として使うため、`allowPositional` を true にして
+ * `--` 始まりのトークンだけを弾く。作業名の中に現れる `--`（`"設計 -- 前半"` のように
+ * 引用符でまとめて渡されたもの）は1つのトークンの途中なので影響を受けない。
+ */
+export function rejectUnknownArgs(
+  argv: readonly string[],
+  options: {
+    readonly command: string;
+    readonly allowedOptions: readonly string[];
+    readonly allowPositional: boolean;
+  },
+): void {
+  const unknown = options.allowPositional ? argv.filter((token) => token.startsWith("--")) : argv;
+
+  if (unknown.length === 0) {
+    return;
+  }
+
+  throw new UserError(
+    `tock ${options.command} が解釈できない引数です: ${unknown.join(" ")}` +
+      `（使えるオプション: ${options.allowedOptions.join(" ")}）`,
+  );
 }
 
 /**
@@ -50,6 +90,11 @@ export function takeOption(
  *
  * 日付を跨いだ指定（前日の 23:00 に開始して 01:00 に停止するなど）はできない。
  * 当日の時刻として解決するため、開始より前になる場合は呼び出し側で弾かれる。
+ *
+ * **未来の時刻は受け付けない。** `--at` は打ち忘れた分を後から入れるためのもので、
+ * 未来を許す意味がない。許すと `start --at 23:59` で未来の開始時刻を持つ実行中エントリが
+ * でき、素の `stop` が常に `end < start` で失敗して停止できなくなる（次の `start` も
+ * 実行中を理由に拒否されるため、打ち間違いから手詰まりになる）。
  */
 export function resolveClockTime(value: string, now: Date): Date {
   const match = CLOCK_TIME.exec(value);
@@ -61,7 +106,20 @@ export function resolveClockTime(value: string, now: Date): Date {
   const at = new Date(now);
   at.setHours(Number(hours), Number(minutes), Number(seconds ?? "0"), 0);
 
+  if (at.getTime() > now.getTime()) {
+    throw new UserError(
+      `--at に未来の時刻は指定できません: ${value}（現在は ${formatClockTime(now)}）`,
+    );
+  }
+
   return at;
+}
+
+/** エラーメッセージ用に、ローカルの壁時計を `HH:MM:SS` で表す。 */
+function formatClockTime(time: Date): string {
+  const parts = [time.getHours(), time.getMinutes(), time.getSeconds()];
+
+  return parts.map((part) => String(part).padStart(2, "0")).join(":");
 }
 
 /**

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,6 +1,6 @@
 import { type Command, type CliIo, UserError } from "../cli.js";
 import { createEntry } from "../domain/entry.js";
-import { type CommandDeps, parseDescription, resolveAt } from "./args.js";
+import { type CommandDeps, parseDescription, rejectUnknownArgs, resolveAt } from "./args.js";
 
 /**
  * 作業の計測を開始する。
@@ -14,15 +14,21 @@ export function createStartCommand(deps: CommandDeps): Command {
     summary: "作業を開始する",
 
     async run(argv: readonly string[], io: CliIo): Promise<void> {
+      // 引数の検査を保存より先に済ませる。打ち間違いで状態が変わらないようにする
+      const { at, rest } = resolveAt(argv, deps.now());
+      rejectUnknownArgs(rest, {
+        command: "start",
+        allowedOptions: ["--at"],
+        allowPositional: true,
+      });
+      const { tags, note } = parseDescription(rest.join(" "));
+
       const running = await deps.store.findRunning();
       if (running !== undefined) {
         throw new UserError(
           `すでに実行中の作業があります（開始: ${running.start}）。先に tock stop してください`,
         );
       }
-
-      const { at, rest } = resolveAt(argv, deps.now());
-      const { tags, note } = parseDescription(rest.join(" "));
 
       const entry = createEntry(
         { start: at, tags, ...(note === undefined ? {} : { note }) },

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,0 +1,40 @@
+import { type Command, type CliIo, UserError } from "../cli.js";
+import { createEntry } from "../domain/entry.js";
+import { type CommandDeps, parseDescription, resolveAt } from "./args.js";
+
+/**
+ * 作業の計測を開始する。
+ *
+ * すでに実行中のエントリがある場合はエラーにする。切り替え（stop と start をまとめて
+ * 行う）は #15 の担当範囲なので、ここで暗黙に停止させない。
+ */
+export function createStartCommand(deps: CommandDeps): Command {
+  return {
+    name: "start",
+    summary: "作業を開始する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const running = await deps.store.findRunning();
+      if (running !== undefined) {
+        throw new UserError(
+          `すでに実行中の作業があります（開始: ${running.start}）。先に tock stop してください`,
+        );
+      }
+
+      const { at, rest } = resolveAt(argv, deps.now());
+      const { tags, note } = parseDescription(rest.join(" "));
+
+      const entry = createEntry(
+        { start: at, tags, ...(note === undefined ? {} : { note }) },
+        { newId: deps.newId },
+      );
+
+      await deps.store.append(entry);
+
+      const label = note ?? "（名前なし）";
+      const tagText = tags.length === 0 ? "" : ` [${tags.map((tag) => `#${tag}`).join(" ")}]`;
+      io.out(`開始しました: ${label}${tagText}`);
+      io.out(`開始時刻: ${entry.start}`);
+    },
+  };
+}

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -2,7 +2,7 @@ import { type Command, type CliIo, UserError } from "../cli.js";
 import { createEntry } from "../domain/entry.js";
 import { durationMs } from "../domain/period.js";
 import { formatDuration } from "../format/duration.js";
-import { type CommandDeps, resolveAt, takeOption } from "./args.js";
+import { type CommandDeps, rejectUnknownArgs, resolveAt, takeOption } from "./args.js";
 
 /**
  * 実行中の作業を終了する。
@@ -16,13 +16,20 @@ export function createStopCommand(deps: CommandDeps): Command {
     summary: "作業を終了する",
 
     async run(argv: readonly string[], io: CliIo): Promise<void> {
+      // 引数の検査を保存より先に済ませる。`tock stop --help` が使い方を見ようとして
+      // 打刻を終了してしまうのを防ぐ
+      const { value: note, rest } = takeOption(argv, "--note");
+      const { at, rest: remaining } = resolveAt(rest, deps.now());
+      rejectUnknownArgs(remaining, {
+        command: "stop",
+        allowedOptions: ["--at", "--note"],
+        allowPositional: false,
+      });
+
       const running = await deps.store.findRunning();
       if (running === undefined) {
         throw new UserError("実行中の作業がありません。tock start で開始してください");
       }
-
-      const { value: note, rest } = takeOption(argv, "--note");
-      const { at } = resolveAt(rest, deps.now());
 
       // createEntry は end < start を弾く。その失敗は打ち間違いなので UserError に translate し、
       // 保存はしない（実行中のまま残るので、正しい時刻で再実行できる）

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,0 +1,61 @@
+import { type Command, type CliIo, UserError } from "../cli.js";
+import { createEntry } from "../domain/entry.js";
+import { durationMs } from "../domain/period.js";
+import { formatDuration } from "../format/duration.js";
+import { type CommandDeps, resolveAt, takeOption } from "./args.js";
+
+/**
+ * 実行中の作業を終了する。
+ *
+ * 実行中がなければエラーにする。何も計測していない状態で `stop` が黙って成功すると、
+ * 打ち忘れに気づけない。
+ */
+export function createStopCommand(deps: CommandDeps): Command {
+  return {
+    name: "stop",
+    summary: "作業を終了する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const running = await deps.store.findRunning();
+      if (running === undefined) {
+        throw new UserError("実行中の作業がありません。tock start で開始してください");
+      }
+
+      const { value: note, rest } = takeOption(argv, "--note");
+      const { at } = resolveAt(rest, deps.now());
+
+      // createEntry は end < start を弾く。その失敗は打ち間違いなので UserError に translate し、
+      // 保存はしない（実行中のまま残るので、正しい時刻で再実行できる）
+      let stopped;
+      try {
+        stopped = createEntry(
+          {
+            start: running.start,
+            end: at,
+            tags: running.tags,
+            ...resolveNote(running.note, note),
+          },
+          { newId: () => running.id },
+        );
+      } catch (error) {
+        throw new UserError(error instanceof Error ? error.message : String(error));
+      }
+
+      await deps.store.update(stopped);
+
+      io.out(`停止しました: ${formatDuration(durationMs(stopped))}`);
+      io.out(`終了時刻: ${stopped.end ?? ""}`);
+    },
+  };
+}
+
+/**
+ * `--note` が与えられればそれを使い、無ければ開始時の note を残す。
+ *
+ * `exactOptionalPropertyTypes` のため、未設定は「プロパティを持たせない」で表す。
+ */
+function resolveNote(existing: string | undefined, given: string | undefined): { note?: string } {
+  const note = given ?? existing;
+
+  return note === undefined ? {} : { note };
+}

--- a/src/format/duration.ts
+++ b/src/format/duration.ts
@@ -1,0 +1,43 @@
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+/**
+ * 長さを人間が読める形に整える（`1h 23m` など）。
+ *
+ * 端数は**切り捨てる**。四捨五入や丸め単位の指定は #7 の担当範囲なので、ここで
+ * 独自の丸め方を持ち込まない。
+ *
+ * 1 分未満は秒で表す。`0m` にすると「短すぎて記録されなかった」ように見えるが、
+ * 実際には記録されているため、秒を見せて情報を落とさない。
+ *
+ * 日には繰り上げない（25 時間は `25h`）。日をまたぐ表示は集計側（#18 / #19）が
+ * 日単位に分割してから扱う想定なので、ここで日を導入すると二重になる。
+ */
+export function formatDuration(ms: number): string {
+  if (Number.isNaN(ms)) {
+    throw new Error("長さが NaN です");
+  }
+  if (!Number.isInteger(ms)) {
+    throw new Error(`長さがミリ秒の整数ではありません: ${String(ms)}`);
+  }
+  if (ms < 0) {
+    throw new Error(`長さが負です: ${String(ms)}`);
+  }
+
+  if (ms < MS_PER_MINUTE) {
+    return `${String(Math.floor(ms / MS_PER_SECOND))}s`;
+  }
+
+  const hours = Math.floor(ms / MS_PER_HOUR);
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
+
+  if (hours === 0) {
+    return `${String(minutes)}m`;
+  }
+  if (minutes === 0) {
+    return `${String(hours)}h`;
+  }
+
+  return `${String(hours)}h ${String(minutes)}m`;
+}

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+/** 固定した現在時刻。テストが実行時刻に依存しないようにする。 */
+const NOW = new Date("2026-08-12T10:00:00Z");
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-start-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date = NOW) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+const allTime = {
+  start: new Date("2000-01-01T00:00:00Z"),
+  end: new Date("2100-01-01T00:00:00Z"),
+};
+
+describe("start", () => {
+  it("実行中のエントリを1件作る", async () => {
+    await createStartCommand(deps()).run(["設計"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.start).toBe("2026-08-12T10:00:00.000Z");
+    expect(entries[0]).not.toHaveProperty("end");
+  });
+
+  it("作業名を note として保存する", async () => {
+    await createStartCommand(deps()).run(["設計"], io);
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("設計");
+  });
+
+  it("#つきの語をタグとして取り出す", async () => {
+    await createStartCommand(deps()).run(["設計 #proj/loop-demo #会議"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.tags).toEqual(["proj/loop-demo", "会議"]);
+    expect(entry?.note).toBe("設計");
+  });
+
+  it("引数が複数に分かれていても1つの文字列として扱う", async () => {
+    await createStartCommand(deps()).run(["設計", "#work"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.note).toBe("設計");
+    expect(entry?.tags).toEqual(["work"]);
+  });
+
+  it("タグだけを渡しても開始できる（note なし）", async () => {
+    await createStartCommand(deps()).run(["#work"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.tags).toEqual(["work"]);
+    expect(entry).not.toHaveProperty("note");
+  });
+
+  it("引数なしでも開始できる（境界）", async () => {
+    await createStartCommand(deps()).run([], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.tags).toEqual([]);
+    expect(entry).not.toHaveProperty("note");
+  });
+
+  it("同じタグを2回書いても1つになる", async () => {
+    await createStartCommand(deps()).run(["#work #work"], io);
+
+    expect((await store.listByRange(allTime))[0]?.tags).toEqual(["work"]);
+  });
+
+  it("`#` だけの語はタグにしない", async () => {
+    await createStartCommand(deps()).run(["設計 #"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.tags).toEqual([]);
+    expect(entry?.note).toBe("設計 #");
+  });
+
+  it("開始したことと時刻を stdout に出す", async () => {
+    await createStartCommand(deps()).run(["設計"], io);
+
+    expect(out.join("\n")).toContain("設計");
+    expect(err).toEqual([]);
+  });
+
+  it("すでに実行中なら UserError で失敗する（終了コード 1 になる）", async () => {
+    await createStartCommand(deps()).run(["1本目"], io);
+
+    await expect(createStartCommand(deps()).run(["2本目"], io)).rejects.toThrow(UserError);
+  });
+
+  it("二重 start でも1件しか保存されない", async () => {
+    await createStartCommand(deps()).run(["1本目"], io);
+    // 失敗することは別のテストで確認済み。ここでは保存件数だけを見る
+    await Promise.resolve(createStartCommand(deps()).run(["2本目"], io)).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("停止したあとなら再度 start できる", async () => {
+    const d = deps();
+    await createStartCommand(d).run(["1本目"], io);
+    await createStopCommand(d).run([], io);
+
+    await createStartCommand(d).run(["2本目"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(2);
+  });
+});
+
+describe("start --at", () => {
+  it("指定した時刻を開始時刻として記録する", async () => {
+    await createStartCommand(deps()).run(["設計", "--at", "09:30"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+    const expected = new Date(NOW);
+    expected.setHours(9, 30, 0, 0);
+
+    expect(entry?.start).toBe(expected.toISOString());
+  });
+
+  it("秒まで指定できる", async () => {
+    await createStartCommand(deps()).run(["--at", "09:30:15"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+    const expected = new Date(NOW);
+    expected.setHours(9, 30, 15, 0);
+
+    expect(entry?.start).toBe(expected.toISOString());
+  });
+
+  it("--at はタグや作業名に混ざらない", async () => {
+    await createStartCommand(deps()).run(["設計 #work", "--at", "09:30"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.note).toBe("設計");
+    expect(entry?.tags).toEqual(["work"]);
+  });
+
+  it.each([
+    ["時が範囲外", "24:00"],
+    ["分が範囲外", "09:60"],
+    ["形式が違う", "9時30分"],
+    ["空文字", ""],
+    ["区切りがない", "0930"],
+  ])("--at が不正（%s）なら UserError で失敗する", async (_label, at) => {
+    await expect(createStartCommand(deps()).run(["--at", at], io)).rejects.toThrow(UserError);
+  });
+
+  it("--at の値が無い場合は UserError で失敗する", async () => {
+    await expect(createStartCommand(deps()).run(["--at"], io)).rejects.toThrow(UserError);
+  });
+});

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -27,6 +27,20 @@ const io = {
 /** 固定した現在時刻。テストが実行時刻に依存しないようにする。 */
 const NOW = new Date("2026-08-12T10:00:00Z");
 
+/**
+ * ローカルの壁時計で `HH:MM:SS` を指す Date を作る。
+ *
+ * `--at` はローカルタイムゾーンで解釈されるため、現在時刻を UTC 文字列で固定すると
+ * 「`--at` が未来か過去か」が実行環境の TZ によって変わってしまう。壁時計から
+ * 組み立てて、TZ に依存しないテストにする。
+ */
+function localTime(hours: number, minutes: number, seconds = 0): Date {
+  const at = new Date(NOW);
+  at.setHours(hours, minutes, seconds, 0);
+
+  return at;
+}
+
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-start-"));
   store = createJsonlStore(join(dir, "entries.jsonl"));
@@ -156,28 +170,27 @@ describe("start", () => {
 });
 
 describe("start --at", () => {
+  /** ローカルの 23:00。`--at` に渡す時刻が必ず過去になるようにする。 */
+  const lateNow = localTime(23, 0);
+
   it("指定した時刻を開始時刻として記録する", async () => {
-    await createStartCommand(deps()).run(["設計", "--at", "09:30"], io);
+    await createStartCommand(deps(lateNow)).run(["設計", "--at", "09:30"], io);
 
     const entry = (await store.listByRange(allTime))[0];
-    const expected = new Date(NOW);
-    expected.setHours(9, 30, 0, 0);
 
-    expect(entry?.start).toBe(expected.toISOString());
+    expect(entry?.start).toBe(localTime(9, 30).toISOString());
   });
 
   it("秒まで指定できる", async () => {
-    await createStartCommand(deps()).run(["--at", "09:30:15"], io);
+    await createStartCommand(deps(lateNow)).run(["--at", "09:30:15"], io);
 
     const entry = (await store.listByRange(allTime))[0];
-    const expected = new Date(NOW);
-    expected.setHours(9, 30, 15, 0);
 
-    expect(entry?.start).toBe(expected.toISOString());
+    expect(entry?.start).toBe(localTime(9, 30, 15).toISOString());
   });
 
   it("--at はタグや作業名に混ざらない", async () => {
-    await createStartCommand(deps()).run(["設計 #work", "--at", "09:30"], io);
+    await createStartCommand(deps(lateNow)).run(["設計 #work", "--at", "09:30"], io);
 
     const entry = (await store.listByRange(allTime))[0];
 
@@ -192,10 +205,74 @@ describe("start --at", () => {
     ["空文字", ""],
     ["区切りがない", "0930"],
   ])("--at が不正（%s）なら UserError で失敗する", async (_label, at) => {
-    await expect(createStartCommand(deps()).run(["--at", at], io)).rejects.toThrow(UserError);
+    await expect(createStartCommand(deps(lateNow)).run(["--at", at], io)).rejects.toThrow(
+      UserError,
+    );
   });
 
   it("--at の値が無い場合は UserError で失敗する", async () => {
-    await expect(createStartCommand(deps()).run(["--at"], io)).rejects.toThrow(UserError);
+    await expect(createStartCommand(deps(lateNow)).run(["--at"], io)).rejects.toThrow(UserError);
+  });
+
+  it("--at の次が別のオプションなら値が無いものとして失敗する", async () => {
+    await expect(createStartCommand(deps(lateNow)).run(["--at", "--note"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});
+
+describe("start --at が未来のとき", () => {
+  it("UserError で失敗する", async () => {
+    await expect(
+      createStartCommand(deps(localTime(9, 0))).run(["--at", "09:30"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("何も保存しない（実行中エントリを作らない）", async () => {
+    await Promise.resolve(
+      createStartCommand(deps(localTime(9, 0))).run(["--at", "09:30"], io),
+    ).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+    expect(await store.findRunning()).toBeUndefined();
+  });
+
+  it("1秒でも未来なら失敗する（境界）", async () => {
+    await expect(
+      createStartCommand(deps(localTime(9, 29, 59))).run(["--at", "09:30"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("現在時刻と同じ時刻なら成功する（境界）", async () => {
+    await createStartCommand(deps(localTime(9, 30))).run(["--at", "09:30"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+});
+
+describe("start の未知のオプション", () => {
+  it.each([["--help"], ["--version"], ["--unknown"]])(
+    "%s は作業名にせず UserError で失敗する",
+    async (token) => {
+      await expect(createStartCommand(deps()).run([token], io)).rejects.toThrow(UserError);
+    },
+  );
+
+  it("失敗したときは何も保存しない", async () => {
+    await Promise.resolve(createStartCommand(deps()).run(["--help"], io)).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+  });
+
+  it("作業名の中に含まれる `--` は弾かない", async () => {
+    await createStartCommand(deps()).run(["設計 -- 前半だけ"], io);
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("設計 -- 前半だけ");
+  });
+
+  it("`-` 始まりの1文字ハイフンは作業名として扱う", async () => {
+    await createStartCommand(deps()).run(["-5分の中断あり"], io);
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("-5分の中断あり");
   });
 });

--- a/tests/commands/stop.test.ts
+++ b/tests/commands/stop.test.ts
@@ -1,0 +1,222 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-stop-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+const allTime = {
+  start: new Date("2000-01-01T00:00:00Z"),
+  end: new Date("2100-01-01T00:00:00Z"),
+};
+
+/** 09:00 に開始した実行中エントリを作る。 */
+async function startAt9(): Promise<void> {
+  await createStartCommand(deps(new Date("2026-08-12T09:00:00Z"))).run(["設計 #work"], io);
+  out = [];
+}
+
+describe("start → stop", () => {
+  it("1件のエントリが終了時刻付きで保存される", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.start).toBe("2026-08-12T09:00:00.000Z");
+    expect(entries[0]?.end).toBe("2026-08-12T10:23:00.000Z");
+  });
+
+  it("作業名とタグは stop でも保たれる", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.note).toBe("設計");
+    expect(entry?.tags).toEqual(["work"]);
+  });
+
+  it("記録された時間を人間可読な形式で表示する", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("1h 23m");
+  });
+
+  it("出力は stdout に出て stderr は空", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.length).toBeGreaterThan(0);
+    expect(err).toEqual([]);
+  });
+
+  it("停止後は実行中エントリがなくなる", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io);
+
+    expect(await store.findRunning()).toBeUndefined();
+  });
+
+  it("0分で停止しても失敗しない（境界）", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T09:00:00Z"))).run([], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.end).toBe(entry?.start);
+    expect(out.join("\n")).toContain("0s");
+  });
+});
+
+describe("stop --note", () => {
+  it("note を後から付けられる", async () => {
+    await createStartCommand(deps(new Date("2026-08-12T09:00:00Z"))).run(["#work"], io);
+
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(
+      ["--note", "実装まで終わった"],
+      io,
+    );
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("実装まで終わった");
+  });
+
+  it("start で付けた note を上書きする", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--note", "上書き"], io);
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("上書き");
+  });
+
+  it("--note を渡さなければ start の note が残る", async () => {
+    await startAt9();
+
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io);
+
+    expect((await store.listByRange(allTime))[0]?.note).toBe("設計");
+  });
+
+  it("--note の値が無い場合は UserError で失敗する", async () => {
+    await startAt9();
+
+    await expect(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--note"], io),
+    ).rejects.toThrow(UserError);
+  });
+});
+
+describe("stop --at", () => {
+  it("指定した時刻を終了時刻として記録する", async () => {
+    const now = new Date("2026-08-12T12:00:00Z");
+    await createStartCommand(deps(new Date("2026-08-12T00:30:00Z"))).run(["設計"], io);
+
+    await createStopCommand(deps(now)).run(["--at", "10:15"], io);
+
+    const expected = new Date(now);
+    expected.setHours(10, 15, 0, 0);
+
+    expect((await store.listByRange(allTime))[0]?.end).toBe(expected.toISOString());
+  });
+
+  it("開始より前の時刻を指定したら UserError で失敗する", async () => {
+    const now = new Date("2026-08-12T23:00:00Z");
+    await createStartCommand(deps(now)).run(["設計"], io);
+
+    await expect(createStopCommand(deps(now)).run(["--at", "00:01"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("開始より前を指定して失敗しても、実行中のままにする", async () => {
+    const now = new Date("2026-08-12T23:00:00Z");
+    await createStartCommand(deps(now)).run(["設計"], io);
+
+    // 失敗することは別のテストで確認済み。ここでは実行中が残るかだけを見る
+    await Promise.resolve(createStopCommand(deps(now)).run(["--at", "00:01"], io)).catch(
+      () => undefined,
+    );
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+
+  it("--at が不正なら UserError で失敗する", async () => {
+    await startAt9();
+
+    await expect(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--at", "25:00"], io),
+    ).rejects.toThrow(UserError);
+  });
+});
+
+describe("実行中がない状態での stop", () => {
+  it("UserError で失敗する（終了コード 1 になる）", async () => {
+    await expect(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("すでに停止したあとに再度 stop すると失敗する", async () => {
+    await startAt9();
+    const d = deps(new Date("2026-08-12T10:00:00Z"));
+    await createStopCommand(d).run([], io);
+
+    await expect(createStopCommand(d).run([], io)).rejects.toThrow(UserError);
+  });
+
+  it("記録が1件もない状態でも例外で落ちずに UserError になる", async () => {
+    await expect(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io),
+    ).rejects.toThrow(/実行中/);
+  });
+});

--- a/tests/commands/stop.test.ts
+++ b/tests/commands/stop.test.ts
@@ -52,6 +52,19 @@ const allTime = {
   end: new Date("2100-01-01T00:00:00Z"),
 };
 
+/**
+ * ローカルの壁時計で `HH:MM` を指す Date を作る。
+ *
+ * `--at` はローカルタイムゾーンで解釈されるため、現在時刻を UTC 文字列で固定すると
+ * 「`--at` が未来か過去か」が実行環境の TZ によって変わってしまう。
+ */
+function localTime(hours: number, minutes: number, seconds = 0): Date {
+  const at = new Date("2026-08-12T12:00:00Z");
+  at.setHours(hours, minutes, seconds, 0);
+
+  return at;
+}
+
 /** 09:00 に開始した実行中エントリを作る。 */
 async function startAt9(): Promise<void> {
   await createStartCommand(deps(new Date("2026-08-12T09:00:00Z"))).run(["設計 #work"], io);
@@ -158,19 +171,15 @@ describe("stop --note", () => {
 
 describe("stop --at", () => {
   it("指定した時刻を終了時刻として記録する", async () => {
-    const now = new Date("2026-08-12T12:00:00Z");
-    await createStartCommand(deps(new Date("2026-08-12T00:30:00Z"))).run(["設計"], io);
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
 
-    await createStopCommand(deps(now)).run(["--at", "10:15"], io);
+    await createStopCommand(deps(localTime(12, 0))).run(["--at", "10:15"], io);
 
-    const expected = new Date(now);
-    expected.setHours(10, 15, 0, 0);
-
-    expect((await store.listByRange(allTime))[0]?.end).toBe(expected.toISOString());
+    expect((await store.listByRange(allTime))[0]?.end).toBe(localTime(10, 15).toISOString());
   });
 
   it("開始より前の時刻を指定したら UserError で失敗する", async () => {
-    const now = new Date("2026-08-12T23:00:00Z");
+    const now = localTime(23, 0);
     await createStartCommand(deps(now)).run(["設計"], io);
 
     await expect(createStopCommand(deps(now)).run(["--at", "00:01"], io)).rejects.toThrow(
@@ -179,7 +188,7 @@ describe("stop --at", () => {
   });
 
   it("開始より前を指定して失敗しても、実行中のままにする", async () => {
-    const now = new Date("2026-08-12T23:00:00Z");
+    const now = localTime(23, 0);
     await createStartCommand(deps(now)).run(["設計"], io);
 
     // 失敗することは別のテストで確認済み。ここでは実行中が残るかだけを見る
@@ -196,6 +205,78 @@ describe("stop --at", () => {
     await expect(
       createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--at", "25:00"], io),
     ).rejects.toThrow(UserError);
+  });
+
+  it("未来の時刻を指定したら UserError で失敗する", async () => {
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
+
+    await expect(
+      createStopCommand(deps(localTime(9, 0))).run(["--at", "09:30"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("未来を指定して失敗しても、実行中のままにする", async () => {
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
+
+    await Promise.resolve(
+      createStopCommand(deps(localTime(9, 0))).run(["--at", "09:30"], io),
+    ).catch(() => undefined);
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+});
+
+describe("stop の未知の引数", () => {
+  it.each([
+    ["サブコマンドのヘルプ", "--help"],
+    ["短縮形のヘルプ", "-h"],
+    ["未知のオプション", "--unknown"],
+    ["余分な位置引数", "余計な引数"],
+  ])("%s を渡したら UserError で失敗する", async (_label, token) => {
+    await startAt9();
+
+    await expect(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([token], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("--help を渡しても実行中の作業を終了しない", async () => {
+    await startAt9();
+
+    await Promise.resolve(
+      createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--help"], io),
+    ).catch(() => undefined);
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+
+  it("--note の値が別のオプションなら UserError で失敗する", async () => {
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
+
+    await expect(
+      createStopCommand(deps(localTime(12, 0))).run(["--note", "--at", "10:00"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("--note の値が別のオプションだった場合、終了時刻を黙って now にしない", async () => {
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
+
+    await Promise.resolve(
+      createStopCommand(deps(localTime(12, 0))).run(["--note", "--at", "10:00"], io),
+    ).catch(() => undefined);
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+
+  it("--at と --note を両方渡すのは通る", async () => {
+    await createStartCommand(deps(localTime(8, 0))).run(["設計"], io);
+
+    await createStopCommand(deps(localTime(12, 0))).run(["--at", "10:15", "--note", "完了"], io);
+
+    const entry = (await store.listByRange(allTime))[0];
+
+    expect(entry?.end).toBe(localTime(10, 15).toISOString());
+    expect(entry?.note).toBe("完了");
   });
 });
 

--- a/tests/format/duration.test.ts
+++ b/tests/format/duration.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDuration } from "../../src/format/duration.js";
+
+describe("formatDuration", () => {
+  it("1時間23分を 1h 23m と表す（Issue の例）", () => {
+    expect(formatDuration(83 * 60_000)).toBe("1h 23m");
+  });
+
+  it("1時間未満は分だけを表す", () => {
+    expect(formatDuration(45 * 60_000)).toBe("45m");
+  });
+
+  it("ちょうど何時間かなら分を付けない", () => {
+    expect(formatDuration(2 * 60 * 60_000)).toBe("2h");
+  });
+
+  it("1分未満は秒で表す（0m にして情報を失わない）", () => {
+    expect(formatDuration(45_000)).toBe("45s");
+  });
+
+  it("0 は 0s（境界）", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("ちょうど1分は 1m（境界）", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+  });
+
+  it("59秒は 59s（境界）", () => {
+    expect(formatDuration(59_000)).toBe("59s");
+  });
+
+  it("ちょうど1時間は 1h（境界）", () => {
+    expect(formatDuration(60 * 60_000)).toBe("1h");
+  });
+
+  it("59分は 59m（境界）", () => {
+    expect(formatDuration(59 * 60_000)).toBe("59m");
+  });
+
+  it("24時間を超えても時間で表す（日には繰り上げない）", () => {
+    expect(formatDuration(25 * 60 * 60_000)).toBe("25h");
+  });
+
+  it("端数の秒は切り捨てる（丸めは #7 の担当なので四捨五入しない）", () => {
+    expect(formatDuration(89 * 60_000 + 59_000)).toBe("1h 29m");
+  });
+
+  it("1分未満の端数ミリ秒も切り捨てる", () => {
+    expect(formatDuration(1999)).toBe("1s");
+  });
+
+  it("負の値は失敗する（長さとして意味を持たない）", () => {
+    expect(() => formatDuration(-1)).toThrow(/負/);
+  });
+
+  it("整数でないミリ秒は失敗する", () => {
+    expect(() => formatDuration(1.5)).toThrow(/整数/);
+  });
+
+  it("NaN は失敗する", () => {
+    expect(() => formatDuration(Number.NaN)).toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

`tock start` / `tock stop` を実装し、CLI の器（#12）とストア（#9）を繋いで
実際に打刻できる状態にした。

- `src/commands/start.ts` — 実行中がなければ1件 append する。すでに実行中なら `UserError`
  （切り替えは #15 の担当なので、暗黙に stop しない）
- `src/commands/stop.ts` — 実行中を終了時刻付きで `update` する。実行中がなければ `UserError`
- `src/commands/args.ts` — `--at` / `--note` の取り出し、時刻の解決、`#tag` と作業名の分解。
  start / stop で共通なのでここに寄せた
- `src/format/duration.ts` — `1h 23m` 形式の整形
- `src/cli.ts` — `buildCommands()` で保存先・現在時刻・採番を組み立てて注入する。
  `domain/` を純関数に保つため、環境に触るのはこの1箇所だけ

Closes #13

## 受け入れ条件

- [x] start → stop で1件のエントリが保存されるテストがある
      → `tests/commands/stop.test.ts` の「1件のエントリが終了時刻付きで保存される」
- [x] 二重 start / 実行中なし stop が終了コード 1 で失敗するテストがある
      → `UserError` が投げられることを検証。`UserError` → 終了コード 1 の対応は
      #12 の `run()` 側で検証済み（`tests/cli.test.ts`）
- [x] `--at` で指定した時刻が記録されるテストがある
      → start / stop 両方に、境界値（`24:00`、`09:60`、区切りなし、空文字、未来）を含めて追加
- [x] 実行後、記録された時間が人間可読な形式（例: `1h 23m`）で表示される
      → `tests/format/duration.test.ts` と stop の出力テスト

## スタック

- base: `main`（スタックなし）
- 作成時点では `feat/12-cli-skeleton`（PR #38）を base にしていたが、#38 がマージされたため
  base を `main` に付け替え、`main` を取り込み直した。差分はこの Issue の分だけ（8ファイル）

## レビュー対応（`ded03b0`）

指摘3件はいずれも「利用者が意図していないのに記録が変わる／変えられなくなる」という
同じ性質の問題だった。3件とも CLI で再現を確認したうえで修正した。

| # | 指摘 | 対応 |
| --- | --- | --- |
| [Major] | 未来の `--at` を許すと `stop` できず手詰まりになる | `at > now` を `UserError` に。境界（1秒差・同時刻）もテスト |
| [Major] | `stop` が余った引数を捨てるため `stop --help` が打刻を終了する | `rejectUnknownArgs` を追加。`start` 側の `--` 始まりも同様に弾く |
| [Minor] | `--note --at 10:00` で note が `--at` になり終了時刻が黙って `now` になる | 次が `--` 始まりなら「値が無い」として `UserError` |

あわせて、両コマンドで**引数の検査を store に触る前へ移した**。検査で落ちる入力では
状態が一切変わらないことが構造的に保証される。

**#3 は提案から一点変えている**（`-` 始まり一律ではなく `--` 始まりに限定）。
`--note "-5分の中断あり"` を書けなくしないため。スレッドで根拠を返信済みで、
同意いただけなければ一律に変更する。

サブコマンドごとの `--help` の中身を出すことは DoD の外と判断し、#42 として起票した。

## 判断が必要だった点

1. **`--at` はローカルタイムゾーンで解釈している。**
   「打ち忘れた分を後から入れる」用途なので、利用者が打った `09:30` は手元の時計の
   9時半だと解釈するのが自然だと考えた。タイムゾーンの設定は #22 の担当なので、
   ここでは環境の TZ に従うだけにしてある。
2. **`--at` は日跨ぎを扱えない。** 実行日の同じ日付として解釈するため、
   23:00 開始 → 翌 00:30 停止は `--at "00:30"` では表現できない（開始より前になり
   `UserError`）。日付込みの指定は Issue のスコープ外と判断した。必要なら別 Issue にする。
3. **`#tag` の抽出は最小限。** 空白区切りで `#` 始まりの語を取り、重複を除くだけ。
   正規化・階層タグの扱いは #8 の担当なので踏み込んでいない（`#` 単体はタグにしない）。
4. **stop で `end < start` になった場合は保存しない。**
   実行中のまま残せば正しい時刻で打ち直せるが、壊れた記録を保存すると集計が狂うため。

## 依存の追加

なし。

## 検証

`npm run check` green（10 files / 277 tests）。CLI として一時ディレクトリで通しの動作、
および指摘3件の修正を実コマンドで確認済み。
