### PR TITLE
[E4-3][P1] `status` コマンド（実行中の作業を表示）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 import { createStartCommand } from "./commands/start.js";
+import { createStatusCommand } from "./commands/status.js";
 import { createStopCommand } from "./commands/stop.js";
 import { randomId } from "./id.js";
 import { createJsonlStore } from "./store/jsonl-store.js";
@@ -159,7 +160,7 @@ function buildCommands(): readonly Command[] {
     newId: randomId,
   };
 
-  return [createStartCommand(deps), createStopCommand(deps)];
+  return [createStartCommand(deps), createStopCommand(deps), createStatusCommand(deps)];
 }
 
 /**

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -52,6 +52,21 @@ export function takeOption(
 }
 
 /**
+ * 値を取らないフラグの有無を調べ、残りを返す。
+ *
+ * 同じフラグを複数回書いても有効として扱う（`--short --short`）。打ち間違いではあるが、
+ * 意図は明らかなのでエラーにする理由がない。
+ */
+export function takeFlag(
+  argv: readonly string[],
+  name: string,
+): { present: boolean; rest: string[] } {
+  const rest = argv.filter((token) => token !== name);
+
+  return { present: rest.length !== argv.length, rest };
+}
+
+/**
  * オプションを取り出した後に余ったトークンを検査し、解釈できないものを弾く。
  *
  * 黙って捨てると `tock stop --help` が使い方の表示ではなく打刻の終了として成功する。

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,102 @@
+import { type CliIo, type Command } from "../cli.js";
+import type { Entry } from "../domain/entry.js";
+import { durationMs } from "../domain/period.js";
+import { formatDuration } from "../format/duration.js";
+import { type CommandDeps, rejectUnknownArgs, takeFlag } from "./args.js";
+
+/** `--short` で実行中が無いときに出す1行。 */
+const NOTHING_RUNNING_SHORT = "-";
+
+/**
+ * 実行中の作業を表示する。
+ *
+ * **実行中が無くてもエラーにしない（終了コード 0）。** `status` は状態を問い合わせる
+ * コマンドなので、「何も動いていない」は正常な答えである。`stop` が実行中なしを
+ * エラーにするのとは意味が違う（あちらは打ち忘れに気づけないため）。
+ *
+ * 読むだけで何も書かない。
+ */
+export function createStatusCommand(deps: CommandDeps): Command {
+  return {
+    name: "status",
+    summary: "実行中の作業を表示する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const { present: short, rest } = takeFlag(argv, "--short");
+      rejectUnknownArgs(rest, {
+        command: "status",
+        allowedOptions: ["--short"],
+        allowPositional: false,
+      });
+
+      const running = await deps.store.findRunning();
+      const lines = short ? shortLines(running, deps.now()) : longLines(running, deps.now());
+
+      for (const line of lines) {
+        io.out(line);
+      }
+    },
+  };
+}
+
+/**
+ * 通常の表示。人が読むための複数行。
+ *
+ * タグが無いときにタグ行を出さないのは、空の項目を並べても情報が増えないため。
+ */
+function longLines(running: Entry | undefined, now: Date): string[] {
+  if (running === undefined) {
+    return ["実行中の作業はありません。tock start で開始してください"];
+  }
+
+  const lines = [`実行中: ${running.note ?? "（名前なし）"}`];
+
+  if (running.tags.length > 0) {
+    lines.push(`タグ: ${formatTags(running.tags)}`);
+  }
+
+  lines.push(`経過: ${formatDuration(durationMs(running, now))}`);
+  lines.push(`開始: ${running.start}`);
+
+  return lines;
+}
+
+/**
+ * `--short` の表示。**必ず1行だけ返す。**
+ *
+ * シェルのプロンプトやステータスバーに埋め込む用途なので、形式を固定する。
+ *
+ * ```
+ * 設計 #work #proj/tock 1h 23m   note とタグの両方がある
+ * 設計 1h 23m                    タグが無い
+ * #work 1h 23m                   note が無い
+ * 1h 23m                         どちらも無い
+ * -                              実行中が無い
+ * ```
+ *
+ * 実行中が無いときも空文字ではなく `-` を出す。プロンプトに埋め込んだときに行が
+ * 消えて表示が詰まるのを避ける。装飾記号を前に付けないのは、埋め込み先の見た目を
+ * 呼び出し側が決められるようにするため。
+ */
+function shortLines(running: Entry | undefined, now: Date): string[] {
+  if (running === undefined) {
+    return [NOTHING_RUNNING_SHORT];
+  }
+
+  const parts: string[] = [];
+
+  if (running.note !== undefined) {
+    parts.push(running.note);
+  }
+  if (running.tags.length > 0) {
+    parts.push(formatTags(running.tags));
+  }
+  parts.push(formatDuration(durationMs(running, now)));
+
+  return [parts.join(" ")];
+}
+
+/** 保存されているタグ名に `#` を戻して並べる。 */
+function formatTags(tags: readonly string[]): string {
+  return tags.map((tag) => `#${tag}`).join(" ");
+}

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1,0 +1,267 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStatusCommand } from "../../src/commands/status.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-status-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+/** 09:00 に開始した実行中エントリを作る。 */
+async function startAt9(description = "設計 #work"): Promise<void> {
+  await createStartCommand(deps(new Date("2026-08-12T09:00:00Z"))).run([description], io);
+  out = [];
+}
+
+describe("status（実行中あり）", () => {
+  it("作業名を表示する", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("設計");
+  });
+
+  it("タグを表示する", async () => {
+    await startAt9("設計 #work #proj/tock");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    const text = out.join("\n");
+
+    expect(text).toContain("#work");
+    expect(text).toContain("#proj/tock");
+  });
+
+  it("経過時間を人間可読な形式で表示する", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("1h 23m");
+  });
+
+  it("開始時刻を表示する", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("2026-08-12T09:00:00.000Z");
+  });
+
+  it("stdout に出て stderr は空、終了コードは 0 相当（例外を投げない）", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.length).toBeGreaterThan(0);
+    expect(err).toEqual([]);
+  });
+
+  it("タグが無ければタグ行を出さない", async () => {
+    await startAt9("設計");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(out.join("\n")).not.toContain("タグ");
+  });
+
+  it("作業名が無くてもタグだけで表示できる", async () => {
+    await startAt9("#work");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    const text = out.join("\n");
+
+    expect(text).toContain("#work");
+    expect(text).toContain("1h 23m");
+  });
+
+  it("開始直後（経過 0）でも表示できる（境界）", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T09:00:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("0s");
+  });
+
+  it("状態を変えない（表示しても実行中のまま）", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([], io);
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+});
+
+describe("status（実行中なし）", () => {
+  it("実行中が無いことを表示し、例外を投げない（終了コード 0）", async () => {
+    await expect(
+      createStatusCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io),
+    ).resolves.toBeUndefined();
+
+    expect(out.join("\n")).toContain("実行中の作業はありません");
+  });
+
+  it("記録が1件もなくてもエラーにしない（境界）", async () => {
+    await createStatusCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io);
+
+    expect(err).toEqual([]);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("停止したあとは実行中なしになる", async () => {
+    await startAt9();
+    await createStopCommand(deps(new Date("2026-08-12T10:00:00Z"))).run([], io);
+    out = [];
+
+    await createStatusCommand(deps(new Date("2026-08-12T11:00:00Z"))).run([], io);
+
+    expect(out.join("\n")).toContain("実行中の作業はありません");
+  });
+});
+
+describe("status --short", () => {
+  it("出力は1行だけ", async () => {
+    await startAt9();
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out).toHaveLength(1);
+  });
+
+  it("形式は `作業名 #タグ 経過時間` で固定", async () => {
+    await startAt9("設計 #work");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out[0]).toBe("設計 #work 1h 23m");
+  });
+
+  it("タグが複数あれば空白区切りで並ぶ", async () => {
+    await startAt9("設計 #work #proj/tock");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out[0]).toBe("設計 #work #proj/tock 1h 23m");
+  });
+
+  it("タグが無ければ作業名と経過時間だけ", async () => {
+    await startAt9("設計");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out[0]).toBe("設計 1h 23m");
+  });
+
+  it("作業名が無ければタグと経過時間だけ", async () => {
+    await startAt9("#work");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out[0]).toBe("#work 1h 23m");
+  });
+
+  it("作業名もタグも無ければ経過時間だけ（境界）", async () => {
+    await createStartCommand(deps(new Date("2026-08-12T09:00:00Z"))).run([], io);
+    out = [];
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(["--short"], io);
+
+    expect(out[0]).toBe("1h 23m");
+  });
+
+  it("実行中が無ければ `-` の1行（プロンプトが崩れないように必ず1行出す）", async () => {
+    await createStatusCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--short"], io);
+
+    expect(out).toEqual(["-"]);
+  });
+
+  it("実行中が無くても例外を投げない（終了コード 0）", async () => {
+    await expect(
+      createStatusCommand(deps(new Date("2026-08-12T10:00:00Z"))).run(["--short"], io),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("status の引数", () => {
+  it.each([
+    ["未知のオプション", "--unknown"],
+    ["サブコマンドのヘルプ", "--help"],
+    ["短縮形", "-s"],
+    ["余分な位置引数", "余計な引数"],
+  ])("%s を渡したら UserError で失敗する", async (_label, token) => {
+    await startAt9();
+
+    await expect(
+      createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run([token], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("--short を2回書いても通る", async () => {
+    await startAt9("設計");
+
+    await createStatusCommand(deps(new Date("2026-08-12T10:23:00Z"))).run(
+      ["--short", "--short"],
+      io,
+    );
+
+    expect(out).toEqual(["設計 1h 23m"]);
+  });
+});
+
+describe("status の経過時間は注入した現在時刻で決まる", () => {
+  it.each([
+    ["45秒", "2026-08-12T09:00:45Z", "45s"],
+    ["45分", "2026-08-12T09:45:00Z", "45m"],
+    ["ちょうど2時間", "2026-08-12T11:00:00Z", "2h"],
+    ["日跨ぎ（25時間）", "2026-08-13T10:00:00Z", "25h"],
+  ])("%s 後なら %s と表示する", async (_label, now, expected) => {
+    await startAt9("設計");
+
+    await createStatusCommand(deps(new Date(now))).run(["--short"], io);
+
+    expect(out[0]).toBe(`設計 ${expected}`);
+  });
+});


### PR DESCRIPTION
## 概要

`tock status` を実装した。打刻したあと「今なにを何分やっているか」を確認する手段がなく、
`start` したことを忘れたまま放置しても気づけなかった。

- `src/commands/status.ts` — 実行中エントリの作業名・タグ・経過時間・開始時刻を表示する。
  読むだけで何も書かない
- `src/commands/args.ts` — 値を取らないフラグ用に `takeFlag` を追加（`--short` 用）
- `src/cli.ts` — `buildCommands()` に登録

Closes #14

### 実行中が無い場合をエラーにしない（終了コード 0）

`status` は状態を問い合わせるコマンドなので、「何も動いていない」は正常な答えである。
`stop` が実行中なしをエラーにするのとは意味が違う（あちらは打ち忘れに気づけないため）。

```
$ tock status
実行中の作業はありません。tock start で開始してください   # exit 0
```

### `--short` は必ず1行だけ出す

シェルのプロンプトやステータスバーに埋め込む用途なので、形式を固定した。

```
設計 #work #proj/tock 1h 23m   note とタグの両方がある
設計 1h 23m                    タグが無い
#work 1h 23m                   note が無い
1h 23m                         どちらも無い
-                              実行中が無い
```

実行中が無いときも空文字ではなく `-` を出す。プロンプトに埋め込んだときに行が消えて
表示が詰まるのを避けるため。装飾記号（`▶` など）を前に付けないのは、見た目を
埋め込み先が決められるようにするため。

## 受け入れ条件

- [x] 実行中あり/なし両方のテストがある
      → `tests/commands/status.test.ts` の「status（実行中あり）」「status（実行中なし）」。
      実行中なしは `resolves.toBeUndefined()` で終了コード 0 相当を検証
- [x] `--short` の出力形式が固定されていることをテストしている
      → 完全一致で検証（`expect(out[0]).toBe("設計 #work 1h 23m")`）。
      note のみ / タグのみ / 両方なし / 実行中なしの4パターンも同様に固定
- [x] 経過時間の算出に固定した現在時刻を注入できる（テスト可能な設計になっている）
      → `deps.now()` から算出。45秒 / 45分 / ちょうど2時間 / 日跨ぎ25時間を注入して検証

## スタック

- base: `main`（スタックなし）
- 作成時は `feat/13-start-stop-command`（PR #41）を base にする予定だったが、実装中に #41 が
  マージされたため `main` ベースに切り替え、`main` を取り込み直した。差分はこの Issue の分だけ（4ファイル）

## 判断した点

- **未知の引数は終了コード 1 で弾く。** `status --help` も現時点ではエラーになる。
  サブコマンドごとの `--help` は #42 の担当範囲なので、ここでは踏み込んでいない
- **`--short` を2回書いても通す。** 打ち間違いではあるが意図は明らかなのでエラーにする理由がない
- **タグが無いときは通常表示のタグ行を出さない。** 空の項目を並べても情報が増えないため

## 依存の追加

なし。

## 検証

`npm run check` green（11 files / 306 tests）。`main` 取り込み後にも再実行して green。
CLI としての通し動作も一時ディレクトリで確認済み
（実行中なし → `start` → `status` / `status --short` → 未知の引数で終了コード 1）。

テストが実際に回帰を捕まえることを、実装を壊して確認しました。

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 注入した `now` を無視して実時刻を使う | 13件 |
| `--short` からタグを落とす | 3件 |
| 実行中なしを例外にする | 3件 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_