### PR TITLE
[E2-3][P2] 時間の丸め（丸め単位・切上/切捨/四捨五入）

### DIFF
--- a/src/domain/rounding.ts
+++ b/src/domain/rounding.ts
@@ -62,6 +62,16 @@ export function roundMs(ms: number, rule: RoundingRule): number {
     case "nearest": {
       return remainder * 2 >= unit ? floored + unit : floored;
     }
+    default: {
+      // 型を外れた mode（設定ファイル #22 など、型検査を通らない経路から来る値）を
+      // 黙って undefined で返すと、戻り値の型が number である約束が破れ、呼び出し側の
+      // 算術が NaN になって集計が静かに壊れる。ここで落とす。
+      //
+      // never への代入にしているのは、**モードを増やして case を書き忘れたときに
+      // 型検査で落ちる**ようにするため。実行時の防御と将来の追加漏れ検出を兼ねる。
+      const unhandled: never = rule.mode;
+      throw new Error(`丸め方が不正です: ${JSON.stringify(unhandled)}`);
+    }
   }
 }
 

--- a/src/domain/rounding.ts
+++ b/src/domain/rounding.ts
@@ -1,0 +1,78 @@
+/**
+ * 時間の丸め。
+ *
+ * 工数報告では「15分単位」のような粒度が求められる一方、記録そのものは実測のままで
+ * 残しておきたい。そのため**丸めは値を返す純関数として持ち、保存されたデータには
+ * 触れない**。集計・表示のときに通す使い方を想定している。
+ *
+ * どの単位・どのモードを既定にするかは設定の話なので #22 の担当範囲。ここでは
+ * 指定された規則どおりに丸めるだけにする。
+ */
+
+const MS_PER_MINUTE = 60 * 1000;
+
+/** 丸め方。 */
+export type RoundingMode =
+  /** 端数があれば次の単位まで上げる。 */
+  | "ceil"
+  /** 端数を落とす。 */
+  | "floor"
+  /** 半分以上なら上げ、半分未満なら落とす。 */
+  | "nearest";
+
+/** 丸めの規則。 */
+export interface RoundingRule {
+  /** 丸める単位（分）。正の整数。 */
+  readonly unitMinutes: number;
+  readonly mode: RoundingMode;
+}
+
+/**
+ * 長さ（ミリ秒）を規則どおりに丸める。
+ *
+ * **0 は 0 のまま返す。** `ceil` で 1 単位に上げると、記録していない時間が報告に
+ * 載ってしまう。長さ 0 のエントリ（打刻の直後に止めたもの）は実際に存在するため、
+ * ここで水増しすると合計が実態と合わなくなる。
+ *
+ * `nearest` はちょうど半分を**上げる側**に寄せる。どちらに寄せるかを決めておかないと、
+ * 同じ入力で結果が変わって見える。
+ *
+ * 引数を書き換えないので、元のエントリや規則はそのまま残る。
+ */
+export function roundMs(ms: number, rule: RoundingRule): number {
+  assertPositiveInteger(rule.unitMinutes, "丸めの単位");
+  assertNonNegativeInteger(ms, "長さ");
+
+  const unit = rule.unitMinutes * MS_PER_MINUTE;
+  const remainder = ms % unit;
+
+  if (remainder === 0) {
+    return ms;
+  }
+
+  const floored = ms - remainder;
+
+  switch (rule.mode) {
+    case "floor": {
+      return floored;
+    }
+    case "ceil": {
+      return floored + unit;
+    }
+    case "nearest": {
+      return remainder * 2 >= unit ? floored + unit : floored;
+    }
+  }
+}
+
+function assertPositiveInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label}は正の整数（分）で指定してください: ${String(value)}`);
+  }
+}
+
+function assertNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label}はミリ秒の非負整数で指定してください: ${String(value)}`);
+  }
+}

--- a/tests/domain/rounding.test.ts
+++ b/tests/domain/rounding.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createEntry } from "../../src/domain/entry.js";
 import { durationMs } from "../../src/domain/period.js";
-import { type RoundingRule, roundMs } from "../../src/domain/rounding.js";
+import { type RoundingMode, type RoundingRule, roundMs } from "../../src/domain/rounding.js";
 
 const MINUTE = 60 * 1000;
 const SECOND = 1000;
@@ -159,5 +159,26 @@ describe("roundMs は元データを書き換えない", () => {
 
     expect(roundMs(ms, given)).toBe(roundMs(ms, given));
     expect(roundMs(roundMs(ms, given), given)).toBe(roundMs(ms, given));
+  });
+});
+
+// 型を外れた mode で戻り値が undefined になると、number という約束が破れて
+// 呼び出し側の算術が NaN になる。集計に流れると静かに壊れるので、実行時にも落とす
+describe("roundMs の不正な丸め方", () => {
+  it.each([
+    ["知らないモード", "bogus"],
+    ["空文字", ""],
+    ["大文字", "CEIL"],
+  ])("mode が %s なら Error を投げる（undefined を返さない）", (_label, mode) => {
+    const given = { mode: mode as RoundingMode, unitMinutes: 1 };
+
+    expect(() => roundMs(90 * SECOND, given)).toThrow(/丸め方/);
+  });
+
+  it("端数が無いときは不正な mode でも Error にならない（早期 return のため）", () => {
+    // 丸める必要が無い入力は mode を見ずに返す。仕様として固定しておく
+    const given = { mode: "bogus" as RoundingMode, unitMinutes: 1 };
+
+    expect(roundMs(2 * MINUTE, given)).toBe(2 * MINUTE);
   });
 });

--- a/tests/domain/rounding.test.ts
+++ b/tests/domain/rounding.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { createEntry } from "../../src/domain/entry.js";
+import { durationMs } from "../../src/domain/period.js";
+import { type RoundingRule, roundMs } from "../../src/domain/rounding.js";
+
+const MINUTE = 60 * 1000;
+const SECOND = 1000;
+
+/** 15分単位。工数報告でよく使う単位。 */
+function rule(unitMinutes: number, mode: RoundingRule["mode"]): RoundingRule {
+  return { unitMinutes, mode };
+}
+
+describe("roundMs（切り上げ）", () => {
+  it("端数があれば次の単位まで上げる", () => {
+    expect(roundMs(1 * MINUTE, rule(15, "ceil"))).toBe(15 * MINUTE);
+  });
+
+  it("1ミリ秒でも超えていれば上げる（境界）", () => {
+    expect(roundMs(15 * MINUTE + 1, rule(15, "ceil"))).toBe(30 * MINUTE);
+  });
+
+  it("単位ちょうどなら変えない（境界）", () => {
+    expect(roundMs(30 * MINUTE, rule(15, "ceil"))).toBe(30 * MINUTE);
+  });
+
+  it("ちょうど半分は上げる（境界）", () => {
+    expect(roundMs(7 * MINUTE + 30 * SECOND, rule(15, "ceil"))).toBe(15 * MINUTE);
+  });
+
+  it("0分は0のまま（境界）", () => {
+    // 0 を 1 単位に上げると、記録していない時間が報告に載ってしまう
+    expect(roundMs(0, rule(15, "ceil"))).toBe(0);
+  });
+});
+
+describe("roundMs（切り捨て）", () => {
+  it("端数を落とす", () => {
+    expect(roundMs(29 * MINUTE, rule(15, "floor"))).toBe(15 * MINUTE);
+  });
+
+  it("単位ちょうどなら変えない（境界）", () => {
+    expect(roundMs(30 * MINUTE, rule(15, "floor"))).toBe(30 * MINUTE);
+  });
+
+  it("ちょうど半分は落とす（境界）", () => {
+    expect(roundMs(7 * MINUTE + 30 * SECOND, rule(15, "floor"))).toBe(0);
+  });
+
+  it("単位に届かない時間は0になる（境界）", () => {
+    expect(roundMs(14 * MINUTE + 59 * SECOND, rule(15, "floor"))).toBe(0);
+  });
+
+  it("0分は0のまま（境界）", () => {
+    expect(roundMs(0, rule(15, "floor"))).toBe(0);
+  });
+});
+
+describe("roundMs（四捨五入）", () => {
+  it("半分未満は落とす", () => {
+    expect(roundMs(7 * MINUTE, rule(15, "nearest"))).toBe(0);
+  });
+
+  it("半分を超えれば上げる", () => {
+    expect(roundMs(8 * MINUTE, rule(15, "nearest"))).toBe(15 * MINUTE);
+  });
+
+  it("ちょうど半分は上げる（境界）", () => {
+    // 「四捨五入」は半分を上げる側に寄せる。どちらに寄せるかを決めておかないと
+    // 同じ入力で結果が変わって見える
+    expect(roundMs(7 * MINUTE + 30 * SECOND, rule(15, "nearest"))).toBe(15 * MINUTE);
+  });
+
+  it("ちょうど半分の1ミリ秒前は落とす（境界）", () => {
+    expect(roundMs(7 * MINUTE + 30 * SECOND - 1, rule(15, "nearest"))).toBe(0);
+  });
+
+  it("単位ちょうどなら変えない（境界）", () => {
+    expect(roundMs(30 * MINUTE, rule(15, "nearest"))).toBe(30 * MINUTE);
+  });
+
+  it("0分は0のまま（境界）", () => {
+    expect(roundMs(0, rule(15, "nearest"))).toBe(0);
+  });
+});
+
+describe("roundMs（単位の指定）", () => {
+  it.each([
+    ["1分単位", 1, 90 * SECOND, 2 * MINUTE],
+    ["5分単位", 5, 6 * MINUTE, 5 * MINUTE],
+    ["30分単位", 30, 20 * MINUTE, 30 * MINUTE],
+    ["60分単位", 60, 31 * MINUTE, 60 * MINUTE],
+  ])("%s で四捨五入できる", (_label, unit, input, expected) => {
+    expect(roundMs(input, rule(unit, "nearest"))).toBe(expected);
+  });
+
+  it("1分単位なら秒の端数だけが丸められる", () => {
+    expect(roundMs(10 * MINUTE + 20 * SECOND, rule(1, "floor"))).toBe(10 * MINUTE);
+  });
+
+  it("長い時間でも桁が狂わない（25時間）", () => {
+    const ms = 25 * 60 * MINUTE + 7 * MINUTE;
+
+    expect(roundMs(ms, rule(15, "floor"))).toBe(25 * 60 * MINUTE);
+  });
+
+  it.each([
+    ["0", 0],
+    ["負の値", -15],
+    ["小数", 1.5],
+    ["NaN", Number.NaN],
+    ["無限", Number.POSITIVE_INFINITY],
+  ])("単位が不正（%s）なら Error を投げる", (_label, unit) => {
+    expect(() => roundMs(60 * MINUTE, rule(unit, "floor"))).toThrow();
+  });
+
+  it.each([
+    ["負の長さ", -1],
+    ["小数の長さ", 1.5],
+    ["NaN", Number.NaN],
+    ["無限", Number.POSITIVE_INFINITY],
+  ])("長さが不正（%s）なら Error を投げる", (_label, ms) => {
+    expect(() => roundMs(ms, rule(15, "floor"))).toThrow();
+  });
+});
+
+describe("roundMs は元データを書き換えない", () => {
+  it("丸めの指定（RoundingRule）を書き換えない", () => {
+    const given = rule(15, "ceil");
+
+    roundMs(7 * MINUTE, given);
+
+    expect(given).toEqual({ unitMinutes: 15, mode: "ceil" });
+  });
+
+  it("エントリを書き換えない（生データは丸めずに保持する）", () => {
+    const entry = createEntry(
+      {
+        start: new Date("2026-08-13T09:00:00Z"),
+        end: new Date("2026-08-13T09:07:00Z"),
+        tags: ["work"],
+      },
+      { newId: () => "id-1" },
+    );
+    const snapshot = structuredClone(entry);
+
+    const rounded = roundMs(durationMs(entry), rule(15, "ceil"));
+
+    expect(rounded).toBe(15 * MINUTE);
+    expect(entry).toEqual(snapshot);
+    // 丸めた値は元の長さと違う。それでもエントリ側は 7 分のまま
+    expect(durationMs(entry)).toBe(7 * MINUTE);
+  });
+
+  it("同じ入力を何度丸めても結果が変わらない", () => {
+    const given = rule(15, "nearest");
+    const ms = 7 * MINUTE + 30 * SECOND;
+
+    expect(roundMs(ms, given)).toBe(roundMs(ms, given));
+    expect(roundMs(roundMs(ms, given), given)).toBe(roundMs(ms, given));
+  });
+});


### PR DESCRIPTION
## 概要

`src/domain/rounding.ts` を追加し、長さ（ミリ秒）を指定した単位・モードで丸める純関数を用意した。

工数報告では「15分単位」のような粒度が求められる一方、記録そのものは実測のままで残しておきたい。
そのため**値を返す純関数として持ち、保存されたデータには触れない**形にした。

```ts
export type RoundingMode = "ceil" | "floor" | "nearest";
export interface RoundingRule { readonly unitMinutes: number; readonly mode: RoundingMode }
export function roundMs(ms: number, rule: RoundingRule): number
```

Closes #7

### 設計の理由

**0 は 0 のまま返す。** `ceil` で 1 単位に上げると、記録していない時間が報告に載る。
長さ 0 のエントリは打刻の直後に止めれば実際に作れる（`stop` の「0分で停止しても失敗しない」
テストで固定されている挙動）ため、ここで水増しすると合計が実態と合わなくなる。

**`nearest` はちょうど半分を上げる側に寄せる。** どちらに寄せるかを決めておかないと、
同じ入力で結果が変わって見える。

**単位が 0・負・小数ならエラーにする。** 0 で割ると剰余が `NaN` になり、丸めたつもりの値が
黙って壊れる。

## 受け入れ条件

- [x] 3モード × 境界値（ちょうど半分、単位ちょうど、0分）のテストがある
      → `tests/domain/rounding.test.ts` の「切り上げ」5件 / 「切り捨て」5件 / 「四捨五入」6件。
      3モードすべてに「ちょうど半分」「単位ちょうど」「0分」を置いた
      ```
      15分単位（元の長さ → floor / nearest / ceil）
        0分      → 0s       0s       0s        ← 0分は3モードすべて 0
        7分00秒  → 0s       0s       15m
        7分30秒  → 0s       15m      15m       ← ちょうど半分。nearest は上げる
        8分00秒  → 0s       15m      15m
        15分00秒 → 15m      15m      15m       ← 単位ちょうどは3モードすべて不変
        29分00秒 → 15m      30m      30m
      ```
      （表示は `formatDuration` を通しているため分未満は切り捨てで出る。
      7分00秒と7分30秒が同じ `7m` に見えるのはそのため）
- [x] 丸めても元データが書き換わらないことがテストされている
      → 「roundMs は元データを書き換えない」3件
      - `RoundingRule` を渡した後も内容が変わらない
      - **`Entry` を `structuredClone` で控えてから `roundMs(durationMs(entry), ...)` を実行し、
        エントリが一致することを確認**。丸めた値が 15分になっても `durationMs(entry)` は 7分のまま
      - 同じ入力を何度丸めても結果が変わらない（べき等）

不正な指定は `Error` で弾く。

```
unitMinutes=0:    丸めの単位は正の整数（分）で指定してください: 0
unitMinutes=-15:  丸めの単位は正の整数（分）で指定してください: -15
unitMinutes=1.5:  丸めの単位は正の整数（分）で指定してください: 1.5
```

## mutation test

`src/` を変更したので実施した。5箇所すべてでテストが落ちた。

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 0 を切り上げて1単位にする（記録していない時間が載る） | 2件 |
| `nearest` のちょうど半分を落とす側に寄せる | 2件 |
| `ceil` と `floor` を入れ替える | 9件 |
| 単位を分ではなく秒として扱う | 17件 |
| 不正な単位の検査をやめる | 5件 |

元に戻して 34 件すべて通ることを確認済み。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 長さ 0（3モード） |
| 同時刻 | 単位ちょうど（3モード）、ちょうど半分とその1ミリ秒前 |
| 日跨ぎ | 25時間の長さで桁が狂わないことを確認 |
| 上限値・範囲外 | 単位が 0 / 負 / 小数 / NaN / 無限、長さが負 / 小数 / NaN / 無限（計9件） |
| 終端のないデータ | **該当しない。** この関数は長さ（数値）だけを受け取り、`end` を持たない `Entry` を直接扱わない。実行中エントリの長さは `durationMs(entry, asOf)` が確定させたあとに渡される |

## スコープについて（レビューで見てほしい）

Issue のスコープに「集計時に適用する（生データは丸めずに保持する）」とあるが、
**この PR では関数の提供までに留め、集計への適用は行っていない。**

理由は2つ。

1. **DoD は関数の振る舞いだけを求めている。** 2項目とも丸めの結果と元データの不変性についてで、
   集計への組み込みは含まれていない
2. **適用するには利用者が単位を選ぶ手段が必要で、それが存在しない。** 設定ファイル（#22）が
   「丸め単位」を担当範囲に含んでおり、CLI フラグを今ここで発明すると #22 と二重になる。
   既定値で無条件に丸めると、実測を見たい人が見られなくなる

なお日次サマリ（#18）は PR #50 でレビュー待ちであり、`main` にはまだ集計コードがありません。
`#7` の依存は E2-2（#6）のみなので `main` ベースにしています。

**「集計時に適用する」を別 Issue として切り出すべきか、この PR に含めるべきかは判断を仰ぎたい点です。**
含める場合は #22（設定ファイル）または #50（日次サマリ）のマージ待ちになります。

## 依存の追加

なし。

## 検証

`npm run check` green（12 files / 340 tests。306 → 340 で +34件）。修正試行 0 回。

## この周の Issue 選定について

自動選択の順序（P2 の中で番号昇順）では **#4** が対象になりましたが、その DoD 3項目は
すでに満たされており着手しても書くコードがないため、#4 にその根拠をコメントしてスキップし、
次の候補である #7 に進みました。#4 を閉じてよいかは #4 のコメントで確認しています。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_