### PR TITLE
[E4-6][P2] `edit` / `rm` コマンド（記録の修正・削除）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
+import { createInterface } from "node:readline/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { createEditCommand } from "./commands/edit.js";
 import { createLogCommand } from "./commands/log.js";
+import { createRmCommand } from "./commands/rm.js";
 import { createStartCommand } from "./commands/start.js";
 import { createStatusCommand } from "./commands/status.js";
 import { createStopCommand } from "./commands/stop.js";
@@ -152,6 +155,33 @@ export async function run(argv: readonly string[], deps: CliDeps): Promise<numbe
 }
 
 /**
+ * 標準入力で「はい／いいえ」を尋ねる。`rm` の確認に使う。
+ *
+ * **対話端末でないときは尋ねずに失敗する。** パイプやスクリプトから実行されていると
+ * 答えを受け取れず、既定を「はい」にすると意図しない削除になり、「いいえ」にすると
+ * 何も起きない理由が分からない。`--yes` を明示してもらう。
+ *
+ * `y` / `yes`（大文字小文字を問わない）だけを肯定とみなす。空の入力（Enter だけ）は
+ * 否定にする——取り消せない操作なので、うっかり通さない。
+ */
+async function confirmOnStdin(question: string): Promise<boolean> {
+  if (process.stdin.isTTY !== true) {
+    throw new UserError(
+      `確認の入力を受け取れません（対話端末ではありません）。--yes を付けて実行してください: ${question}`,
+    );
+  }
+
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await prompt.question(`${question} [y/N] `);
+
+    return /^y(?:es)?$/i.test(answer.trim());
+  } finally {
+    prompt.close();
+  }
+}
+
+/**
  * 実際に使うサブコマンドを組み立てる。
  *
  * 保存先の決定と現在時刻・採番の取得はここでだけ行う。`run` と各コマンドは注入された
@@ -173,6 +203,8 @@ function buildCommands(): readonly Command[] {
     createSummaryCommand(deps),
     createLogCommand(deps),
     createWeekCommand(deps),
+    createEditCommand(deps),
+    createRmCommand(deps, confirmOnStdin),
   ];
 }
 

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -113,18 +113,32 @@ export function rejectUnknownArgs(
  * 実行中を理由に拒否されるため、打ち間違いから手詰まりになる）。
  */
 export function resolveClockTime(value: string, now: Date): Date {
+  return resolveClockTimeOn(value, now, now, "--at");
+}
+
+/**
+ * `HH:MM` を**指定した日付の**その時刻として解決する。
+ *
+ * `resolveClockTime` は「今日の HH:MM」を返すが、既にある記録を編集する（#17）ときは
+ * **その記録自身の日付**に適用しなければならない。今日の日付に当てると、3日前の記録を
+ * 直したつもりで今日へ移動してしまう。
+ *
+ * 未来を弾く規則は共通。`--at` と同じ理由で、未来の開始時刻を持つ記録を作らせない。
+ * オプション名を引数で受けるのは、エラーメッセージに実際に打ったオプションを出すため。
+ */
+export function resolveClockTimeOn(value: string, onDate: Date, now: Date, label: string): Date {
   const match = CLOCK_TIME.exec(value);
   if (match === null) {
-    throw new UserError(`--at は HH:MM または HH:MM:SS で指定してください: ${value}`);
+    throw new UserError(`${label} は HH:MM または HH:MM:SS で指定してください: ${value}`);
   }
 
   const [, hours, minutes, seconds] = match;
-  const at = new Date(now);
+  const at = new Date(onDate);
   at.setHours(Number(hours), Number(minutes), Number(seconds ?? "0"), 0);
 
   if (at.getTime() > now.getTime()) {
     throw new UserError(
-      `--at に未来の時刻は指定できません: ${value}（現在は ${formatClockTime(now)}）`,
+      `${label} に未来の時刻は指定できません: ${value}（現在は ${formatClockTime(now)}）`,
     );
   }
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -1,0 +1,145 @@
+import { type CliIo, type Command, UserError } from "../cli.js";
+import { applyEdit, type EntryChanges, findOverlapping } from "../domain/edit.js";
+import type { Entry } from "../domain/entry.js";
+import { startedAt } from "../domain/entry.js";
+import { normalizeTag } from "../domain/tag.js";
+import { type CommandDeps, rejectUnknownArgs, resolveClockTimeOn, takeOption } from "./args.js";
+import { findById, listAllEntries } from "./lookup.js";
+
+/**
+ * 記録を修正する。
+ *
+ * ```
+ * tock edit <id> [--start HH:MM] [--end HH:MM] [--tags "a b"] [--note "..."]
+ * ```
+ *
+ * **`--start` / `--end` はその記録自身の日付に適用する。** 今日の日付に当てると、
+ * 前日の記録を直したつもりで今日へ移動してしまう。日付そのものを変える操作は
+ * このコマンドに入れていない（下記）。
+ *
+ * **書き込む前に、失敗しうる検証をすべて済ませる。** 途中で弾かれても記録が変わらない
+ * ようにするため。`switch`（#15）と同じ考え方。
+ *
+ * 記録の**日付を別の日に移す**操作は入れていない。`--start 2026-08-11T09:00` のような
+ * 指定方法を決める必要があり、時刻の表記全体（#45）と揃えて決めるのが筋だから。
+ */
+export function createEditCommand(deps: CommandDeps): Command {
+  return {
+    name: "edit",
+    summary: "記録を修正する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const { value: startValue, rest: afterStart } = takeOption(argv, "--start");
+      const { value: endValue, rest: afterEnd } = takeOption(afterStart, "--end");
+      const { value: tagsValue, rest: afterTags } = takeOption(afterEnd, "--tags");
+      const { value: noteValue, rest } = takeOption(afterTags, "--note");
+      rejectUnknownArgs(rest, {
+        command: "edit",
+        allowedOptions: ["--start", "--end", "--tags", "--note"],
+        allowPositional: true,
+      });
+
+      const id = takeId(rest);
+      if (
+        startValue === undefined &&
+        endValue === undefined &&
+        tagsValue === undefined &&
+        noteValue === undefined
+      ) {
+        throw new UserError(
+          "変更する内容を指定してください（--start / --end / --tags / --note のいずれか）",
+        );
+      }
+
+      const entries = await listAllEntries(deps.store);
+      const target = findById(entries, id);
+      if (target === undefined) {
+        throw new UserError(`その id の記録がありません: ${id}`);
+      }
+
+      const now = deps.now();
+      const onDate = startedAt(target);
+      const changes: EntryChanges = {
+        ...(startValue === undefined
+          ? {}
+          : { start: resolveClockTimeOn(startValue, onDate, now, "--start") }),
+        ...(endValue === undefined
+          ? {}
+          : { end: resolveClockTimeOn(endValue, onDate, now, "--end") }),
+        ...(tagsValue === undefined ? {} : { tags: parseTagList(tagsValue) }),
+        ...(noteValue === undefined ? {} : { note: noteValue }),
+      };
+
+      const edited = translate(() => applyEdit(target, changes));
+
+      const conflict = findOverlapping(edited, entries);
+      if (conflict !== undefined) {
+        throw new UserError(
+          `編集後の時間が別の記録と重なります: ${describe(conflict)}（id: ${conflict.id}）`,
+        );
+      }
+
+      await deps.store.update(edited);
+
+      io.out(`修正しました: ${describe(edited)}`);
+      io.out(`id: ${edited.id}`);
+    },
+  };
+}
+
+/**
+ * 位置引数から id を1つ取り出す。
+ *
+ * **id を必須にし、2つ以上は弾く。** 省略を許して「実行中の記録」を暗黙の対象にすると、
+ * 直したつもりの記録と実際に直る記録が食い違う。
+ */
+function takeId(positional: readonly string[]): string {
+  const [id, ...extra] = positional;
+
+  if (id === undefined || id.trim() === "") {
+    throw new UserError("修正する記録の id を指定してください（tock log で確認できます）");
+  }
+  if (extra.length > 0) {
+    throw new UserError(`id は1つだけ指定してください: ${positional.join(" ")}`);
+  }
+
+  return id;
+}
+
+/**
+ * `--tags "会議 proj/tock"` を正規化したタグの並びにする。
+ *
+ * 空白で区切る。`#` は付けても付けなくてもよい（`normalizeTag` が落とす）。
+ * **空文字を渡すとタグを消す**（空の並びになる）。
+ */
+function parseTagList(value: string): readonly string[] {
+  const words = value.split(/\s+/).filter((word) => word !== "");
+  const tags: string[] = [];
+
+  for (const word of words) {
+    const tag = translate(() => normalizeTag(word));
+    if (!tags.includes(tag)) {
+      tags.push(tag);
+    }
+  }
+
+  return tags;
+}
+
+/** 記録を1行で表す。何が変わったかを確認できる程度の情報を出す。 */
+function describe(entry: Entry): string {
+  const label = [entry.note, ...entry.tags.map((tag) => `#${tag}`)].filter(
+    (part) => part !== undefined && part !== "",
+  );
+
+  return label.length === 0 ? "（名前なし）" : label.join(" ");
+}
+
+/** domain のエラーを利用者向けに翻訳する（domain は `UserError` を知らない）。 */
+function translate<T>(run: () => T): T {
+  try {
+    return run();
+  } catch (error) {
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -1,7 +1,7 @@
 import { type CliIo, type Command, UserError } from "../cli.js";
 import { applyEdit, type EntryChanges, findOverlapping } from "../domain/edit.js";
 import type { Entry } from "../domain/entry.js";
-import { startedAt } from "../domain/entry.js";
+import { endedAt, startedAt } from "../domain/entry.js";
 import { normalizeTag } from "../domain/tag.js";
 import { type CommandDeps, rejectUnknownArgs, resolveClockTimeOn, takeOption } from "./args.js";
 import { findById, listAllEntries } from "./lookup.js";
@@ -13,9 +13,9 @@ import { findById, listAllEntries } from "./lookup.js";
  * tock edit <id> [--start HH:MM] [--end HH:MM] [--tags "a b"] [--note "..."]
  * ```
  *
- * **`--start` / `--end` はその記録自身の日付に適用する。** 今日の日付に当てると、
- * 前日の記録を直したつもりで今日へ移動してしまう。日付そのものを変える操作は
- * このコマンドに入れていない（下記）。
+ * **`--start` は記録の開始日、`--end` は記録の終了日に適用する。** 今日の日付に当てると、
+ * 前日の記録を直したつもりで今日へ移動してしまう。開始日に揃えると、日を跨いだ記録の
+ * 終了時刻が直せない（`endBaseDate` を参照）。日付そのものを変える操作は入れていない（下記）。
  *
  * **書き込む前に、失敗しうる検証をすべて済ませる。** 途中で弾かれても記録が変わらない
  * ようにするため。`switch`（#15）と同じ考え方。
@@ -58,14 +58,13 @@ export function createEditCommand(deps: CommandDeps): Command {
       }
 
       const now = deps.now();
-      const onDate = startedAt(target);
       const changes: EntryChanges = {
         ...(startValue === undefined
           ? {}
-          : { start: resolveClockTimeOn(startValue, onDate, now, "--start") }),
+          : { start: resolveClockTimeOn(startValue, startedAt(target), now, "--start") }),
         ...(endValue === undefined
           ? {}
-          : { end: resolveClockTimeOn(endValue, onDate, now, "--end") }),
+          : { end: resolveClockTimeOn(endValue, endBaseDate(target, now), now, "--end") }),
         ...(tagsValue === undefined ? {} : { tags: parseTagList(tagsValue) }),
         ...(noteValue === undefined ? {} : { note: noteValue }),
       };
@@ -85,6 +84,25 @@ export function createEditCommand(deps: CommandDeps): Command {
       io.out(`id: ${edited.id}`);
     },
   };
+}
+
+/**
+ * `--end` の `HH:MM` を載せる日付を決める。
+ *
+ * **`--start` は開始日、`--end` は終了日**に載せる。開始日に揃えると、**日を跨いだ記録の
+ * 終了時刻が直せない。** 23:00 開始・翌 01:00 終了の記録に `--end 00:45` と打つと、
+ * 開始日の 00:45（開始より前）になって拒否される。利用者が指したいのは翌日の 00:45 である。
+ * 日跨ぎの記録は `--at` では作れないが、**実際に日付を跨いで作業すれば普通に作られる。**
+ *
+ * 実行中の記録には終了日が無いので `now` の日付に載せる。実行中の終端は「今」なので、
+ * 置き換える値の日付として `now` が最も近い。開始日にすると、**日を跨いで実行中のまま
+ * になっている記録**（23:00 開始で翌朝まで止め忘れ）で同じ問題が起きる。
+ *
+ * **残る曖昧さ:** 日跨ぎの記録の終了を「開始と同じ日」に縮める操作（翌 01:00 → 前日 23:30）は
+ * この規則では書けない。日付を明示する指定が必要で、時刻の表記全体（#45）と揃えて決める話。
+ */
+function endBaseDate(entry: Entry, now: Date): Date {
+  return endedAt(entry) ?? now;
 }
 
 /**

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -5,6 +5,7 @@ import type { Period } from "../domain/period.js";
 import { normalizeTag } from "../domain/tag.js";
 import { formatLogLines } from "../format/log.js";
 import { type CommandDeps, rejectUnknownArgs, takeOption } from "./args.js";
+import { ALL_TIME } from "./lookup.js";
 
 /**
  * `--limit` を省略したときの件数。
@@ -17,15 +18,6 @@ const DEFAULT_LIMIT = 20;
 
 /** 十進の1以上の整数。先頭の `0`・符号・小数点・指数・空白をすべて許さない。 */
 const DECIMAL_POSITIVE_INTEGER = /^[1-9]\d*$/;
-
-/**
- * `--period` を省略したときの範囲。`Date` が表せる全範囲。
- *
- * `Store` には「全件返す」操作が無く、`listByRange` に範囲を渡すしかない。
- * 期間指定なしの `log` は「いつの記録でも新しい順に直近 N 件」なので、
- * 範囲で落とさないよう最大幅を渡す。
- */
-const ALL_TIME: Period = { start: new Date(-8.64e15), end: new Date(8.64e15) };
 
 /**
  * 記録を新しい順に一覧表示する。

--- a/src/commands/lookup.ts
+++ b/src/commands/lookup.ts
@@ -1,0 +1,27 @@
+import type { Entry } from "../domain/entry.js";
+import type { Period } from "../domain/period.js";
+import type { Store } from "../store/store.js";
+
+/**
+ * id で記録を引く。
+ *
+ * **`Store` に「id で1件取る」操作も「全件返す」操作も無い**ため、`listByRange` に
+ * `Date` が表せる最大幅を渡して全件を得てから絞る。編集・削除（#17）と期間指定なしの
+ * 一覧（#16）が同じ細工を必要とするので、コピーを増やさないようここに集約する。
+ *
+ * **この形は Store の制約への回避策であり、#57 で解消する予定。**
+ * あちらが入ったら、この2つはその操作に置き換えられる。
+ */
+
+/** 期間で絞らないときに使う範囲。`Date` が表せる全範囲。 */
+export const ALL_TIME: Period = { start: new Date(-8.64e15), end: new Date(8.64e15) };
+
+/** 保存されている記録をすべて返す。並び順は store の返す順（追加した順）。 */
+export async function listAllEntries(store: Store): Promise<Entry[]> {
+  return store.listByRange(ALL_TIME);
+}
+
+/** id が一致する記録を返す。無ければ `undefined`。 */
+export function findById(entries: readonly Entry[], id: string): Entry | undefined {
+  return entries.find((entry) => entry.id === id);
+}

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -1,0 +1,89 @@
+import { type CliIo, type Command, UserError } from "../cli.js";
+import type { Entry } from "../domain/entry.js";
+import { type CommandDeps, rejectUnknownArgs, takeFlag } from "./args.js";
+import { findById, listAllEntries } from "./lookup.js";
+
+/**
+ * 削除してよいかを尋ねる。
+ *
+ * **`CliIo` は出力しか持たないため、入力は別に注入する。** テストから「はい」「いいえ」を
+ * 固定できるようにするのが目的で、実際の実装（標準入力を読む）は `cli.ts` が持つ。
+ */
+export type Confirm = (question: string) => Promise<boolean>;
+
+/**
+ * 記録を削除する。
+ *
+ * ```
+ * tock rm <id> [--yes]
+ * ```
+ *
+ * **`--yes` が無ければ確認する。** 削除は取り消せない（追記のみの JSONL でも、
+ * 削除の記録が畳まれた結果は戻せない）ので、既定では黙って消さない。
+ *
+ * 中止は**エラーにしない**（終了コード 0）。「消すのをやめた」は正常な操作であり、
+ * `status` が実行中なしを 0 で返すのと同じ考え方。
+ */
+export function createRmCommand(deps: CommandDeps, confirm: Confirm): Command {
+  return {
+    name: "rm",
+    summary: "記録を削除する",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const { present: skipConfirm, rest } = takeFlag(argv, "--yes");
+      rejectUnknownArgs(rest, {
+        command: "rm",
+        allowedOptions: ["--yes"],
+        allowPositional: true,
+      });
+
+      const id = takeId(rest);
+
+      // **消せるものかを先に確かめる。** 存在しない id で確認を出すと、
+      // 「はい」と答えたのに失敗する流れになる
+      const target = findById(await listAllEntries(deps.store), id);
+      if (target === undefined) {
+        throw new UserError(`その id の記録がありません: ${id}`);
+      }
+
+      if (!skipConfirm && !(await confirm(`削除しますか: ${describe(target)}（id: ${id}）`))) {
+        io.out("中止しました。削除していません");
+        return;
+      }
+
+      await deps.store.delete(id);
+
+      io.out(`削除しました: ${describe(target)}`);
+      io.out(`id: ${id}`);
+    },
+  };
+}
+
+/**
+ * 位置引数から id を1つ取り出す。
+ *
+ * **id を必須にし、2つ以上は弾く。** 省略を許すと、どの記録が消えるのか打った人に
+ * 分からない。まとめて消す指定（期間・タグでの一括削除）は入れていない——
+ * 取り消せない操作なので、対象を1件に限る。
+ */
+function takeId(positional: readonly string[]): string {
+  const [id, ...extra] = positional;
+
+  if (id === undefined || id.trim() === "") {
+    throw new UserError("削除する記録の id を指定してください（tock log で確認できます）");
+  }
+  if (extra.length > 0) {
+    throw new UserError(`id は1つだけ指定してください: ${positional.join(" ")}`);
+  }
+
+  return id;
+}
+
+/** 記録を1行で表す。何を消すのかが分かる程度の情報を出す。 */
+function describe(entry: Entry): string {
+  const label = [entry.note, ...entry.tags.map((tag) => `#${tag}`)].filter(
+    (part) => part !== undefined && part !== "",
+  );
+
+  return label.length === 0 ? "（名前なし）" : label.join(" ");
+}

--- a/src/domain/edit.ts
+++ b/src/domain/edit.ts
@@ -1,0 +1,63 @@
+import { createEntry, type Entry, endedAt, startedAt } from "./entry.js";
+import { overlaps } from "./period.js";
+
+/**
+ * 記録の編集。
+ *
+ * **検証は `createEntry` に通して行う。** `end < start` を弾く規則や時刻の正規化を
+ * ここに書き写すと、打刻で作るときと編集で直すときで通る値が食い違う。
+ * `newId` に元の id を返す関数を渡すことで、同じ検証を通しつつ id を保つ。
+ */
+
+/** 変更したいフィールドだけを持つ。省略したものは元の値を引き継ぐ。 */
+export interface EntryChanges {
+  readonly start?: Date;
+  /** 終了時刻。実行中の記録に与えると実行中でなくなる。 */
+  readonly end?: Date;
+  /** 空の配列を渡すとタグを消す。 */
+  readonly tags?: readonly string[];
+  /** 空文字を渡すと作業名を消す。 */
+  readonly note?: string;
+}
+
+/**
+ * 変更を適用した新しい `Entry` を返す。**id は変わらない。**
+ *
+ * 編集は同じ記録の書き換えなので id を保つ。id が変わると、一覧で見た行と
+ * 編集後の記録が別物になり、続けて操作できない。
+ *
+ * 引数のエントリは書き換えない。
+ *
+ * **終了時刻を消して実行中に戻す操作は用意していない。** 「終わった記録を再開する」は
+ * 打刻の意味が変わる操作で、`start` と組み合わせた指定方法も決める必要がある。
+ * この Issue（#17）のスコープは修正と削除まで。
+ */
+export function applyEdit(entry: Entry, changes: EntryChanges): Entry {
+  const start = changes.start ?? startedAt(entry);
+  const end = changes.end ?? endedAt(entry);
+  const tags = changes.tags ?? entry.tags;
+  const note = changes.note ?? entry.note;
+
+  return createEntry(
+    {
+      start,
+      ...(end === undefined ? {} : { end }),
+      tags,
+      ...(note === undefined ? {} : { note }),
+    },
+    { newId: () => entry.id },
+  );
+}
+
+/**
+ * 編集後のエントリと時間が重なる別の記録を返す。無ければ `undefined`。
+ *
+ * **自分自身は id で除く。** 除かないと必ず自分と重なって、どの編集も弾かれる。
+ *
+ * 重なりの判定は `overlaps`（#6）に任せる。半開区間なので端点が接するだけの記録は
+ * 重ならず、長さ 0 の記録はどれとも重ならない。実行中の記録は開始以降ずっと続くものと
+ * して扱われるため、**編集で実行中の開始を前に動かすと後続の記録と重なることも検出される。**
+ */
+export function findOverlapping(edited: Entry, all: readonly Entry[]): Entry | undefined {
+  return all.find((other) => other.id !== edited.id && overlaps(edited, other));
+}

--- a/tests/commands/edit.test.ts
+++ b/tests/commands/edit.test.ts
@@ -412,3 +412,107 @@ describe("edit の結果は log に反映される", () => {
     expect(out[0]).not.toContain("設計");
   });
 });
+
+/**
+ * 日跨ぎの記録の編集。
+ *
+ * **`--at` では日跨ぎの記録は作れないが、実際に日付を跨いで作業すれば普通に作られる**
+ * （23:00 に `start`、翌 01:00 に `stop`）。`CLAUDE.md` の境界値チェックリストが挙げる
+ * 「23:00 開始で翌 01:00 終了」がこれに当たる。
+ */
+describe("edit と日跨ぎの記録", () => {
+  /** 実時間の経過で日跨ぎ記録を作る（--at を使わない）。 */
+  async function overnight(): Promise<string> {
+    await createStartCommand(deps(local(13, 23))).run(["夜間作業 #work"], io);
+    await createStopCommand(deps(local(14, 1))).run([], io);
+    out = [];
+
+    return (await store.listByRange(allTime)).at(-1)?.id ?? "";
+  }
+
+  it("終了時刻は終了日の側に載る（開始日に載せると直せない）", async () => {
+    const id = await overnight();
+
+    await createEditCommand(deps(local(14, 10))).run([id, "--end", "00:45"], io);
+
+    expect((await byId(id))?.end).toBe(local(14, 0, 45).toISOString());
+  });
+
+  it("開始時刻は開始日の側に載る", async () => {
+    const id = await overnight();
+
+    await createEditCommand(deps(local(14, 10))).run([id, "--start", "22:00"], io);
+
+    expect((await byId(id))?.start).toBe(local(13, 22).toISOString());
+  });
+
+  it("開始と終了を同時に直しても、それぞれの日付に載る", async () => {
+    const id = await overnight();
+
+    await createEditCommand(deps(local(14, 10))).run(
+      [id, "--start", "22:00", "--end", "02:00"],
+      io,
+    );
+
+    const edited = await byId(id);
+
+    expect(edited?.start).toBe(local(13, 22).toISOString());
+    expect(edited?.end).toBe(local(14, 2).toISOString());
+  });
+
+  it("日跨ぎのまま長さが正しく変わる", async () => {
+    const id = await overnight();
+
+    await createEditCommand(deps(local(14, 10))).run([id, "--end", "02:30"], io);
+    out = [];
+    await createLogCommand(deps(local(14, 10))).run([], io);
+
+    // 23:00 → 翌 02:30 は 3h 30m
+    expect(out[0]).toContain("3h 30m");
+  });
+
+  it("終了を開始より前にする編集は日跨ぎでも拒否される（境界）", async () => {
+    const id = await overnight();
+
+    // 終了日の 00:45 より前でも、開始（前日 23:00）より後なので通る。
+    // 逆に開始日側へ動かす指定はこの規則では書けない（下記の判断待ち）
+    await expect(
+      createEditCommand(deps(local(14, 10))).run([id, "--start", "23:30", "--end", "23:00"], io),
+    ).rejects.toThrow(UserError);
+  });
+});
+
+/** 日を跨いで実行中のままになっている記録（止め忘れ）。 */
+describe("edit と日跨ぎの実行中エントリ（終端がない）", () => {
+  async function runningOvernight(): Promise<string> {
+    await createStartCommand(deps(local(13, 23))).run(["止め忘れ #work"], io);
+    out = [];
+
+    return (await store.listByRange(allTime)).at(-1)?.id ?? "";
+  }
+
+  it("--end は now の日付に載る（開始日に載せると直せない）", async () => {
+    const id = await runningOvernight();
+
+    // 翌朝 08:00 に気づいて、01:00 で止めたことにする
+    await createEditCommand(deps(local(14, 8))).run([id, "--end", "01:00"], io);
+
+    expect((await byId(id))?.end).toBe(local(14, 1).toISOString());
+  });
+
+  it("停止した記録になる", async () => {
+    const id = await runningOvernight();
+
+    await createEditCommand(deps(local(14, 8))).run([id, "--end", "01:00"], io);
+
+    expect(await store.findRunning()).toBeUndefined();
+  });
+
+  it("開始時刻は開始日の側に載ったまま", async () => {
+    const id = await runningOvernight();
+
+    await createEditCommand(deps(local(14, 8))).run([id, "--start", "22:00"], io);
+
+    expect((await byId(id))?.start).toBe(local(13, 22).toISOString());
+  });
+});

--- a/tests/commands/edit.test.ts
+++ b/tests/commands/edit.test.ts
@@ -1,0 +1,414 @@
+import { mkdtemp, rm as removeDir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createEditCommand } from "../../src/commands/edit.js";
+import { createLogCommand } from "../../src/commands/log.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import type { Entry } from "../../src/domain/entry.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-edit-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await removeDir(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+/** ローカルの壁時計で日時を組み立てる。テストを実行環境の TZ に依存させない。 */
+function local(day: number, hours: number, minutes = 0, seconds = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, day);
+  date.setHours(hours, minutes, seconds, 0);
+
+  return date;
+}
+
+const allTime = { start: local(1, 0), end: local(28, 0) };
+
+/** 2026-08-13 の夕方。編集の基準時刻。 */
+const NOW = local(13, 18);
+
+async function record(start: Date, end: Date, description: string): Promise<string> {
+  await createStartCommand(deps(start)).run([description], io);
+  await createStopCommand(deps(end)).run([], io);
+  out = [];
+
+  const entries = await store.listByRange(allTime);
+
+  return entries.at(-1)?.id ?? "";
+}
+
+async function byId(id: string): Promise<Entry | undefined> {
+  return (await store.listByRange(allTime)).find((entry) => entry.id === id);
+}
+
+describe("edit の各フィールドの編集（DoD）", () => {
+  it("開始時刻を変えられる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--start", "08:30"], io);
+
+    expect((await byId(id))?.start).toBe(local(13, 8, 30).toISOString());
+  });
+
+  it("終了時刻を変えられる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--end", "11:15"], io);
+
+    expect((await byId(id))?.end).toBe(local(13, 11, 15).toISOString());
+  });
+
+  it("タグを変えられる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--tags", "会議 proj/tock"], io);
+
+    expect((await byId(id))?.tags).toEqual(["会議", "proj/tock"]);
+  });
+
+  it("タグは `#` 付きでも指定できる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--tags", "#会議 #proj/tock"], io);
+
+    expect((await byId(id))?.tags).toEqual(["会議", "proj/tock"]);
+  });
+
+  it("作業名を変えられる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
+
+    expect((await byId(id))?.note).toBe("実装");
+  });
+
+  it("複数のフィールドを同時に変えられる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run(
+      [id, "--start", "08:00", "--end", "12:00", "--tags", "会議", "--note", "打ち合わせ"],
+      io,
+    );
+
+    const edited = await byId(id);
+
+    expect(edited?.start).toBe(local(13, 8).toISOString());
+    expect(edited?.end).toBe(local(13, 12).toISOString());
+    expect(edited?.tags).toEqual(["会議"]);
+    expect(edited?.note).toBe("打ち合わせ");
+  });
+
+  it("空文字の --note で作業名を消せる（境界）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", ""], io);
+
+    expect(await byId(id)).not.toHaveProperty("note");
+  });
+
+  it("空文字の --tags でタグを消せる（境界）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--tags", ""], io);
+
+    expect((await byId(id))?.tags).toEqual([]);
+  });
+
+  it("id は変わらない", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
+
+    expect((await byId(id))?.id).toBe(id);
+  });
+
+  it("記録の件数は増えない（追加ではなく書き換え）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("何を変えたかを stdout に出す", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
+
+    expect(out.join("\n")).toContain("実装");
+    expect(err).toEqual([]);
+  });
+});
+
+describe("edit の時刻は記録自身の日付に適用される", () => {
+  it("前日の記録を編集しても、その記録の日付のままになる", async () => {
+    // 8/11 の記録を 8/13 に編集する。--start 08:00 は 8/11 の 08:00 でなければならない
+    const id = await record(local(11, 9), local(11, 10), "前々日 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--start", "08:00"], io);
+
+    expect((await byId(id))?.start).toBe(local(11, 8).toISOString());
+  });
+
+  it("終了時刻も記録自身の日付に適用される", async () => {
+    const id = await record(local(11, 9), local(11, 10), "前々日 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--end", "11:00"], io);
+
+    expect((await byId(id))?.end).toBe(local(11, 11).toISOString());
+  });
+
+  it("秒まで指定できる", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--start", "08:30:15"], io);
+
+    expect((await byId(id))?.start).toBe(local(13, 8, 30, 15).toISOString());
+  });
+});
+
+describe("edit の不正な編集（DoD）", () => {
+  it("終了が開始より前になる編集は UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--end", "08:00"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("開始が終了より後になる編集も UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--start", "11:00"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("失敗したときは記録を変えない", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+    const before = await byId(id);
+
+    await Promise.resolve(createEditCommand(deps(NOW)).run([id, "--end", "08:00"], io)).catch(
+      () => undefined,
+    );
+
+    expect(await byId(id)).toEqual(before);
+  });
+
+  it("失敗したときは何も出力しない", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await Promise.resolve(createEditCommand(deps(NOW)).run([id, "--end", "08:00"], io)).catch(
+      () => undefined,
+    );
+
+    expect(out).toEqual([]);
+  });
+
+  it("他の記録と重なる編集は UserError で失敗する", async () => {
+    await record(local(13, 7), local(13, 8), "前の作業 #work");
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--start", "07:30"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("端点が接するだけの編集は通る（境界: 半開区間）", async () => {
+    await record(local(13, 7), local(13, 8), "前の作業 #work");
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--start", "08:00"], io);
+
+    expect((await byId(id))?.start).toBe(local(13, 8).toISOString());
+  });
+
+  it("未来の時刻を指定すると UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--end", "23:00"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it.each([
+    ["時が範囲外", "24:00"],
+    ["分が範囲外", "09:60"],
+    ["形式が違う", "9時30分"],
+    ["空文字", ""],
+  ])("--start が不正（%s）なら UserError で失敗する", async (_label, value) => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--start", value], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("不正なタグは UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--tags", "#"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});
+
+describe("edit の id の指定（DoD）", () => {
+  it("存在しない id なら UserError で失敗する（終了コード 1）", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(
+      createEditCommand(deps(NOW)).run(["no-such-id", "--note", "実装"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("記録が1件も無い状態でも UserError で失敗する（境界）", async () => {
+    await expect(
+      createEditCommand(deps(NOW)).run(["no-such-id", "--note", "実装"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("id を省略すると UserError で失敗する", async () => {
+    await expect(createEditCommand(deps(NOW)).run(["--note", "実装"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("id を2つ渡すと UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(
+      createEditCommand(deps(NOW)).run([id, "extra", "--note", "実装"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("変更を1つも指定しないと UserError で失敗する（黙って書き換えない）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id], io)).rejects.toThrow(UserError);
+  });
+
+  it("未知のオプションは UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--help"], io)).rejects.toThrow(UserError);
+  });
+});
+
+// CLAUDE.md の境界値チェックリスト「終端のないデータ」
+describe("edit と実行中エントリ（終端がない）", () => {
+  async function startOnly(start: Date, description: string): Promise<string> {
+    await createStartCommand(deps(start)).run([description], io);
+    out = [];
+
+    return (await store.listByRange(allTime)).at(-1)?.id ?? "";
+  }
+
+  it("実行中の記録のタグを変えられる（実行中のまま）", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--tags", "会議"], io);
+
+    const edited = await byId(id);
+
+    expect(edited?.tags).toEqual(["会議"]);
+    expect(edited).not.toHaveProperty("end");
+  });
+
+  it("実行中の記録の開始時刻を変えられる（実行中のまま）", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--start", "08:00"], io);
+
+    const edited = await byId(id);
+
+    expect(edited?.start).toBe(local(13, 8).toISOString());
+    expect(edited).not.toHaveProperty("end");
+  });
+
+  it("実行中の記録に --end を与えると停止した記録になる", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--end", "10:00"], io);
+
+    expect((await byId(id))?.end).toBe(local(13, 10).toISOString());
+    expect(await store.findRunning()).toBeUndefined();
+  });
+
+  it("実行中の記録に開始より前の --end を与えると UserError（境界）", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--end", "08:00"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("実行中の開始を前に動かして他の記録と重なると UserError（境界）", async () => {
+    await record(local(13, 7), local(13, 8), "前の作業 #work");
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await expect(createEditCommand(deps(NOW)).run([id, "--start", "07:30"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("編集後も実行中は1件のまま", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "別の名前"], io);
+
+    const running = (await store.listByRange(allTime)).filter((entry) => entry.end === undefined);
+
+    expect(running).toHaveLength(1);
+  });
+});
+
+describe("edit の結果は log に反映される", () => {
+  it("編集した作業名が一覧に出る", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
+    out = [];
+    await createLogCommand(deps(NOW)).run([], io);
+
+    expect(out[0]).toContain("実装");
+    expect(out[0]).not.toContain("設計");
+  });
+});

--- a/tests/commands/rm.test.ts
+++ b/tests/commands/rm.test.ts
@@ -1,0 +1,286 @@
+import { mkdtemp, rm as removeDir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createLogCommand } from "../../src/commands/log.js";
+import { type Confirm, createRmCommand } from "../../src/commands/rm.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+let asked: string[];
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+/** 常に「はい」と答える確認。何を聞かれたかを記録する。 */
+const confirmYes: Confirm = (question) => {
+  asked.push(question);
+
+  return Promise.resolve(true);
+};
+
+/** 常に「いいえ」と答える確認。 */
+const confirmNo: Confirm = (question) => {
+  asked.push(question);
+
+  return Promise.resolve(false);
+};
+
+/** 呼ばれてはいけない確認。呼ばれたら落ちる。 */
+const confirmNever: Confirm = () => {
+  throw new Error("確認が呼ばれました（--yes のときは聞かないはず）");
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-rm-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  asked = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await removeDir(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+function local(day: number, hours: number, minutes = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, day);
+  date.setHours(hours, minutes, 0, 0);
+
+  return date;
+}
+
+const allTime = { start: local(1, 0), end: local(28, 0) };
+const NOW = local(13, 18);
+
+async function record(start: Date, end: Date, description: string): Promise<string> {
+  await createStartCommand(deps(start)).run([description], io);
+  await createStopCommand(deps(end)).run([], io);
+  out = [];
+
+  return (await store.listByRange(allTime)).at(-1)?.id ?? "";
+}
+
+describe("rm の削除（DoD）", () => {
+  it("--yes を付けると確認せずに削除する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmNever).run([id, "--yes"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+  });
+
+  it("削除後に一覧から消える（DoD）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+    await record(local(13, 11), local(13, 12), "会議 #会議");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+    out = [];
+    await createLogCommand(deps(NOW)).run([], io);
+
+    expect(out.join("\n")).not.toContain("設計");
+    expect(out.join("\n")).toContain("会議");
+  });
+
+  it("残りの記録は消えない", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+    await record(local(13, 11), local(13, 12), "会議 #会議");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    const remaining = await store.listByRange(allTime);
+
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.note).toBe("会議");
+  });
+
+  it("最後の1件を削除すると 0 件になる（境界）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+  });
+
+  it("削除したことを stdout に出す", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    expect(out.join("\n")).toContain("設計");
+    expect(err).toEqual([]);
+  });
+});
+
+describe("rm の確認プロンプト", () => {
+  it("--yes が無ければ確認する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id], io);
+
+    expect(asked).toHaveLength(1);
+  });
+
+  it("確認の文言に、消す記録が分かる情報が入る", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id], io);
+
+    expect(asked[0]).toContain("設計");
+  });
+
+  it("「はい」と答えると削除する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+  });
+
+  it("「いいえ」と答えると削除しない", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmNo).run([id], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("「いいえ」でもエラーにしない（中止は正常な操作）", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createRmCommand(deps(NOW), confirmNo).run([id], io)).resolves.toBeUndefined();
+  });
+
+  it("「いいえ」のときは中止したことを伝える", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createRmCommand(deps(NOW), confirmNo).run([id], io);
+
+    expect(out.join("\n")).toContain("中止");
+  });
+
+  it("存在しない id のときは確認せずに失敗する（消せないものを聞かない）", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createRmCommand(deps(NOW), confirmNever).run(["no-such-id"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});
+
+describe("rm の id の指定（DoD）", () => {
+  it("存在しない id なら UserError で失敗する（終了コード 1）", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(
+      createRmCommand(deps(NOW), confirmYes).run(["no-such-id", "--yes"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("存在しない id のときは何も削除しない", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await Promise.resolve(
+      createRmCommand(deps(NOW), confirmYes).run(["no-such-id", "--yes"], io),
+    ).catch(() => undefined);
+
+    expect(await store.listByRange(allTime)).toHaveLength(1);
+  });
+
+  it("記録が1件も無い状態でも UserError で失敗する（境界）", async () => {
+    await expect(
+      createRmCommand(deps(NOW), confirmYes).run(["no-such-id", "--yes"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("id を省略すると UserError で失敗する", async () => {
+    await expect(createRmCommand(deps(NOW), confirmYes).run([], io)).rejects.toThrow(UserError);
+  });
+
+  it("id を2つ渡すと UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createRmCommand(deps(NOW), confirmYes).run([id, "extra"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("未知のオプションは UserError で失敗する", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await expect(createRmCommand(deps(NOW), confirmYes).run([id, "--help"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});
+
+// CLAUDE.md の境界値チェックリスト「終端のないデータ」
+describe("rm と実行中エントリ（終端がない）", () => {
+  async function startOnly(start: Date, description: string): Promise<string> {
+    await createStartCommand(deps(start)).run([description], io);
+    out = [];
+
+    return (await store.listByRange(allTime)).at(-1)?.id ?? "";
+  }
+
+  it("実行中の記録を削除できる", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    expect(await store.listByRange(allTime)).toHaveLength(0);
+  });
+
+  it("実行中の記録を削除すると、実行中が無い状態になる", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    expect(await store.findRunning()).toBeUndefined();
+  });
+
+  it("実行中を削除したあとは start できる（手詰まりにならない）", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+    await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
+
+    await createStartCommand(deps(local(13, 19))).run(["新しい作業"], io);
+
+    expect(await store.findRunning()).toBeDefined();
+  });
+
+  it("実行中の記録でも確認の文言に情報が入る", async () => {
+    const id = await startOnly(local(13, 9), "作業中 #work");
+
+    await createRmCommand(deps(NOW), confirmYes).run([id], io);
+
+    expect(asked[0]).toContain("作業中");
+  });
+});

--- a/tests/domain/edit.test.ts
+++ b/tests/domain/edit.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import { applyEdit, findOverlapping } from "../../src/domain/edit.js";
+import type { Entry } from "../../src/domain/entry.js";
+
+function local(day: number, hours: number, minutes = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, day);
+  date.setHours(hours, minutes, 0, 0);
+
+  return date;
+}
+
+function entry(
+  id: string,
+  start: Date,
+  end: Date | undefined,
+  tags: readonly string[] = [],
+  note?: string,
+): Entry {
+  return {
+    id,
+    start: start.toISOString(),
+    ...(end === undefined ? {} : { end: end.toISOString() }),
+    tags,
+    ...(note === undefined ? {} : { note }),
+  };
+}
+
+/** 8/13 09:00〜10:00、#work、「設計」。 */
+const BASE = entry("target", local(13, 9), local(13, 10), ["work"], "設計");
+
+describe("applyEdit の各フィールドの編集", () => {
+  it("開始時刻を変えられる", () => {
+    const edited = applyEdit(BASE, { start: local(13, 8) });
+
+    expect(edited.start).toBe(local(13, 8).toISOString());
+    expect(edited.end).toBe(local(13, 10).toISOString());
+  });
+
+  it("終了時刻を変えられる", () => {
+    const edited = applyEdit(BASE, { end: local(13, 11) });
+
+    expect(edited.end).toBe(local(13, 11).toISOString());
+    expect(edited.start).toBe(local(13, 9).toISOString());
+  });
+
+  it("タグを変えられる", () => {
+    const edited = applyEdit(BASE, { tags: ["会議", "proj/tock"] });
+
+    expect(edited.tags).toEqual(["会議", "proj/tock"]);
+  });
+
+  it("作業名を変えられる", () => {
+    expect(applyEdit(BASE, { note: "実装" }).note).toBe("実装");
+  });
+
+  it("複数のフィールドを同時に変えられる", () => {
+    const edited = applyEdit(BASE, {
+      start: local(13, 8),
+      end: local(13, 12),
+      tags: ["会議"],
+      note: "打ち合わせ",
+    });
+
+    expect(edited.start).toBe(local(13, 8).toISOString());
+    expect(edited.end).toBe(local(13, 12).toISOString());
+    expect(edited.tags).toEqual(["会議"]);
+    expect(edited.note).toBe("打ち合わせ");
+  });
+
+  it("指定しなかったフィールドは変わらない", () => {
+    const edited = applyEdit(BASE, { note: "実装" });
+
+    expect(edited.start).toBe(BASE.start);
+    expect(edited.end).toBe(BASE.end);
+    expect(edited.tags).toEqual(BASE.tags);
+  });
+
+  it("**id は変わらない**（編集は同じ記録の書き換えなので）", () => {
+    expect(applyEdit(BASE, { note: "実装" }).id).toBe("target");
+  });
+
+  it("何も変えなければ同じ内容になる（境界）", () => {
+    expect(applyEdit(BASE, {})).toEqual(BASE);
+  });
+
+  it("元のエントリを書き換えない", () => {
+    applyEdit(BASE, { note: "実装", tags: ["会議"] });
+
+    expect(BASE.note).toBe("設計");
+    expect(BASE.tags).toEqual(["work"]);
+  });
+});
+
+describe("applyEdit の空にする編集", () => {
+  it("空文字の作業名で作業名を消せる（境界）", () => {
+    expect(applyEdit(BASE, { note: "" })).not.toHaveProperty("note");
+  });
+
+  it("空の配列でタグを消せる（境界）", () => {
+    expect(applyEdit(BASE, { tags: [] }).tags).toEqual([]);
+  });
+
+  it("作業名を消してもタグは残る", () => {
+    expect(applyEdit(BASE, { note: "" }).tags).toEqual(["work"]);
+  });
+});
+
+describe("applyEdit の不正な編集", () => {
+  it("終了が開始より前になる編集は Error（DoD）", () => {
+    expect(() => applyEdit(BASE, { end: local(13, 8) })).toThrow();
+  });
+
+  it("開始が終了より後になる編集も Error（DoD。開始側を動かした場合）", () => {
+    expect(() => applyEdit(BASE, { start: local(13, 11) })).toThrow();
+  });
+
+  it("開始と終了が同時刻になる編集は通る（境界: 長さ 0 は作れる）", () => {
+    const edited = applyEdit(BASE, { end: local(13, 9) });
+
+    expect(edited.start).toBe(edited.end);
+  });
+
+  it("両方を同時に動かして前後が保たれていれば通る", () => {
+    const edited = applyEdit(BASE, { start: local(13, 14), end: local(13, 15) });
+
+    expect(edited.start).toBe(local(13, 14).toISOString());
+    expect(edited.end).toBe(local(13, 15).toISOString());
+  });
+
+  it("空のタグは Error", () => {
+    expect(() => applyEdit(BASE, { tags: [""] })).toThrow();
+  });
+
+  it("不正な Date は Error", () => {
+    expect(() => applyEdit(BASE, { start: new Date(Number.NaN) })).toThrow();
+  });
+});
+
+// CLAUDE.md の境界値チェックリスト「終端のないデータ」
+describe("applyEdit と実行中エントリ（終端がない）", () => {
+  const RUNNING = entry("running", local(13, 9), undefined, ["work"], "作業中");
+
+  it("実行中のまま開始時刻を変えられる", () => {
+    const edited = applyEdit(RUNNING, { start: local(13, 8) });
+
+    expect(edited.start).toBe(local(13, 8).toISOString());
+    expect(edited).not.toHaveProperty("end");
+  });
+
+  it("実行中のままタグを変えられる", () => {
+    const edited = applyEdit(RUNNING, { tags: ["会議"] });
+
+    expect(edited.tags).toEqual(["会議"]);
+    expect(edited).not.toHaveProperty("end");
+  });
+
+  it("終了時刻を与えると実行中でなくなる", () => {
+    expect(applyEdit(RUNNING, { end: local(13, 10) }).end).toBe(local(13, 10).toISOString());
+  });
+
+  it("与えた終了時刻が開始より前なら Error（境界）", () => {
+    expect(() => applyEdit(RUNNING, { end: local(13, 8) })).toThrow();
+  });
+
+  it("実行中に開始と同時刻の終了を与えても通る（境界: 長さ 0）", () => {
+    expect(applyEdit(RUNNING, { end: local(13, 9) }).end).toBe(local(13, 9).toISOString());
+  });
+});
+
+describe("findOverlapping", () => {
+  const others = [
+    entry("before", local(13, 7), local(13, 8), ["work"]),
+    entry("after", local(13, 12), local(13, 13), ["work"]),
+  ];
+
+  it("重なる記録が無ければ undefined", () => {
+    expect(findOverlapping(BASE, [BASE, ...others])).toBeUndefined();
+  });
+
+  it("他の記録と重なると、その記録を返す", () => {
+    const moved = applyEdit(BASE, { start: local(13, 7, 30) });
+
+    expect(findOverlapping(moved, [BASE, ...others])?.id).toBe("before");
+  });
+
+  it("自分自身とは重ならない（同じ id は除く）", () => {
+    // 自分と比べると必ず重なるため、id で除外していないとここで落ちる
+    expect(findOverlapping(BASE, [BASE])).toBeUndefined();
+  });
+
+  it("端点が接するだけなら重ならない（境界: 半開区間）", () => {
+    const touching = applyEdit(BASE, { start: local(13, 8) });
+
+    expect(findOverlapping(touching, [BASE, ...others])).toBeUndefined();
+  });
+
+  it("1ミリ秒でも食い込めば重なる（境界）", () => {
+    const overlapping = applyEdit(BASE, { start: new Date(local(13, 8).getTime() - 1) });
+
+    expect(findOverlapping(overlapping, [BASE, ...others])?.id).toBe("before");
+  });
+
+  it("長さ 0 の記録はどれとも重ならない（境界）", () => {
+    const zero = applyEdit(BASE, { start: local(13, 7, 30), end: local(13, 7, 30) });
+
+    expect(findOverlapping(zero, [BASE, ...others])).toBeUndefined();
+  });
+
+  it("記録が自分1件だけなら undefined（境界）", () => {
+    expect(findOverlapping(BASE, [BASE])).toBeUndefined();
+  });
+
+  it("空の一覧でも落ちない（境界）", () => {
+    expect(findOverlapping(BASE, [])).toBeUndefined();
+  });
+
+  it("実行中の記録は開始以降ずっと続くものとして重なりを見る（終端なし）", () => {
+    const running = entry("running", local(13, 11), undefined, ["work"]);
+    const moved = applyEdit(BASE, { start: local(13, 11, 30), end: local(13, 11, 45) });
+
+    expect(findOverlapping(moved, [BASE, running])?.id).toBe("running");
+  });
+
+  it("実行中の記録を編集したとき、後続の記録と重なることを検出する（終端なし）", () => {
+    const running = entry("running", local(13, 9), undefined, ["work"]);
+    const moved = applyEdit(running, { start: local(13, 6) });
+
+    // 実行中は開始以降ずっと続くので、after（12:00〜13:00）と重なる
+    expect(findOverlapping(moved, [running, ...others])).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

`tock edit` と `tock rm` を追加した。打刻の押し忘れやタグの間違いを後から直せるようにする。

- `src/domain/edit.ts` — 変更の適用と重なりの検出（`applyEdit` / `findOverlapping`）
- `src/commands/edit.ts` — `tock edit <id> [--start] [--end] [--tags] [--note]`
- `src/commands/rm.ts` — `tock rm <id> [--yes]`（確認プロンプト付き）
- `src/commands/lookup.ts` — id で記録を引く（`log` と共有）

Closes #17

### 設計の理由

**検証は `createEntry` に通している。** `end < start` を弾く規則や時刻の正規化を
`applyEdit` に書き写すと、打刻で作るときと編集で直すときで通る値が食い違う。
`newId` に**元の id を返す関数**を渡すことで、同じ検証を通しつつ id を保っている。

```ts
return createEntry({ start, ...end, tags, ...note }, { newId: () => entry.id });
```

**`--start` は開始日、`--end` は終了日に載せる。** 今日の日付に当てると、前日の記録を
直したつもりで今日へ移動してしまう。一方で**両方を開始日に揃えると、日を跨いだ記録の
終了時刻が直せない**（レビューで指摘を受けて修正。下記）。実行中の記録は終了日を持たない
ので `now` の日付に載せる。

`resolveClockTime` を `resolveClockTimeOn(value, onDate, now, label)` として共有し、
**`--at` の挙動とエラーメッセージは変えていない**（既存の start / stop / switch のテストは
そのまま通る）。

**`rm` は `--yes` が無ければ確認する。** 削除は取り消せないので既定では黙って消さない。
`CliIo` は出力しか持たないため、確認は関数として注入し、実装（標準入力を読む）は
`cli.ts` が持つ。テストからは「はい」「いいえ」を固定できる。

**中止はエラーにしない**（終了コード 0）。「消すのをやめた」は正常な操作で、
`status` が実行中なしを 0 で返すのと同じ考え方。

**対話端末でないときは尋ねずに失敗する。** パイプやスクリプトから実行されると答えを
受け取れず、既定を「はい」にすると意図しない削除になり、「いいえ」にすると何も起きない
理由が分からない。`--yes` を明示してもらう。

## 受け入れ条件

- [x] **各フィールドの編集テストがある**
      → `tests/domain/edit.test.ts`「applyEdit の各フィールドの編集」、
      `tests/commands/edit.test.ts`「edit の各フィールドの編集（DoD）」。
      開始・終了・タグ・作業名を個別と同時、および**空文字で消す**境界も固定
      ```
      $ tock log
      6c503751-...  2026-08-13  11:00-11:30  30m  会議 #会議
      ec58aaea-...  2026-08-13  09:00-10:00  1h   設計 #work

      $ tock edit 6c503751-... --note "定例会議" --tags "会議 proj/tock"
      修正しました: 定例会議 #会議 #proj/tock
      id: 6c503751-...

      $ tock edit 6c503751-... --start 10:45
      修正しました: 定例会議 #会議 #proj/tock

      $ tock log
      6c503751-...  2026-08-13  10:45-11:30  45m  定例会議 #会議 #proj/tock
      ec58aaea-...  2026-08-13  09:00-10:00  1h   設計 #work
      ```
- [x] **不正な編集（end < start）が拒否されるテストがある**
      → `tests/domain/edit.test.ts`「applyEdit の不正な編集」、
      `tests/commands/edit.test.ts`「edit の不正な編集（DoD）」。
      **終了側を動かす場合と開始側を動かす場合の両方**を固定
      ```
      $ tock edit <id> --end 08:00
      end が start より前です: start=2026-08-13T11:00:00.000Z end=2026-08-13T08:00:00.000Z
      $ tock edit <id> --start 12:00
      end が start より前です: start=2026-08-13T12:00:00.000Z end=2026-08-13T11:30:00.000Z
      $ tock edit <id> --end 23:00
      --end に未来の時刻は指定できません: 23:00（現在は 18:51:58）
      $ tock edit <id> --start 09:30
      編集後の時間が別の記録と重なります: 設計 #work（id: 7963719f-...）
      ```
      いずれも終了コード 1（パイプなしで実測）。
      ```
      tock edit <id> --end 08:00 → exit=1
      tock edit <id> --end 23:00 → exit=1
      tock edit <id> --tags #    → exit=1
      tock edit <id> --note 実装 → exit=0
      ```
- [x] **存在しない ID を指定した場合に終了コード 1 で失敗するテストがある**
      → `tests/commands/edit.test.ts`「edit の id の指定（DoD）」、
      `tests/commands/rm.test.ts`「rm の id の指定（DoD）」。
      **記録が0件のときも**固定（境界）
      ```
      $ tock edit no-such-id --note x
      その id の記録がありません: no-such-id
      $ echo $?
      1
      $ tock rm no-such-id --yes
      その id の記録がありません: no-such-id
      $ echo $?
      1
      ```
      `rm` は**存在確認を確認プロンプトより先に**行う（「はい」と答えたのに失敗する流れを避ける）。
- [x] **削除後に一覧から消えるテストがある**
      → `tests/commands/rm.test.ts`「削除後に一覧から消える（DoD）」。
      `log` コマンドの出力で確認している（store を直接見るだけにしない）
      ```
      $ tock rm dce249ba-... --yes
      削除しました: 会議 #会議
      id: dce249ba-...

      $ tock log
      b344d442-...  2026-08-13  09:00-10:00  1h  設計 #work
      ```

### 確認プロンプトの実測

対話端末を用意して両方の答えを確認した。

```
$ tock rm <id>          # "n" と答える
削除しますか: 会議 #会議（id: 465c66c6-...） [y/N] n
中止しました。削除していません
→ 記録は2件のまま

$ tock rm <id>          # "y" と答える
削除しますか: 会議 #会議（id: 465c66c6-...） [y/N] y
削除しました: 会議 #会議
→ 記録は1件になった
```

非対話（パイプ）では尋ねずに失敗する。

```
$ echo "" | tock rm <id>
確認の入力を受け取れません（対話端末ではありません）。--yes を付けて実行してください: 削除しますか: 設計 #work（id: b344d442-...）
$ echo $?
1
→ 記録は消えていない
```

## レビュー指摘への対応（[Major] 1件。修正済み）

**日を跨いだ記録の終了時刻が `edit` で直せませんでした。** `71fa7f2` で修正。

`--start` も `--end` も開始日に載せていたため、23:00 開始・翌 01:00 終了の記録に
`--end 00:45` と打つと開始日の 00:45（開始より前）になって拒否されていました。

```
作った日跨ぎ記録（--at は使わず、実時間の経過で作る）:
  start: 2026-08-13T23:00:00.000Z → end: 2026-08-14T01:00:00.000Z

$ tock edit <id> --end 00:45   （現在 2026-08-14 10:00）
→ 失敗: end が start より前です: end=2026-08-13T00:45:00.000Z
```

`--end` を終了日に載せるようにして直りました。

```
$ tock edit <id> --end 00:45   （修正後）
修正しました: 夜間作業 #work

$ tock log
id-1  2026-08-13  23:00-00:45  1h 45m  夜間作業 #work
```

**実行中の記録は `now` の日付に載せています**（レビューの提案「実行中なら開始日」とは
違えました）。開始日にすると、**日を跨いで止め忘れた記録**で同じ問題が再発するためです。
23:00 開始で翌朝 08:00 に気づき「01:00 で止めたことにする」場合、開始日だと前日の 01:00 に
なって拒否されます。実行中の終端は「今」なので、置き換える値の日付として `now` が最も近い
と判断しました。

### この PR の初版に書いた境界値の表は誤りでした

初版の表には境界「日跨ぎ」に対応済みと書いていましたが、**実際に固定していたのは
「過去の日付の同一暦日内」だけ**で、23:00〜翌 01:00 の記録は1件も試していませんでした。
レビューの「テストは前々日の同一暦日内しか見ておらず、CLAUDE.md が挙げる 23:00〜翌 01:00 の
境界が抜けている」がそのまま当たっています。表の記述が事実と違っていたので訂正します。

日跨ぎの記録を**実時間の経過で作る**テストを8件追加しました（完了した記録と、日を跨いで
実行中のままの記録の両方）。**元のバグを入れ直すと5件落ちます。**

```
 × 終了時刻は終了日の側に載る（開始日に載せると直せない）
 × 開始と終了を同時に直しても、それぞれの日付に載る
 × 日跨ぎのまま長さが正しく変わる
 × --end は now の日付に載る（開始日に載せると直せない）
 × 停止した記録になる

 Tests  5 failed | 42 passed (47)
```

## mutation test

DoD の中心にある振る舞いを10箇所壊した。**すべてでテストが落ちた（穴なし）。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 編集で id を作り直す（同じ記録の書き換えにならない） | 25件 |
| `start` の変更を無視して元の値を使う | 18件 |
| `end` は元の値を優先する（変更が効かない） | 12件 |
| 重なり判定から自分自身の除外を落とす | 26件 |
| 重なりの検査そのものをやめる | 2件 |
| 時刻を記録自身の日付ではなく今日に当てる | 2件 |
| 存在しない id を通してしまう（edit） | 2件 |
| `rm` が `--yes` を無視して必ず確認する | 1件 |
| `rm` が確認の答えを無視して必ず削除する | 5件 |
| `rm` が実際には削除しない | 8件 |
| **`--end` を開始日に載せる**（レビュー指摘後に追加） | **5件**（当初 0件） |

元に戻して 934 件すべて通ることを確認済み。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 記録0件での edit / rm、空文字の `--note` / `--tags`（消す）、変更を1つも指定しない、id を省略 |
| 同時刻 | 開始と終了が同時刻になる編集（長さ 0 は作れる）、端点が接するだけの編集（重ならない） |
| **日跨ぎ** | **23:00 開始・翌 01:00 終了の記録を実時間の経過で作り、`--end` / `--start` / 両方同時の編集を固定。日を跨いで実行中のままの記録も別に固定**（初版はここが抜けていた） |
| 上限値・範囲外 | `24:00` / `09:60` / 形式違い / 空文字、未来の時刻、id を2つ、未知のオプション |
| **終端のないデータ** | **下記のとおり edit / rm の両方で固定した** |

実行中エントリ（`end` を持たない）の扱い。

- `applyEdit`: 実行中のまま開始時刻・タグを変えられる／`--end` を与えると実行中でなくなる／
  与えた終了が開始より前なら Error／開始と同時刻なら通る（長さ 0）
- `findOverlapping`: **実行中は開始以降ずっと続くものとして重なりを見る**ので、
  編集で実行中の開始を前に動かすと後続の記録と重なることも検出される
- `edit` コマンド: 実行中の編集後も**実行中は1件のまま**／**日を跨いで実行中の記録**の
  `--end` が `now` の日付に載る
- `rm` コマンド: 実行中を削除できる／削除後は実行中が無い状態になる／
  **削除したあとに `start` できる**（手詰まりにならない）

## `log` / `args.ts` に触った理由

**どちらも `edit` / `rm` を実装するために必要な差分で、「ついでの修正」ではない。**

1. **`src/commands/lookup.ts` を追加し、`log` の `ALL_TIME` を移した。**
   `Store` には「id で1件取る」操作も「全件返す」操作も無いため、`listByRange` に
   `Date` の最大幅を渡す細工が必要になる。`edit` と `rm` の2つが同じものを要るので、
   そのまま書くと**3箇所目のコピー**になる。この形は Store の制約への回避策で、
   **#57 で解消される**ことをコメントに明記した
2. **`resolveClockTime` を `resolveClockTimeOn` として共有した。** `--start` / `--end` を
   記録の日付に当てる必要があるため。**`--at` の挙動とメッセージは変えていない**
   （`resolveClockTime` は `resolveClockTimeOn(value, now, now, "--at")` に委譲するだけ）

## スコープに入れなかったもの

- **記録の日付を別の日に移す操作**。`--start 2026-08-11T09:00` のような指定方法を決める
  必要があり、時刻の表記全体（#45）と揃えるのが筋だと判断した
- **日跨ぎの記録の終了を「開始と同じ日」に縮める操作**（翌 01:00 → 前日 23:30）。
  今の規則では `--end 23:30` は終了日の 23:30 になる。**日付を明示する指定が必要**で、
  上と同じ理由で #45 と揃えて決める話。コードのコメントにも残した
- **終了時刻を消して実行中に戻す操作**。「終わった記録を再開する」は打刻の意味が変わる操作で、
  #17 のスコープ（修正と削除）を超える
- **まとめて削除する指定**（期間・タグでの一括削除）。取り消せない操作なので対象を1件に限った
- **id の前方一致による解決**。#58 の担当範囲なので、この PR では**一覧に出た id を
  そのまま渡す**形にしている（`tock log` の出力からコピーできる）

## スタック

- base: `main`（スタックなし）
- 依存は E4-5（#16）で、マージ済み

## 依存の追加

なし（確認プロンプトは Node 標準の `node:readline/promises` を使った）。

## 検証

`npm run check` green（30 files / 934 tests。832 → 934 で +102件）。

- 実装フェーズの修正試行 **1回**（lint の `no-unused-vars`）
- レビュー対応フェーズの修正試行 **0回**（指摘への修正は1回で通った）

## 判断を仰ぎたい点

**id をそのまま打つ必要があり、実際に使うと長いです。**

```
$ tock edit 6c503751-f8c5-4b56-b6cd-a8b7c3faefbd --note "定例会議"
```

短縮と前方一致は **#58** に切ってありますが、`edit` / `rm` が入った今のほうが必要性が
はっきりしたので、**#58 を次に上げるかどうか**の判断をお願いします。この PR で先取りすると
「表示だけ短くして参照は長いまま」か「参照方法を2つ持つ」のどちらかになるため、
入れていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_