### PR TITLE
[E4-4][P2] `switch` コマンド（stop と start をまとめて行う）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { createStartCommand } from "./commands/start.js";
 import { createStatusCommand } from "./commands/status.js";
 import { createStopCommand } from "./commands/stop.js";
+import { createSwitchCommand } from "./commands/switch.js";
 import { randomId } from "./id.js";
 import { createJsonlStore } from "./store/jsonl-store.js";
 import { resolveStorePath } from "./store/store.js";
@@ -160,7 +161,12 @@ function buildCommands(): readonly Command[] {
     newId: randomId,
   };
 
-  return [createStartCommand(deps), createStopCommand(deps), createStatusCommand(deps)];
+  return [
+    createStartCommand(deps),
+    createStopCommand(deps),
+    createStatusCommand(deps),
+    createSwitchCommand(deps),
+  ];
 }
 
 /**

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -1,0 +1,113 @@
+import { type CliIo, type Command, UserError } from "../cli.js";
+import { createEntry, type Entry } from "../domain/entry.js";
+import { durationMs } from "../domain/period.js";
+import { formatDuration } from "../format/duration.js";
+import { type CommandDeps, parseDescription, rejectUnknownArgs, resolveAt } from "./args.js";
+
+/**
+ * 実行中の作業を終了して、そのまま次の作業を開始する。
+ *
+ * 実行中が無ければ単なる `start` として動く。切り替えるつもりで打った人にとって
+ * 「実行中が無い」はエラーではなく、始めればよいだけである。
+ *
+ * **前のエントリの `end` と新しいエントリの `start` は同一時刻にする。** 2コマンドに
+ * 分けて打つと隙間が空き、合計が実態より短くなる。それを避けるのがこのコマンドの目的。
+ */
+export function createSwitchCommand(deps: CommandDeps): Command {
+  return {
+    name: "switch",
+    summary: "実行中の作業を終了して次の作業を開始する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const { at, rest } = resolveAt(argv, deps.now());
+      rejectUnknownArgs(rest, {
+        command: "switch",
+        allowedOptions: ["--at"],
+        allowPositional: true,
+      });
+      const { tags, note } = parseDescription(rest.join(" "));
+
+      const running = await deps.store.findRunning();
+
+      // **書き込む前に、失敗しうる組み立てをすべて済ませる。**
+      // 途中で弾かれると「前を止めただけで新規開始されない」中途半端な状態が残るため、
+      // 検証は保存の前に寄せる
+      const next = createEntry(
+        { start: at, tags, ...(note === undefined ? {} : { note }) },
+        { newId: deps.newId },
+      );
+      const stopped = running === undefined ? undefined : stopAt(running, at);
+
+      await save(deps, running, stopped, next);
+
+      if (stopped !== undefined) {
+        io.out(`停止しました: ${formatDuration(durationMs(stopped))}`);
+      }
+      io.out(`開始しました: ${label(note, tags)}`);
+      io.out(`開始時刻: ${next.start}`);
+    },
+  };
+}
+
+/**
+ * 確定と追記を行う。追記に失敗したら、確定を巻き戻す。
+ *
+ * ストアに複数の書き込みをまとめる手段が無いため（追記のみの JSONL）、片方だけ成功した
+ * 状態がありえる。順序と巻き戻しでそれを詰める。
+ *
+ * - 確定を先にするのは、追記を先にすると失敗時に**実行中が2件**残るため。
+ *   どちらを止めるべきか決められない状態になり、0件より不都合が大きい
+ * - 追記が落ちた場合は元の実行中エントリを書き戻し、切り替えを試す前の状態に戻す
+ *
+ * 巻き戻し自体が失敗する可能性は残る。書き込みを1回にまとめる話は #11（ファイルロック）や
+ * #40（ストアの整理）の範囲なので、ここでは扱わない。
+ */
+async function save(
+  deps: CommandDeps,
+  running: Entry | undefined,
+  stopped: Entry | undefined,
+  next: Entry,
+): Promise<void> {
+  if (stopped !== undefined) {
+    await deps.store.update(stopped);
+  }
+
+  try {
+    await deps.store.append(next);
+  } catch (error) {
+    if (running !== undefined) {
+      await deps.store.update(running);
+    }
+    throw error;
+  }
+}
+
+/**
+ * 実行中エントリを指定時刻で確定させる。
+ *
+ * `createEntry` は `end < start` を弾く。打ち間違いなので `UserError` に翻訳する
+ * （`stop` と同じ扱い）。
+ */
+function stopAt(running: Entry, at: Date): Entry {
+  try {
+    return createEntry(
+      {
+        start: running.start,
+        end: at,
+        tags: running.tags,
+        ...(running.note === undefined ? {} : { note: running.note }),
+      },
+      { newId: () => running.id },
+    );
+  } catch (error) {
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** 開始したことを伝える1行の見出し。`start` と同じ形にする。 */
+function label(note: string | undefined, tags: readonly string[]): string {
+  const name = note ?? "（名前なし）";
+  const tagText = tags.length === 0 ? "" : ` [${tags.map((tag) => `#${tag}`).join(" ")}]`;
+
+  return `${name}${tagText}`;
+}

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -76,10 +76,44 @@ async function save(
     await deps.store.append(next);
   } catch (error) {
     if (running !== undefined) {
-      await deps.store.update(running);
+      await rollback(deps, running, error);
     }
     throw error;
   }
+}
+
+/**
+ * 追記が落ちたあと、元の実行中エントリを書き戻す。
+ *
+ * **巻き戻しが失敗したときに、追記側の失敗を捨てない。** 素に `await` するだけだと
+ * 巻き戻しの例外が上に飛び、利用者には「巻き戻しが失敗しました」しか届かない。
+ * 本当の原因（追記が落ちた理由）が消えるため、何が起きたのか追えなくなる。
+ *
+ * この状態は DoD が避けたい形（前の作業は停止済み・新しい作業は無し）そのままなので、
+ * **今どうなっているかと、どう戻すか**もメッセージに入れる。書き込みを1回にまとめて
+ * この状態自体を作らない話は #11（ファイルロック）や #40（ストアの整理）の範囲。
+ */
+async function rollback(deps: CommandDeps, running: Entry, cause: unknown): Promise<void> {
+  try {
+    await deps.store.update(running);
+  } catch (rollbackError) {
+    throw new Error(
+      [
+        "切り替えに失敗し、元の状態への巻き戻しにも失敗しました。",
+        `追記の失敗: ${messageOf(cause)}`,
+        `巻き戻しの失敗: ${messageOf(rollbackError)}`,
+        `現在の状態: 前の作業は停止済みで、新しい作業は開始されていません`,
+        `復帰するには tock start で開始し直してください`,
+      ].join("\n"),
+      // 巻き戻し側の例外を cause に残す。追記側の失敗は本文に載せている
+      { cause: rollbackError },
+    );
+  }
+}
+
+/** 例外から利用者に見せるメッセージを取り出す。Error でない値を投げられても落ちない。 */
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**

--- a/tests/commands/switch.test.ts
+++ b/tests/commands/switch.test.ts
@@ -73,6 +73,26 @@ function storeWithFailingAppend(base: Store): Store {
 }
 
 /**
+ * 追記が失敗し、そのあとの巻き戻しも失敗するストア。
+ *
+ * 確定（`stopped` の update。`end` を持つ）は通し、**巻き戻し（`running` の update。
+ * `end` を持たない）だけを落とす。** 追記側の失敗が巻き戻しの例外に上書きされて
+ * 消えないことを確かめるために使う。
+ */
+function storeWithFailingAppendAndRollback(base: Store): Store {
+  return {
+    append: () => Promise.reject(new Error("追記が失敗しました")),
+    update: (entry) =>
+      entry.end === undefined
+        ? Promise.reject(new Error("巻き戻しが失敗しました"))
+        : base.update(entry),
+    delete: (id) => base.delete(id),
+    listByRange: (range) => base.listByRange(range),
+    findRunning: () => base.findRunning(),
+  };
+}
+
+/**
  * 確定（update）だけが必ず失敗するストア。
  *
  * 「追記を先にして確定を後にする」実装だと、追記が通ってから確定が落ちるため
@@ -365,5 +385,41 @@ describe("switch を続けて使う", () => {
 
     expect(running).toHaveLength(1);
     expect(running[0]?.note).toBe("3番目");
+  });
+});
+
+// 巻き戻しの失敗で追記側の失敗が消えると、本当の原因が追えなくなる
+describe("switch は巻き戻しにも失敗したとき、両方の原因を伝える", () => {
+  it("追記の失敗と巻き戻しの失敗の両方がメッセージに載る", async () => {
+    await createStartCommand(deps(local(9, 0), store)).run(["1本目 #work"], io);
+
+    await expect(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingAppendAndRollback(store))).run(
+        ["次の作業"],
+        io,
+      ),
+    ).rejects.toThrow(/追記が失敗しました[\s\S]*巻き戻しが失敗しました/);
+  });
+
+  it("いま何が起きているかと復帰方法を伝える", async () => {
+    await createStartCommand(deps(local(9, 0), store)).run(["1本目 #work"], io);
+
+    await expect(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingAppendAndRollback(store))).run(
+        ["次の作業"],
+        io,
+      ),
+    ).rejects.toThrow(/tock start/);
+  });
+
+  it("利用者起因ではないので UserError にしない（終了コード 2 のまま）", async () => {
+    await createStartCommand(deps(local(9, 0), store)).run(["1本目 #work"], io);
+
+    await expect(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingAppendAndRollback(store))).run(
+        ["次の作業"],
+        io,
+      ),
+    ).rejects.not.toThrow(UserError);
   });
 });

--- a/tests/commands/switch.test.ts
+++ b/tests/commands/switch.test.ts
@@ -1,0 +1,369 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createSwitchCommand } from "../../src/commands/switch.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-switch-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date, override: Store = store) {
+  return {
+    store: override,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+/** ローカルの壁時計で時刻を組み立てる。`--at` の解釈が TZ に依存するため。 */
+function local(hours: number, minutes = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, 13);
+  date.setHours(hours, minutes, 0, 0);
+
+  return date;
+}
+
+const allTime = {
+  start: new Date("2000-01-01T00:00:00Z"),
+  end: new Date("2100-01-01T00:00:00Z"),
+};
+
+/** 追記だけが必ず失敗するストア。書き込みが途中で落ちた状況を作る。 */
+function storeWithFailingAppend(base: Store): Store {
+  return {
+    append: () => Promise.reject(new Error("書き込みに失敗しました")),
+    update: (entry) => base.update(entry),
+    delete: (id) => base.delete(id),
+    listByRange: (range) => base.listByRange(range),
+    findRunning: () => base.findRunning(),
+  };
+}
+
+/**
+ * 確定（update）だけが必ず失敗するストア。
+ *
+ * 「追記を先にして確定を後にする」実装だと、追記が通ってから確定が落ちるため
+ * **実行中が2件**残る。どちらを止めるべきか決められない状態になるので、
+ * 順序が逆になっていないことをこのストアで確かめる。
+ */
+function storeWithFailingUpdate(base: Store): Store {
+  return {
+    append: (entry) => base.append(entry),
+    update: () => Promise.reject(new Error("確定の書き込みに失敗しました")),
+    delete: (id) => base.delete(id),
+    listByRange: (range) => base.listByRange(range),
+    findRunning: () => base.findRunning(),
+  };
+}
+
+/** 09:00 に開始した実行中エントリを作る。 */
+async function startAt9(description = "前の作業 #work"): Promise<void> {
+  await createStartCommand(deps(local(9, 0))).run([description], io);
+  out = [];
+}
+
+describe("switch（実行中があるとき）", () => {
+  it("前のエントリが確定し、新しいエントリが実行中になる", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 30))).run(["次の作業 #会議"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.end).toBe(local(10, 30).toISOString());
+    expect(entries[1]).not.toHaveProperty("end");
+    expect(entries[1]?.note).toBe("次の作業");
+  });
+
+  it("実行中は新しいエントリ1件だけになる", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 30))).run(["次の作業"], io);
+
+    const running = await store.findRunning();
+
+    expect(running?.note).toBe("次の作業");
+  });
+
+  it("前後の時刻に隙間も重複も生じない", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 30))).run(["次の作業"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries[0]?.end).toBe(entries[1]?.start);
+  });
+
+  it("前のエントリの作業名とタグは保たれる", async () => {
+    await startAt9("前の作業 #work #proj");
+
+    await createSwitchCommand(deps(local(10, 30))).run(["次の作業"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries[0]?.note).toBe("前の作業");
+    expect(entries[0]?.tags).toEqual(["work", "proj"]);
+  });
+
+  it("停止した時間と開始したことを両方 stdout に出す", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 30))).run(["次の作業"], io);
+
+    const text = out.join("\n");
+
+    expect(text).toContain("1h 30m");
+    expect(text).toContain("次の作業");
+    expect(err).toEqual([]);
+  });
+
+  it("--at で切り替え時刻を指定できる", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(12, 0))).run(["次の作業", "--at", "10:30"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries[0]?.end).toBe(local(10, 30).toISOString());
+    expect(entries[1]?.start).toBe(local(10, 30).toISOString());
+  });
+
+  it("引数なしでも切り替えられる（名前なしの新エントリ）", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 30))).run([], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).not.toHaveProperty("note");
+  });
+
+  it("前の開始と同時刻に切り替えても失敗しない（長さ0で確定・境界）", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(9, 0))).run(["次の作業"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries[0]?.end).toBe(entries[0]?.start);
+    expect(entries[1]?.start).toBe(entries[0]?.end);
+  });
+});
+
+describe("switch（実行中がないとき）", () => {
+  it("単なる start として動作する", async () => {
+    await createSwitchCommand(deps(local(9, 0))).run(["最初の作業 #work"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).not.toHaveProperty("end");
+    expect(entries[0]?.note).toBe("最初の作業");
+    expect(entries[0]?.tags).toEqual(["work"]);
+  });
+
+  it("エラーにしない（start と同じ扱い）", async () => {
+    await expect(
+      createSwitchCommand(deps(local(9, 0))).run(["最初の作業"], io),
+    ).resolves.toBeUndefined();
+  });
+
+  it("記録が1件も無い状態でも落ちない（境界）", async () => {
+    await createSwitchCommand(deps(local(9, 0))).run([], io);
+
+    expect(await store.findRunning()).toBeDefined();
+    expect(err).toEqual([]);
+  });
+});
+
+describe("switch（途中で失敗しても中途半端な状態を残さない）", () => {
+  it("新規の追記が失敗したら、前のエントリは実行中のまま戻る", async () => {
+    await startAt9();
+
+    await expect(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingAppend(store))).run(["次の作業"], io),
+    ).rejects.toThrow();
+
+    // 「前を止めただけで新規開始されない」状態になっていないこと
+    const running = await store.findRunning();
+
+    expect(running).toBeDefined();
+    expect(running?.note).toBe("前の作業");
+    expect(running).not.toHaveProperty("end");
+  });
+
+  it("新規の追記が失敗したら、エントリは1件のまま", async () => {
+    await startAt9();
+
+    await Promise.resolve(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingAppend(store))).run(["次の作業"], io),
+    ).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("確定の書き込みが失敗しても、実行中が2件になることはない", async () => {
+    await startAt9();
+
+    await expect(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingUpdate(store))).run(["次の作業"], io),
+    ).rejects.toThrow();
+
+    // 追記を先にすると「新規が追記済み・前が未確定」で実行中が2件残り、
+    // どちらを止めるべきか決められなくなる
+    const running = (await store.listByRange(allTime)).filter((entry) => entry.end === undefined);
+
+    expect(running).toHaveLength(1);
+    expect(running[0]?.note).toBe("前の作業");
+  });
+
+  it("確定の書き込みが失敗したら、新しいエントリは作られない", async () => {
+    await startAt9();
+
+    await Promise.resolve(
+      createSwitchCommand(deps(local(10, 30), storeWithFailingUpdate(store))).run(["次の作業"], io),
+    ).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("--at が前の開始より前なら UserError で、記録は何も変わらない", async () => {
+    await startAt9();
+
+    await expect(
+      createSwitchCommand(deps(local(10, 0))).run(["次の作業", "--at", "08:00"], io),
+    ).rejects.toThrow(UserError);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).not.toHaveProperty("end");
+  });
+
+  it("--at が不正なら UserError で、記録は何も変わらない", async () => {
+    await startAt9();
+
+    await expect(
+      createSwitchCommand(deps(local(10, 0))).run(["次の作業", "--at", "25:00"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(await store.findRunning()).toBeDefined();
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("--at が未来なら UserError で、記録は何も変わらない", async () => {
+    await startAt9();
+
+    await expect(
+      createSwitchCommand(deps(local(10, 0))).run(["次の作業", "--at", "11:00"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("失敗したときは何も出力しない（成功したように見えない）", async () => {
+    await startAt9();
+
+    await Promise.resolve(
+      createSwitchCommand(deps(local(10, 0))).run(["次の作業", "--at", "08:00"], io),
+    ).catch(() => undefined);
+
+    expect(out).toEqual([]);
+  });
+});
+
+describe("switch の引数", () => {
+  it.each([
+    ["サブコマンドのヘルプ", "--help"],
+    ["未知のオプション", "--unknown"],
+    ["stop 用のオプション", "--note"],
+  ])("%s を渡したら UserError で失敗する", async (_label, token) => {
+    await startAt9();
+
+    await expect(createSwitchCommand(deps(local(10, 0))).run([token], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("未知のオプションで失敗しても記録は変わらない", async () => {
+    await startAt9();
+
+    await Promise.resolve(createSwitchCommand(deps(local(10, 0))).run(["--help"], io)).catch(
+      () => undefined,
+    );
+
+    expect(await store.findRunning()).toBeDefined();
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("作業名の中の `/` は弾かない", async () => {
+    await startAt9();
+
+    await createSwitchCommand(deps(local(10, 0))).run(["a/b の設計"], io);
+
+    expect((await store.listByRange(allTime))[1]?.note).toBe("a/b の設計");
+  });
+});
+
+describe("switch を続けて使う", () => {
+  it("3回切り替えると3件が隙間なく繋がる", async () => {
+    await startAt9();
+    await createSwitchCommand(deps(local(10, 0))).run(["2番目"], io);
+    await createSwitchCommand(deps(local(11, 0))).run(["3番目"], io);
+
+    const entries = await store.listByRange(allTime);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]?.end).toBe(entries[1]?.start);
+    expect(entries[1]?.end).toBe(entries[2]?.start);
+    expect(entries[2]).not.toHaveProperty("end");
+  });
+
+  it("切り替えを繰り返しても実行中は常に1件", async () => {
+    await startAt9();
+    await createSwitchCommand(deps(local(10, 0))).run(["2番目"], io);
+    await createSwitchCommand(deps(local(11, 0))).run(["3番目"], io);
+
+    const entries = await store.listByRange(allTime);
+    const running = entries.filter((entry) => entry.end === undefined);
+
+    expect(running).toHaveLength(1);
+    expect(running[0]?.note).toBe("3番目");
+  });
+});


### PR DESCRIPTION
## 概要

`tock switch "次の作業 #tag"` を追加した。作業を切り替えるたびに `stop` と `start` を2回打つのは
面倒で、かつ2コマンドの間に隙間が空くため合計が実態より短くなる。

```
$ tock switch "設計 #work" --at 07:00      # 実行中が無ければ start として動く
開始しました: 設計 [#work]
開始時刻: 2026-08-13T07:00:00.000Z

$ tock switch "レビュー #会議" --at 08:30
停止しました: 1h 30m
開始しました: レビュー [#会議]
開始時刻: 2026-08-13T08:30:00.000Z
```

Closes #15

### 中途半端な状態を残さないための設計（DoD 3項目目）

ストアは追記のみの JSONL で、複数の書き込みをまとめる手段がない。そこで2段構えにした。

**1. 失敗しうる組み立てを、書き込みより前にすべて済ませる。**
引数の検査（`--at` の形式・未来・未知のオプション）と `Entry` の生成（`end < start` の検出）を
保存の前に寄せた。論理的な失敗ではストアに一切触れない。

**2. 確定（`update`）を先に、追記（`append`）を後にする。**
逆にすると、追記が通ってから確定が落ちた場合に**実行中が2件**残る。どちらを止めるべきか
決められない状態になり、0件より不都合が大きい。追記が落ちた場合は元の実行中エントリを
書き戻して、切り替えを試す前の状態に戻す。

巻き戻し自体が失敗する可能性は残ります。書き込みを1回にまとめるのは #11（ファイルロック）や
#40（ストアの整理）の範囲なので、ここでは扱っていません。

## 受け入れ条件

- [x] switch 後に前のエントリが確定し、新しいエントリが実行中になるテストがある
      → `tests/commands/switch.test.ts`「switch（実行中があるとき）」8件。
      前のエントリの作業名・タグが保たれることも確認
      ```
      $ # switch 実行後の保存内容
      設計       start=2026-08-13T07:00:00.000Z end=2026-08-13T08:30:00.000Z
      レビュー   start=2026-08-13T08:30:00.000Z end=(実行中)
      ```
- [x] 前後のエントリの時刻に隙間も重複も生じないテストがある
      → 「前後の時刻に隙間も重複も生じない」（`entries[0].end === entries[1].start`）、
      および「switch を続けて使う」で3回切り替えても連続することを確認。
      上の実行結果でも前の `end` と次の `start` が一致しています
- [x] 途中で失敗した場合に中途半端な状態が残らない
      → 「switch（途中で失敗しても中途半端な状態を残さない）」8件。
      **書き込みが失敗するストアを注入**して確認した
      - 追記が失敗 → 前のエントリが実行中のまま戻る（1件のまま）
      - 確定が失敗 → 実行中が2件にならない / 新しいエントリが作られない
      - `--at` が前の開始より前 / 不正 / 未来 → `UserError` で記録は変わらない
      - 失敗時は何も出力しない（成功したように見えない）
      ```
      $ tock switch "巻き戻し" --at 06:00
      end が start より前です: start=2026-08-13T08:30:00.000Z end=2026-08-13T06:00:00.000Z
      $ echo $?
      1
      $ tock status --short
      レビュー #会議 3h 17m          ← 記録は変わっていない
      ```

## mutation test

`src/` を変更したので実施した。**1箇所でテストの穴が見つかり、テストを追加してから進めた。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 追記失敗時の巻き戻しをやめる | 1件 |
| **追記を先にする（失敗時に実行中が2件残る）** | **0件 → テスト追加後 2件** |
| 前の `end` を `--at` にせず `now` にする（隙間ができる） | 3件 |
| 実行中を確定しない（重複したまま新規開始する） | 6件 |
| 引数の検査をやめる（`--help` でも切り替わる） | 4件 |

**穴だった理由**: 失敗を注入するストアが `append` の失敗だけだったため、順序を入れ替えても
「追記が即座に失敗して何も起きない」経路しか通らず、区別できていなかった。
`update` が失敗するストアを追加し、**実行中が2件にならないこと**を検証するテストを2件足した。
追加後に同じ改変を当てて、落ちることを確認済み。

元に戻して 26 件すべて通ることを確認済み。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 記録が1件も無い状態での switch、引数なしの switch |
| 同時刻 | **前の開始と同時刻で切り替え**（長さ0で確定・境界）、前の `end` と新の `start` の一致 |
| 日跨ぎ | このコマンドは時刻を跨いで保存するだけで、日単位の処理は持たない（集計側 #18 の担当） |
| 上限値・範囲外 | `--at` が `25:00` / 未来 / 前の開始より前、`--help` / `--unknown` / `--note` |
| **終端のないデータ** | **実行中エントリの扱いが中心**。実行中あり（確定される）/ なし（start として動く）/ 切り替え後に実行中が常に1件 / 失敗時に実行中が2件にならない・0件にならない |

## 判断した点

- **`--note` は受け付けない。** `stop --note` は停止するエントリに note を付けるが、`switch` では
  前後どちらの note か曖昧になる。未知のオプションとして終了コード 1 で弾き、テストで固定した
- **前の開始と同時刻の切り替えを許す。** 長さ 0 のエントリができるが、`stop` が「0分で停止しても
  失敗しない」としているのと揃えた。打ち間違いを弾くのは `end < start` の側で足りる

## スタック

- base: `main`（スタックなし）

## 依存の追加

なし。

## 検証

`npm run check` green（12 files / 332 tests。306 → 332 で +26件）。修正試行 0 回。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_