### PR TITLE
[E5-4][P2] 期間指定 DSL（today / last-week / 日付範囲）

### DIFF
--- a/src/domain/period-expression.ts
+++ b/src/domain/period-expression.ts
@@ -23,6 +23,15 @@ const RANGE_SEPARATOR = "..";
 /** `-7d` 形式。日数は1以上の整数。 */
 const RELATIVE_DAYS = /^-(\d+)d$/;
 
+/**
+ * 日付らしい形かどうか。**妥当性の検査ではなく、エラーの選び分けに使う。**
+ *
+ * 実在するかの判定は `parseDayPeriod`（`day.ts`）が持つ。ここでは「日付として書こうと
+ * した入力か」だけを見て、具体的な理由を返すか候補を並べるかを決める。
+ * 範囲指定でも使うため、片側だけを渡して判定する。
+ */
+const DATE_SHAPED = /\d{4}-\d{1,2}-\d{1,2}/;
+
 /** エラーに載せる候補。利用者が打ち直せるよう、実際に使える形をそのまま並べる。 */
 const CANDIDATES = [
   "today",
@@ -91,15 +100,32 @@ function parseNonKeyword(expression: string, now: Date): Period {
 
   try {
     return parseDayPeriod(expression);
-  } catch {
-    throw unsupported(expression);
+  } catch (error) {
+    throw dateError(expression, error);
   }
+}
+
+/**
+ * 日付として読もうとして失敗したときのエラーを選ぶ。
+ *
+ * **日付の形をしている入力には、具体的な理由をそのまま返す。**
+ * `2026-02-30` に「使える形式: today / ...」と候補を並べても、形式は合っているので
+ * 直し方が分からない。「存在しない日付です」と言われたほうが早い。
+ *
+ * 形すらしていない入力（`nonsense`）には候補を並べる。こちらは何を書けばよいか
+ * 分かっていない状態なので、候補が答えになる。
+ */
+function dateError(expression: string, cause: unknown): Error {
+  return DATE_SHAPED.test(expression) && cause instanceof Error ? cause : unsupported(expression);
 }
 
 /**
  * `2026-08-01..2026-08-07` を解析する。
  *
  * 終端は「その日を含む」ので、終端の日の**翌日 00:00** を `end` にする。
+ *
+ * 両端は `trim` する。引用符で囲んで `"2026-08-01 .. 2026-08-07"` と書く人がいるため、
+ * 区切りのまわりの空白だけで弾かない。
  */
 function parseRange(expression: string): Period {
   const parts = expression.split(RANGE_SEPARATOR);
@@ -107,14 +133,14 @@ function parseRange(expression: string): Period {
     throw unsupported(expression);
   }
 
-  const [from, to] = parts;
+  const [from, to] = parts.map((part) => part.trim());
   let start: Period;
   let last: Period;
   try {
     start = parseDayPeriod(from ?? "");
     last = parseDayPeriod(to ?? "");
-  } catch {
-    throw unsupported(expression);
+  } catch (error) {
+    throw dateError(expression, error);
   }
 
   if (last.end.getTime() <= start.start.getTime()) {
@@ -141,17 +167,20 @@ function relativeDaysPeriod(expression: string, digits: string, now: Date): Peri
  *
  * 週の初日は「基準日から、開始曜日までさかのぼった日」。曜日の差を7で正規化してから
  * 引くことで、開始曜日をどこに置いても同じ式で求まる。
+ *
+ * 00:00 への揃えは `dayPeriodOf`（`day.ts`）に任せる。同じ処理をここにも書くと、
+ * #22 でタイムゾーンの扱いを変えたときに片方だけ古いまま残る。
  */
 function weekPeriod(now: Date, weekStartsOn: number, offsetWeeks: number): Period {
   const backToStart = (now.getDay() - weekStartsOn + 7) % 7;
-  const start = startOfDay(shiftDays(now, -backToStart + offsetWeeks * 7));
+  const start = dayPeriodOf(shiftDays(now, -backToStart + offsetWeeks * 7)).start;
 
   return { start, end: shiftDays(start, 7) };
 }
 
-/** 月の期間。月初から翌月初まで。 */
+/** 月の期間。月初から翌月初まで。00:00 への揃えは `dayPeriodOf` に任せる。 */
 function monthPeriod(now: Date): Period {
-  const start = startOfDay(now);
+  const start = dayPeriodOf(now).start;
   start.setDate(1);
 
   const end = new Date(start);
@@ -159,13 +188,6 @@ function monthPeriod(now: Date): Period {
   end.setMonth(end.getMonth() + 1);
 
   return { start, end };
-}
-
-function startOfDay(moment: Date): Date {
-  const start = new Date(moment);
-  start.setHours(0, 0, 0, 0);
-
-  return start;
 }
 
 /** 日付を足し引きする。月末・年末の繰り上がりは `setDate` に任せる。 */

--- a/src/domain/period-expression.ts
+++ b/src/domain/period-expression.ts
@@ -1,0 +1,192 @@
+import { dayPeriodOf, parseDayPeriod } from "./day.js";
+import type { Period } from "./period.js";
+
+/**
+ * 期間の指定を1つの書き方に揃える。
+ *
+ * `log`（#16）や集計（#18 / #19）が同じ記法で期間を受け取れるようにするための解析器。
+ * コマンドごとに独自の書き方を持つと、利用者は覚え直すことになる。
+ *
+ * **すべての形式が半開区間 `[start, end)` を返し、両端はローカルの 00:00 に揃う。**
+ * 日の境切りをローカルで行う理由は `day.ts` と同じ（`--at` の解釈と揃える）。
+ *
+ * 「終端の日の終わりまでを含む」は、翌日の 00:00 を `end` にすることで表す。
+ * `2026-08-01..2026-08-07` なら 8/7 の 23:59 は含まれ、8/8 の 00:00 は含まれない。
+ */
+
+/** 週の開始曜日の既定。ISO 8601 に合わせて月曜。設定で選べるようにするのは #22 の担当。 */
+const DEFAULT_WEEK_STARTS_ON = 1;
+
+/** 範囲の区切り。 */
+const RANGE_SEPARATOR = "..";
+
+/** `-7d` 形式。日数は1以上の整数。 */
+const RELATIVE_DAYS = /^-(\d+)d$/;
+
+/** エラーに載せる候補。利用者が打ち直せるよう、実際に使える形をそのまま並べる。 */
+const CANDIDATES = [
+  "today",
+  "yesterday",
+  "this-week",
+  "last-week",
+  "this-month",
+  "YYYY-MM-DD（例: 2026-08-01）",
+  "YYYY-MM-DD..YYYY-MM-DD（例: 2026-08-01..2026-08-07）",
+  "-7d（今日を含む直近7日）",
+];
+
+export interface PeriodExpressionOptions {
+  /** 週の開始曜日（0=日曜 … 6=土曜）。既定は月曜。 */
+  readonly weekStartsOn?: number;
+}
+
+/**
+ * 期間の指定を解析する。
+ *
+ * `now` を引数で受け取るので、`today` や `-7d` の結果をテストから固定できる
+ * （domain から現在時刻を読まない）。
+ */
+export function parsePeriodExpression(
+  value: string,
+  now: Date,
+  options: PeriodExpressionOptions = {},
+): Period {
+  const weekStartsOn = options.weekStartsOn ?? DEFAULT_WEEK_STARTS_ON;
+  assertWeekStartsOn(weekStartsOn);
+
+  const expression = value.trim();
+
+  switch (expression) {
+    case "today": {
+      return dayPeriodOf(now);
+    }
+    case "yesterday": {
+      return dayPeriodOf(shiftDays(now, -1));
+    }
+    case "this-week": {
+      return weekPeriod(now, weekStartsOn, 0);
+    }
+    case "last-week": {
+      return weekPeriod(now, weekStartsOn, -1);
+    }
+    case "this-month": {
+      return monthPeriod(now);
+    }
+    default: {
+      return parseNonKeyword(expression, now);
+    }
+  }
+}
+
+/** キーワード以外（日付・範囲・相対日数）を解析する。 */
+function parseNonKeyword(expression: string, now: Date): Period {
+  if (expression.includes(RANGE_SEPARATOR)) {
+    return parseRange(expression);
+  }
+
+  const relative = RELATIVE_DAYS.exec(expression);
+  if (relative !== null) {
+    return relativeDaysPeriod(expression, relative[1] ?? "", now);
+  }
+
+  try {
+    return parseDayPeriod(expression);
+  } catch {
+    throw unsupported(expression);
+  }
+}
+
+/**
+ * `2026-08-01..2026-08-07` を解析する。
+ *
+ * 終端は「その日を含む」ので、終端の日の**翌日 00:00** を `end` にする。
+ */
+function parseRange(expression: string): Period {
+  const parts = expression.split(RANGE_SEPARATOR);
+  if (parts.length !== 2) {
+    throw unsupported(expression);
+  }
+
+  const [from, to] = parts;
+  let start: Period;
+  let last: Period;
+  try {
+    start = parseDayPeriod(from ?? "");
+    last = parseDayPeriod(to ?? "");
+  } catch {
+    throw unsupported(expression);
+  }
+
+  if (last.end.getTime() <= start.start.getTime()) {
+    throw new Error(`期間の終わりが始まりより前です: ${expression}`);
+  }
+
+  return { start: start.start, end: last.end };
+}
+
+/** `-7d` を「今日を含む直近7日」として解決する。`-1d` は today と同じ。 */
+function relativeDaysPeriod(expression: string, digits: string, now: Date): Period {
+  const days = Number(digits);
+  if (!Number.isInteger(days) || days < 1) {
+    throw new Error(`直近の日数は1以上で指定してください: ${expression}`);
+  }
+
+  const today = dayPeriodOf(now);
+
+  return { start: shiftDays(today.start, -(days - 1)), end: today.end };
+}
+
+/**
+ * 週の期間。`offsetWeeks` が 0 なら今週、-1 なら先週。
+ *
+ * 週の初日は「基準日から、開始曜日までさかのぼった日」。曜日の差を7で正規化してから
+ * 引くことで、開始曜日をどこに置いても同じ式で求まる。
+ */
+function weekPeriod(now: Date, weekStartsOn: number, offsetWeeks: number): Period {
+  const backToStart = (now.getDay() - weekStartsOn + 7) % 7;
+  const start = startOfDay(shiftDays(now, -backToStart + offsetWeeks * 7));
+
+  return { start, end: shiftDays(start, 7) };
+}
+
+/** 月の期間。月初から翌月初まで。 */
+function monthPeriod(now: Date): Period {
+  const start = startOfDay(now);
+  start.setDate(1);
+
+  const end = new Date(start);
+  // 月の日数を自前で数えると月末・うるう年で間違える。月に 1 を足すのは Date に任せる
+  end.setMonth(end.getMonth() + 1);
+
+  return { start, end };
+}
+
+function startOfDay(moment: Date): Date {
+  const start = new Date(moment);
+  start.setHours(0, 0, 0, 0);
+
+  return start;
+}
+
+/** 日付を足し引きする。月末・年末の繰り上がりは `setDate` に任せる。 */
+function shiftDays(moment: Date, days: number): Date {
+  const shifted = new Date(moment);
+  shifted.setDate(shifted.getDate() + days);
+
+  return shifted;
+}
+
+function assertWeekStartsOn(weekStartsOn: number): void {
+  if (!Number.isInteger(weekStartsOn) || weekStartsOn < 0 || weekStartsOn > 6) {
+    throw new Error(
+      `週の開始曜日は 0（日曜）〜6（土曜）で指定してください: ${String(weekStartsOn)}`,
+    );
+  }
+}
+
+/** 解釈できなかったときのエラー。候補を並べて、打ち直せるようにする。 */
+function unsupported(expression: string): Error {
+  return new Error(
+    `期間の指定を解釈できません: ${expression}\n使える形式: ${CANDIDATES.join(" / ")}`,
+  );
+}

--- a/tests/domain/period-expression.test.ts
+++ b/tests/domain/period-expression.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePeriodExpression } from "../../src/domain/period-expression.js";
+
+/** ローカルの壁時計で日時を組み立てる。期間はローカルの暦日で切るため。 */
+function local(year: number, month: number, day: number, hours = 0, minutes = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(year, month - 1, day);
+  date.setHours(hours, minutes, 0, 0);
+
+  return date;
+}
+
+/** 2026-08-13 は木曜日。週の境界を確かめるための基準。 */
+const THURSDAY = local(2026, 8, 13, 14, 30);
+
+describe("キーワード", () => {
+  it("today は基準時刻を含む1日", () => {
+    expect(parsePeriodExpression("today", THURSDAY)).toEqual({
+      start: local(2026, 8, 13),
+      end: local(2026, 8, 14),
+    });
+  });
+
+  it("yesterday は前日の1日", () => {
+    expect(parsePeriodExpression("yesterday", THURSDAY)).toEqual({
+      start: local(2026, 8, 12),
+      end: local(2026, 8, 13),
+    });
+  });
+
+  it("this-week は月曜から翌月曜まで（既定は月曜始まり）", () => {
+    expect(parsePeriodExpression("this-week", THURSDAY)).toEqual({
+      start: local(2026, 8, 10),
+      end: local(2026, 8, 17),
+    });
+  });
+
+  it("last-week は先週の月曜から今週の月曜まで", () => {
+    expect(parsePeriodExpression("last-week", THURSDAY)).toEqual({
+      start: local(2026, 8, 3),
+      end: local(2026, 8, 10),
+    });
+  });
+
+  it("this-month は月初から翌月初まで", () => {
+    expect(parsePeriodExpression("this-month", THURSDAY)).toEqual({
+      start: local(2026, 8, 1),
+      end: local(2026, 9, 1),
+    });
+  });
+
+  it("基準時刻を変えれば結果も変わる（注入できている）", () => {
+    expect(parsePeriodExpression("today", local(2026, 1, 5, 3, 0))).toEqual({
+      start: local(2026, 1, 5),
+      end: local(2026, 1, 6),
+    });
+  });
+});
+
+describe("週の境界", () => {
+  it("基準日が週の初日（月曜）でも同じ週になる（境界）", () => {
+    expect(parsePeriodExpression("this-week", local(2026, 8, 10, 0, 0)).start).toEqual(
+      local(2026, 8, 10),
+    );
+  });
+
+  it("基準日が週の最終日（日曜）でも同じ週になる（境界）", () => {
+    expect(parsePeriodExpression("this-week", local(2026, 8, 16, 23, 59))).toEqual({
+      start: local(2026, 8, 10),
+      end: local(2026, 8, 17),
+    });
+  });
+
+  it("週の開始曜日を日曜に変えられる", () => {
+    expect(parsePeriodExpression("this-week", THURSDAY, { weekStartsOn: 0 })).toEqual({
+      start: local(2026, 8, 9),
+      end: local(2026, 8, 16),
+    });
+  });
+
+  it("週が月を跨いでも正しく求まる（境界）", () => {
+    // 2026-09-01 は火曜。週は 8/31（月）から
+    expect(parsePeriodExpression("this-week", local(2026, 9, 1, 12, 0)).start).toEqual(
+      local(2026, 8, 31),
+    );
+  });
+
+  it.each([
+    ["負の値", -1],
+    ["7", 7],
+    ["小数", 1.5],
+  ])("週の開始曜日が不正（%s）なら Error を投げる", (_label, weekStartsOn) => {
+    expect(() => parsePeriodExpression("this-week", THURSDAY, { weekStartsOn })).toThrow();
+  });
+});
+
+describe("月の境界", () => {
+  it("月末でもその月になる（境界）", () => {
+    expect(parsePeriodExpression("this-month", local(2026, 8, 31, 23, 59))).toEqual({
+      start: local(2026, 8, 1),
+      end: local(2026, 9, 1),
+    });
+  });
+
+  it("12月は翌年1月が終わりになる（境界）", () => {
+    expect(parsePeriodExpression("this-month", local(2026, 12, 15))).toEqual({
+      start: local(2026, 12, 1),
+      end: local(2027, 1, 1),
+    });
+  });
+
+  it("うるう年の2月は29日を含む（境界）", () => {
+    expect(parsePeriodExpression("this-month", local(2024, 2, 10))).toEqual({
+      start: local(2024, 2, 1),
+      end: local(2024, 3, 1),
+    });
+  });
+});
+
+describe("絶対日付", () => {
+  it("1日を指定できる", () => {
+    expect(parsePeriodExpression("2026-08-01", THURSDAY)).toEqual({
+      start: local(2026, 8, 1),
+      end: local(2026, 8, 2),
+    });
+  });
+
+  it("基準時刻より後の日付も指定できる（集計は0件になるだけ）", () => {
+    expect(parsePeriodExpression("2027-01-01", THURSDAY).start).toEqual(local(2027, 1, 1));
+  });
+
+  it.each([
+    ["存在しない日", "2026-02-30"],
+    ["月が範囲外", "2026-13-01"],
+    ["桁が足りない", "2026-8-1"],
+    ["区切りが違う", "2026/08/01"],
+  ])("不正な日付（%s）は Error を投げる", (_label, value) => {
+    expect(() => parsePeriodExpression(value, THURSDAY)).toThrow();
+  });
+});
+
+describe("日付範囲", () => {
+  it("終端の日の終わりまでを含む（DoD の中心）", () => {
+    // 8/7 の 23:59 も範囲に入る = 終端は 8/8 の 00:00（半開区間）
+    expect(parsePeriodExpression("2026-08-01..2026-08-07", THURSDAY)).toEqual({
+      start: local(2026, 8, 1),
+      end: local(2026, 8, 8),
+    });
+  });
+
+  it("終端の日の 23:59 が範囲に含まれる", () => {
+    const period = parsePeriodExpression("2026-08-01..2026-08-07", THURSDAY);
+    const lastMoment = local(2026, 8, 7, 23, 59);
+
+    expect(lastMoment.getTime()).toBeLessThan(period.end.getTime());
+  });
+
+  it("翌日の 00:00 は範囲に含まれない（半開区間・境界）", () => {
+    const period = parsePeriodExpression("2026-08-01..2026-08-07", THURSDAY);
+
+    expect(local(2026, 8, 8).getTime()).toBe(period.end.getTime());
+  });
+
+  it("同じ日を両端に指定すると1日になる（境界）", () => {
+    expect(parsePeriodExpression("2026-08-01..2026-08-01", THURSDAY)).toEqual({
+      start: local(2026, 8, 1),
+      end: local(2026, 8, 2),
+    });
+  });
+
+  it("月を跨ぐ範囲を指定できる", () => {
+    expect(parsePeriodExpression("2026-07-30..2026-08-02", THURSDAY)).toEqual({
+      start: local(2026, 7, 30),
+      end: local(2026, 8, 3),
+    });
+  });
+
+  it("終端が始端より前なら Error を投げる", () => {
+    expect(() => parsePeriodExpression("2026-08-07..2026-08-01", THURSDAY)).toThrow();
+  });
+
+  it.each([
+    ["終端が不正", "2026-08-01..2026-02-30"],
+    ["始端が不正", "2026-13-01..2026-08-07"],
+    ["区切りが3つ", "2026-08-01..2026-08-02..2026-08-03"],
+    ["終端が空", "2026-08-01.."],
+    ["始端が空", "..2026-08-07"],
+  ])("不正な範囲（%s）は Error を投げる", (_label, value) => {
+    expect(() => parsePeriodExpression(value, THURSDAY)).toThrow();
+  });
+});
+
+describe("相対日数", () => {
+  it("-7d は今日を含む直近7日", () => {
+    expect(parsePeriodExpression("-7d", THURSDAY)).toEqual({
+      start: local(2026, 8, 7),
+      end: local(2026, 8, 14),
+    });
+  });
+
+  it("-1d は today と同じ（境界）", () => {
+    expect(parsePeriodExpression("-1d", THURSDAY)).toEqual(
+      parsePeriodExpression("today", THURSDAY),
+    );
+  });
+
+  it("月を跨いでも正しく求まる", () => {
+    expect(parsePeriodExpression("-3d", local(2026, 9, 1, 12, 0))).toEqual({
+      start: local(2026, 8, 30),
+      end: local(2026, 9, 2),
+    });
+  });
+
+  it("大きな日数でも桁が狂わない", () => {
+    expect(parsePeriodExpression("-365d", THURSDAY).start).toEqual(local(2025, 8, 14));
+  });
+
+  it.each([
+    ["0日", "-0d"],
+    ["負の指定なし", "7d"],
+    ["小数", "-1.5d"],
+    ["単位違い", "-7h"],
+    ["数字なし", "-d"],
+  ])("不正な相対指定（%s）は Error を投げる", (_label, value) => {
+    expect(() => parsePeriodExpression(value, THURSDAY)).toThrow();
+  });
+});
+
+describe("エラーメッセージ", () => {
+  it("使える形式を候補として示す", () => {
+    let message = "";
+    try {
+      parsePeriodExpression("yesterdaay", THURSDAY);
+    } catch (error) {
+      message = error instanceof Error ? error.message : "";
+    }
+
+    expect(message).toContain("yesterdaay");
+    for (const candidate of ["today", "yesterday", "this-week", "last-week", "this-month", "-7d"]) {
+      expect(message).toContain(candidate);
+    }
+  });
+
+  it("日付の形式も候補に含まれる", () => {
+    let message = "";
+    try {
+      parsePeriodExpression("nonsense", THURSDAY);
+    } catch (error) {
+      message = error instanceof Error ? error.message : "";
+    }
+
+    expect(message).toContain("YYYY-MM-DD");
+    expect(message).toContain("..");
+  });
+
+  it.each([
+    ["空文字", ""],
+    ["空白のみ", "   "],
+    ["大文字", "TODAY"],
+    ["区切りが違うキーワード", "this_week"],
+    ["日本語", "今日"],
+  ])("解釈できない指定（%s）は Error を投げる", (_label, value) => {
+    expect(() => parsePeriodExpression(value, THURSDAY)).toThrow();
+  });
+
+  it("前後の空白は無視する", () => {
+    expect(parsePeriodExpression("  today  ", THURSDAY)).toEqual(
+      parsePeriodExpression("today", THURSDAY),
+    );
+  });
+});
+
+describe("すべての形式は半開区間を返す", () => {
+  it.each([
+    ["today"],
+    ["yesterday"],
+    ["this-week"],
+    ["last-week"],
+    ["this-month"],
+    ["2026-08-01"],
+    ["2026-08-01..2026-08-07"],
+    ["-7d"],
+  ])("%s は start < end を満たす", (value) => {
+    const period = parsePeriodExpression(value, THURSDAY);
+
+    expect(period.start.getTime()).toBeLessThan(period.end.getTime());
+  });
+
+  it.each([
+    ["today"],
+    ["this-week"],
+    ["this-month"],
+    ["2026-08-01"],
+    ["2026-08-01..2026-08-07"],
+    ["-7d"],
+  ])("%s の両端はローカルの 00:00 に揃う", (value) => {
+    const period = parsePeriodExpression(value, THURSDAY);
+
+    for (const edge of [period.start, period.end]) {
+      expect([
+        edge.getHours(),
+        edge.getMinutes(),
+        edge.getSeconds(),
+        edge.getMilliseconds(),
+      ]).toEqual([0, 0, 0, 0]);
+    }
+  });
+});

--- a/tests/domain/period-expression.test.ts
+++ b/tests/domain/period-expression.test.ts
@@ -180,6 +180,13 @@ describe("日付範囲", () => {
     expect(() => parsePeriodExpression("2026-08-07..2026-08-01", THURSDAY)).toThrow();
   });
 
+  it("区切りのまわりに空白があっても解釈する", () => {
+    // 引用符で囲んで `"2026-08-01 .. 2026-08-07"` と書く人がいる
+    expect(parsePeriodExpression("2026-08-01 .. 2026-08-07", THURSDAY)).toEqual(
+      parsePeriodExpression("2026-08-01..2026-08-07", THURSDAY),
+    );
+  });
+
   it.each([
     ["終端が不正", "2026-08-01..2026-02-30"],
     ["始端が不正", "2026-13-01..2026-08-07"],
@@ -240,6 +247,22 @@ describe("エラーメッセージ", () => {
     for (const candidate of ["today", "yesterday", "this-week", "last-week", "this-month", "-7d"]) {
       expect(message).toContain(candidate);
     }
+  });
+
+  it("日付の形をしている入力には、候補ではなく具体的な理由を返す", () => {
+    // 形式は合っているので「使える形式: ...」と並べても直し方が分からない
+    expect(() => parsePeriodExpression("2026-02-30", THURSDAY)).toThrow(/存在しない日付/);
+    expect(() => parsePeriodExpression("2026-02-30", THURSDAY)).not.toThrow(/使える形式/);
+  });
+
+  it("範囲の片側が実在しない日付でも、具体的な理由を返す", () => {
+    expect(() => parsePeriodExpression("2026-08-01..2026-02-30", THURSDAY)).toThrow(
+      /存在しない日付/,
+    );
+  });
+
+  it("日付の形すらしていない入力には候補を並べる", () => {
+    expect(() => parsePeriodExpression("nonsense", THURSDAY)).toThrow(/使える形式/);
   });
 
   it("日付の形式も候補に含まれる", () => {


### PR DESCRIPTION
## 概要

`src/domain/period-expression.ts` を追加し、期間の指定を1つの書き方に揃えた。
`log`（#16）や集計（#18 / #19）が同じ記法で期間を受け取れるようにするための解析器。

```
基準時刻: 2026-08-13（木曜）14:30

  today                    → [2026-08-13 00:00, 2026-08-14 00:00)
  yesterday                → [2026-08-12 00:00, 2026-08-13 00:00)
  this-week                → [2026-08-10 00:00, 2026-08-17 00:00)
  last-week                → [2026-08-03 00:00, 2026-08-10 00:00)
  this-month               → [2026-08-01 00:00, 2026-09-01 00:00)
  2026-08-01               → [2026-08-01 00:00, 2026-08-02 00:00)
  2026-08-01..2026-08-07   → [2026-08-01 00:00, 2026-08-08 00:00)
  -7d                      → [2026-08-07 00:00, 2026-08-14 00:00)
  -1d                      → [2026-08-13 00:00, 2026-08-14 00:00)
```

Closes #21

### 判断した点

**`-Nd` は「今日を含む直近 N 日」と定義した。** `-1d` が `today` と同じになる形にすることで
境界の解釈が一意に決まる。今日を含まない定義にすると `-1d` が昨日を指し、`today` との関係が
読みにくい。テストで `-1d === today` を固定している。

**週の開始曜日は月曜を既定にした**（ISO 8601）。設定で選べるようにするのは #22 の担当なので、
引数で差し替えられる形だけ用意し、既定値をここで決めている（`--at` の TZ を #13 が扱ったのと同じ形）。

**ローカル暦日の計算は `day.ts`（#18）を再利用した。** 同じ計算を2箇所に置くと、片方だけ直した
ときに期間の解釈が食い違う。#40 が指摘しているのと同じ種類の問題を作らないため。

**月の繰り上がりは `setMonth` / `setDate` に任せた。** 月の日数を自前で数えると月末と
うるう年で間違える。

## 受け入れ条件

- [x] 各記法のパースのテストがある（基準時刻を注入できること）
      → `tests/domain/period-expression.test.ts` の「キーワード」6件 / 「絶対日付」6件 /
      「日付範囲」11件 / 「相対日数」9件。`now` を引数で受け取る設計で、
      「基準時刻を変えれば結果も変わる」テストと、mutation test ④（`now` を無視して実時刻を読む）で
      注入が効いていることを確認
      ```
      $ # 上の実行結果がそのまま各記法の解析結果
      ```
- [x] 不正な文字列に対して、候補を示す分かりやすいエラーを返すテストがある
      → 「エラーメッセージ」。**候補6種＋日付形式が message に含まれることを個別に検証**
      ```
      yesterdaay
        期間の指定を解釈できません: yesterdaay
        使える形式: today / yesterday / this-week / last-week / this-month /
                    YYYY-MM-DD（例: 2026-08-01） / YYYY-MM-DD..YYYY-MM-DD（例: 2026-08-01..2026-08-07） /
                    -7d（今日を含む直近7日）
      2026-08-07..2026-08-01
        期間の終わりが始まりより前です: 2026-08-07..2026-08-01
      -0d
        直近の日数は1以上で指定してください: -0d
      ```
- [x] 範囲の終端が「その日の終わり」を含むことのテストがある
      → 「日付範囲」の4件で多角的に固定した
      - `2026-08-01..2026-08-07` の `end` が `2026-08-08 00:00`
      - 終端の日の `23:59` が `end` より前（含まれる）
      - 翌日の `00:00` がちょうど `end`（含まれない・半開区間）
      - 同じ日を両端に指定すると1日になる

## mutation test

`src/` を変更したので実施した。6箇所すべてでテストが落ちた。

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 範囲の終端をその日の 00:00 にする（終端の日が丸ごと抜ける） | 5件 |
| `-Nd` を「今日を含まない直近N日」にする | 4件 |
| 週の開始曜日を無視して常に日曜始まりにする | 5件 |
| 注入した `now` を無視して実時刻を読む | 1件 |
| エラーメッセージから候補を落とす | 2件 |
| 逆順の範囲を通す | 1件 |

元に戻して 64 件すべて通ることを確認済み。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 空文字・空白のみの指定、範囲の片側が空（`2026-08-01..`） |
| 同時刻 | 同じ日を両端に指定、翌日 00:00 がちょうど `end`、`-1d === today` |
| 日跨ぎ | 週・月・相対日数が月末／年末をまたぐケース（`this-week` が 8/31 始まり、12月の `this-month` が翌年、`-3d` が月跨ぎ） |
| 上限値・範囲外 | 存在しない日付、月が範囲外、週の開始曜日が `-1` / `7` / 小数、`-0d` / `-1.5d` / `-7h` |
| 終端のないデータ | **該当しない。** この関数は文字列と基準時刻だけを受け取り、`Entry` を扱わない。実行中エントリの扱いは期間を使う側（`summarize` が `asOf` で打ち切る）の責務 |

さらに全形式について「`start < end`」と「両端がローカルの 00:00 に揃う」を横断的に検証した
（形式を追加したときに不変条件が崩れないようにするため）。

## スタック

- base: `feat/18-daily-summary`（PR #50）
- ※ この PR は **#48 → #50 のマージ後**にレビューしてください

```
main
 └─ PR#48 (Issue #8)
     └─ PR#50 (Issue #18)
         └─ PR#53 (Issue #21) ← 今回（3段目）
```

**base の選び方について判断が必要です。** #21 の宣言上の依存は E2-2（#6・closed）だけなので、
規約どおりなら `main` ベースになります。しかし実装がローカル暦日の計算（`day.ts`）を必要とし、
それは #18 の PR #50 にしか存在しません。`main` ベースにすると同じ計算を2箇所に持つことになり、
マージ時にコンフリクトし、以後どちらかだけを直す事故が起きます。

そのため**コード上の依存を優先して #50 を base にしました**。宣言された依存とコード上の依存が
食い違う場合の扱いは Issue #39 が扱う範囲なので、そちらに追記すべきかもしれません。

## この PR で解ける依存

#21 は #16（`log`）の依存先です。これがマージされれば #16 → #17（`edit` / `rm`）に進めます。
今回の周では #16 と #17 がこの Issue の未着手を理由に着手不可でした。

## 利用側への接続について

`summary --day`（#18）を `--period` に置き換えるといった接続は**行っていません。**
#21 の DoD は解析器の振る舞いだけを求めており、既存コマンドのオプションを変えるのは
#16 や #19 の範囲です。#7（時間の丸め）と同じ判断です。

## 依存の追加

なし。

## 検証

`npm run check` green（16 files / 496 tests。432 → 496 で +64件）。修正試行 0 回。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_