### PR TITLE
[E6-2][P2] CSV / JSON エクスポート

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { createExportCommand } from "./commands/export.js";
 import { createLogCommand } from "./commands/log.js";
 import { createStartCommand } from "./commands/start.js";
 import { createStatusCommand } from "./commands/status.js";
@@ -173,6 +174,7 @@ function buildCommands(): readonly Command[] {
     createSummaryCommand(deps),
     createLogCommand(deps),
     createWeekCommand(deps),
+    createExportCommand(deps),
   ];
 }
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,0 +1,102 @@
+import { type CliIo, type Command, UserError } from "../cli.js";
+import type { Entry } from "../domain/entry.js";
+import { selectExportEntries } from "../domain/export.js";
+import { parsePeriodExpression } from "../domain/period-expression.js";
+import type { Period } from "../domain/period.js";
+import { formatCsvLines, formatJsonLines } from "../format/export.js";
+import { type CommandDeps, rejectUnknownArgs, takeOption } from "./args.js";
+import { ALL_TIME } from "./log.js";
+
+/** 書き出せる形式。 */
+const FORMATTERS = {
+  csv: formatCsvLines,
+  json: formatJsonLines,
+} as const satisfies Record<string, (entries: readonly Entry[]) => string[]>;
+
+type Format = keyof typeof FORMATTERS;
+
+const FORMAT_NAMES = Object.keys(FORMATTERS);
+
+/**
+ * 記録を機械が読む形で標準出力に書き出す。
+ *
+ * ```
+ * tock export --format csv > 2026-08.csv
+ * ```
+ *
+ * 読むだけで何も書かない。該当0件でもエラーにしない（`log` と同じ考え方で、
+ * 「その期間には記録がない」は正常な答えである）。
+ *
+ * **`--format` は省略できない。** 既定を決めると、書き出したファイルの形式が
+ * コマンドの見た目から分からなくなる。取り込み先が csv か json かは利用者が
+ * 分かっていることなので、明示してもらうほうが取り違えが起きない。
+ *
+ * ファイルへの保存はリダイレクト（`>`）に任せ、出力先のオプションは持たない。
+ * 保存先を自前で扱うと、上書きの確認や書き込み失敗の扱いをこのコマンドが
+ * 抱えることになる。標準出力に出しておけば `head` や他のコマンドにも繋げられる。
+ */
+export function createExportCommand(deps: CommandDeps): Command {
+  return {
+    name: "export",
+    summary: "記録を CSV / JSON で書き出す",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const { value: formatValue, rest: afterFormat } = takeOption(argv, "--format");
+      const { value: periodValue, rest } = takeOption(afterFormat, "--period");
+      rejectUnknownArgs(rest, {
+        command: "export",
+        allowedOptions: ["--format", "--period"],
+        allowPositional: false,
+      });
+
+      // 引数の検査をすべて済ませてから store に触る。打ち間違いのときに
+      // ファイルを読む必要はなく、失敗の理由も引数だけで決まる
+      const format = resolveFormat(formatValue);
+      const period = resolvePeriod(periodValue, deps.now());
+
+      const entries = await deps.store.listByRange(period);
+
+      for (const line of FORMATTERS[format](selectExportEntries(entries, period))) {
+        io.out(line);
+      }
+    },
+  };
+}
+
+/**
+ * `--format` の解決。
+ *
+ * 大文字で書かれても受け付ける。`CSV` と打つのは表記の揺れであって別の指定ではなく、
+ * ここで弾いても利用者にできることは打ち直しだけになる。
+ */
+function resolveFormat(value: string | undefined): Format {
+  if (value === undefined) {
+    throw new UserError(`--format を指定してください（${FORMAT_NAMES.join(" / ")}）`);
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!isFormat(normalized)) {
+    throw new UserError(
+      `--format に指定できるのは ${FORMAT_NAMES.join(" / ")} です: ${JSON.stringify(value)}`,
+    );
+  }
+
+  return normalized;
+}
+
+function isFormat(value: string): value is Format {
+  return Object.hasOwn(FORMATTERS, value);
+}
+
+/** `--period` の解決。domain のエラーは利用者向けに翻訳する（domain は `UserError` を知らない）。 */
+function resolvePeriod(value: string | undefined, now: Date): Period {
+  if (value === undefined) {
+    return ALL_TIME;
+  }
+
+  try {
+    return parsePeriodExpression(value, now);
+  } catch (error) {
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -24,8 +24,12 @@ const DECIMAL_POSITIVE_INTEGER = /^[1-9]\d*$/;
  * `Store` には「全件返す」操作が無く、`listByRange` に範囲を渡すしかない。
  * 期間指定なしの `log` は「いつの記録でも新しい順に直近 N 件」なので、
  * 範囲で落とさないよう最大幅を渡す。
+ *
+ * **`export`（#23）も同じものを必要とするため公開している。** 書き写すと、
+ * 片方だけ直したときに「一覧には出るが書き出されない」記録が生まれる。
+ * この細工そのものは `Store` の制約への回避策で、**#57 で解消される**。
  */
-const ALL_TIME: Period = { start: new Date(-8.64e15), end: new Date(8.64e15) };
+export const ALL_TIME: Period = { start: new Date(-8.64e15), end: new Date(8.64e15) };
 
 /**
  * 記録を新しい順に一覧表示する。

--- a/src/domain/export.ts
+++ b/src/domain/export.ts
@@ -1,0 +1,23 @@
+import type { Entry } from "./entry.js";
+import { overlapsPeriod, type Period } from "./period.js";
+
+/**
+ * 書き出しのための記録の選び出し。
+ *
+ * 期間で絞り込み、開始が古い順に並べる。出力の形は `format/export.ts`、
+ * ファイルの読み出しは `store` が持つ。ここは純関数だけで構成する。
+ *
+ * **`clipToPeriod` と違い、期間で切り出さない。** 書き出した各行は `id` を持つので、
+ * 切り出して同じ `id` の行を複数出すと、表計算で集計したときに記録の件数が実態と
+ * 合わなくなる。期間は「その期間に重なる記録を選ぶ」ためだけに使い、記録そのものは
+ * 元の長さで返す（`selectLogRows` と同じ考え方）。
+ *
+ * **並びは `log` と逆の古い順にする。** `log` は「直近の記録を見る」ためのものなので
+ * 新しい順が読みやすいが、書き出したものは表計算に貼って上から時系列に読む。
+ */
+export function selectExportEntries(entries: readonly Entry[], period: Period): Entry[] {
+  const selected = entries.filter((entry) => overlapsPeriod(entry, period));
+
+  // toSorted は元の配列を書き換えず、同じ鍵の要素の順序を保つ（開始時刻が同じ記録は保存順）
+  return selected.toSorted((a, b) => Date.parse(a.start) - Date.parse(b.start));
+}

--- a/src/domain/export.ts
+++ b/src/domain/export.ts
@@ -1,4 +1,4 @@
-import type { Entry } from "./entry.js";
+import { type Entry, startedAt } from "./entry.js";
 import { overlapsPeriod, type Period } from "./period.js";
 
 /**
@@ -19,5 +19,5 @@ export function selectExportEntries(entries: readonly Entry[], period: Period): 
   const selected = entries.filter((entry) => overlapsPeriod(entry, period));
 
   // toSorted は元の配列を書き換えず、同じ鍵の要素の順序を保つ（開始時刻が同じ記録は保存順）
-  return selected.toSorted((a, b) => Date.parse(a.start) - Date.parse(b.start));
+  return selected.toSorted((a, b) => startedAt(a).getTime() - startedAt(b).getTime());
 }

--- a/src/domain/log.ts
+++ b/src/domain/log.ts
@@ -1,5 +1,5 @@
 import { endedAt, type Entry, startedAt } from "./entry.js";
-import type { Period } from "./period.js";
+import { overlapsPeriod, type Period } from "./period.js";
 import { expandTags, normalizeTag } from "./tag.js";
 
 /**
@@ -55,29 +55,6 @@ export function selectLogRows(entries: readonly Entry[], filter: LogFilter, asOf
   const sorted = selected.toSorted((a, b) => b.start.getTime() - a.start.getTime());
 
   return limit === undefined ? sorted : sorted.slice(0, limit);
-}
-
-/**
- * 記録が期間に重なるか。期間は半開区間 `[start, end)`。
- *
- * **実行中の記録は終端が未定なので、開始以降ずっと続くものとして扱う**（`overlaps` と同じ）。
- * これにより「範囲より前に始まって、まだ終わっていない」記録が落ちない。この取りこぼしは
- * 過去に `listByRange` で実際に起きている。
- *
- * 長さ 0 の記録は、半開区間の一般式では何とも重ならない。`clipToPeriod` と同じく
- * 「開始が期間内なら残す」に揃える。記録したものが一覧から黙って消えるほうが不都合が大きい。
- */
-function overlapsPeriod(entry: Entry, period: Period): boolean {
-  const from = startedAt(entry).getTime();
-  const to = endedAt(entry)?.getTime() ?? Number.POSITIVE_INFINITY;
-  const periodStart = period.start.getTime();
-  const periodEnd = period.end.getTime();
-
-  if (from === to) {
-    return from >= periodStart && from < periodEnd;
-  }
-
-  return from < periodEnd && to > periodStart;
 }
 
 /**

--- a/src/domain/period.ts
+++ b/src/domain/period.ts
@@ -162,6 +162,37 @@ export function overlaps(a: Entry, b: Entry): boolean {
   return aStart < bEnd && bStart < aEnd;
 }
 
+/**
+ * 記録が期間に重なるか。期間は半開区間 `[start, end)`。
+ *
+ * **実行中の記録は終端が未定なので、開始以降ずっと続くものとして扱う**（`overlaps` と同じ）。
+ * これにより「範囲より前に始まって、まだ終わっていない」記録が落ちない。この取りこぼしは
+ * 過去に `listByRange` で実際に起きている。
+ *
+ * 長さ 0 の記録は、半開区間の一般式では何とも重ならない。`clipToPeriod` と同じく
+ * 「開始が期間内なら残す」に揃える。記録したものが一覧から黙って消えるほうが不都合が大きい。
+ *
+ * **`overlaps`（エントリ同士）と違い、長さ 0 を落とさない。** あちらは二重打刻の検出が
+ * 目的で、瞬間の記録は二重打刻にならない。こちらは集計・一覧・書き出しのための抽出で、
+ * 記録が黙って消えないことを優先する。
+ *
+ * 選び出しの意味を1箇所に置くために、`log`（#16）と `export`（#23）は同じこの関数を通す。
+ * 同じ判定を各所に書き写すと、片方だけ直したときに「一覧には出るが書き出されない」
+ * といった食い違いが生まれる。
+ */
+export function overlapsPeriod(entry: Entry, period: Period): boolean {
+  const from = startMs(entry);
+  const to = endMs(entry) ?? Number.POSITIVE_INFINITY;
+  const periodStart = period.start.getTime();
+  const periodEnd = period.end.getTime();
+
+  if (from === to) {
+    return from >= periodStart && from < periodEnd;
+  }
+
+  return from < periodEnd && to > periodStart;
+}
+
 function assertValidPeriod(period: Period): void {
   if (Number.isNaN(period.start.getTime()) || Number.isNaN(period.end.getTime())) {
     throw new Error("期間の境界が不正な Date です");

--- a/src/format/csv.ts
+++ b/src/format/csv.ts
@@ -1,0 +1,39 @@
+/**
+ * CSV の組み立て。
+ *
+ * 依存を増やさずに済ませるため自前で持つ（`CLAUDE.md`「依存ライブラリの追加ルール」）。
+ * 必要なのは書き出しだけで、規則も RFC 4180 の引用規則だけに収まる。
+ *
+ * **改行は LF。** RFC 4180 は CRLF を定めているが、この CLI の出力は `CliIo` が1行ずつ
+ * 改行を付けて書く形になっており、行の区切りを整形側から選べない。Excel・Numbers・
+ * Google スプレッドシートはいずれも LF 区切りの CSV を読める。
+ */
+
+/** 引用が必要になる文字。カンマ・引用符・改行（CR / LF）。 */
+const NEEDS_QUOTING = /[",\r\n]/;
+
+/** フィールドの区切り。 */
+const SEPARATOR = ",";
+
+/** 引用符。 */
+const QUOTE = '"';
+
+/**
+ * 値1つを CSV のフィールドにする。
+ *
+ * カンマ・引用符・改行を含む値は引用符で囲み、値の中の引用符は2つ重ねる。
+ * それ以外はそのまま返す（不要な引用符を付けると、表計算に読ませたときの
+ * 見た目が変わるわけではないが、diff や目視での確認がしづらくなる）。
+ */
+export function csvField(value: string): string {
+  if (!NEEDS_QUOTING.test(value)) {
+    return value;
+  }
+
+  return QUOTE + value.replaceAll(QUOTE, QUOTE + QUOTE) + QUOTE;
+}
+
+/** 値の並びを CSV の1行にする。空の値も列として残す。 */
+export function csvLine(fields: readonly string[]): string {
+  return fields.map(csvField).join(SEPARATOR);
+}

--- a/src/format/export.ts
+++ b/src/format/export.ts
@@ -1,0 +1,89 @@
+import type { Entry } from "../domain/entry.js";
+import { durationMs } from "../domain/period.js";
+import { csvLine } from "./csv.js";
+
+/**
+ * 記録を機械が読む形に整える。
+ *
+ * **時刻は保存されている ISO 8601（UTC）をそのまま出す。** 書き出したものは表計算や
+ * 別のツールが読むため、地域や表記の揺れを持ち込まない形が要る。人が読むための
+ * 表記に直す話（#45）は画面向けの出力の担当で、ここには入れない。
+ */
+
+/**
+ * CSV の列の順序。**この並びは固定する。**
+ *
+ * 書き出したものを取り込む側は列の位置に依存する。並べ替えると、既にある取り込み手順が
+ * 黙って壊れる（列名は合っているのに中身が入れ替わる）。
+ */
+export const CSV_HEADER = ["id", "start", "end", "duration_min", "tags", "note"] as const;
+
+/** タグを1つの欄にまとめるときの区切り。 */
+const TAG_SEPARATOR = " ";
+
+/** `duration_min` の小数の桁数。 */
+const DURATION_DECIMALS = 2;
+
+const MS_PER_MINUTE = 60 * 1000;
+
+/**
+ * 記録を CSV の行にする。先頭は必ず見出し行。
+ *
+ * ```
+ * id,start,end,duration_min,tags,note
+ * a1b2,2026-08-13T00:00:00.000Z,2026-08-13T01:30:00.000Z,90,work proj/tock,設計
+ * ```
+ *
+ * **記録が0件でも見出し行だけは出す。** 列名のない空のファイルを表計算で開いても
+ * 何のデータか分からず、取り込み側の処理も列を見つけられない。
+ */
+export function formatCsvLines(entries: readonly Entry[]): string[] {
+  return [csvLine([...CSV_HEADER]), ...entries.map((entry) => csvLine(cellsOf(entry)))];
+}
+
+/**
+ * 1件分の各列の値。**列の数は常に `CSV_HEADER` と同じ。**
+ *
+ * 実行中の記録は `end` と `duration_min` を空欄にする。経過時間を入れると、同じ記録を
+ * 書き出すたびに値が変わる報告ができてしまう。まだ終わっていないことは空欄で表す。
+ */
+function cellsOf(entry: Entry): string[] {
+  return [
+    entry.id,
+    entry.start,
+    entry.end ?? "",
+    entry.end === undefined ? "" : formatMinutes(durationMs(entry)),
+    entry.tags.join(TAG_SEPARATOR),
+    entry.note ?? "",
+  ];
+}
+
+/**
+ * 長さを分で表す。小数第2位まで（それ未満は四捨五入）。
+ *
+ * **これは表示の桁であって、工数の丸め（#7）ではない。** 15分単位に切り上げるといった
+ * 集計の規則はここでは適用しない。丸めの単位とどこで適用するかは設定（#22）で決める話で、
+ * 書き出しが勝手に決めてよいものではない。
+ *
+ * 正確な時刻は `start` と `end` の列にそのまま残るため、この桁で落ちた端数は
+ * 取り込み側で必要なら計算し直せる。
+ */
+function formatMinutes(ms: number): string {
+  const scale = 10 ** DURATION_DECIMALS;
+
+  return String(Math.round((ms / MS_PER_MINUTE) * scale) / scale);
+}
+
+/**
+ * 記録を JSON の行にする。
+ *
+ * **保存されている `Entry` をそのまま並べる。** 列名を付け替えたり長さを足したりすると、
+ * 書き出したものを読み戻して記録として扱えなくなる。派生した値（長さ）は `start` と
+ * `end` から計算できるので持たせない。
+ *
+ * 実行中の記録は `end` の欄を持たない。`Entry` が「実行中は未設定」と定めているため、
+ * `null` を入れると読み戻したときに別の意味になる。
+ */
+export function formatJsonLines(entries: readonly Entry[]): string[] {
+  return JSON.stringify(entries, null, 2).split("\n");
+}

--- a/src/format/export.ts
+++ b/src/format/export.ts
@@ -1,5 +1,5 @@
 import type { Entry } from "../domain/entry.js";
-import { durationMs } from "../domain/period.js";
+import { durationMinutes } from "../domain/period.js";
 import { csvLine } from "./csv.js";
 
 /**
@@ -20,11 +20,6 @@ export const CSV_HEADER = ["id", "start", "end", "duration_min", "tags", "note"]
 
 /** タグを1つの欄にまとめるときの区切り。 */
 const TAG_SEPARATOR = " ";
-
-/** `duration_min` の小数の桁数。 */
-const DURATION_DECIMALS = 2;
-
-const MS_PER_MINUTE = 60 * 1000;
 
 /**
  * 記録を CSV の行にする。先頭は必ず見出し行。
@@ -52,26 +47,28 @@ function cellsOf(entry: Entry): string[] {
     entry.id,
     entry.start,
     entry.end ?? "",
-    entry.end === undefined ? "" : formatMinutes(durationMs(entry)),
+    entry.end === undefined ? "" : formatMinutes(entry),
     entry.tags.join(TAG_SEPARATOR),
     entry.note ?? "",
   ];
 }
 
 /**
- * 長さを分で表す。小数第2位まで（それ未満は四捨五入）。
+ * 長さを分で表す。**桁を落とさない。**
  *
- * **これは表示の桁であって、工数の丸め（#7）ではない。** 15分単位に切り上げるといった
- * 集計の規則はここでは適用しない。丸めの単位とどこで適用するかは設定（#22）で決める話で、
- * 書き出しが勝手に決めてよいものではない。
+ * 当初は小数第2位で四捨五入していたが、**それ自体が集計を壊す。** この列は表計算で
+ * `SUM` される前提のもので、行ごとに丸めると誤差が同じ向きに積み上がる。1秒の記録が
+ * 40件あると、実際の合計 0.667分 に対して丸めた列の合計は 0.8分 になる（レビューで指摘）。
  *
- * 正確な時刻は `start` と `end` の列にそのまま残るため、この桁で落ちた端数は
- * 取り込み側で必要なら計算し直せる。
+ * 分は 60 で割った値なので、そもそも有限小数で正確に表せない（1秒 = 0.016666…分）。
+ * 桁で妥協するのではなく、`durationMinutes`（#6）が返す値をそのまま出す。`String` は
+ * 元の数値に戻せる最短の表記を選ぶので、取り込み側で足しても系統的なずれが出ない。
+ *
+ * **工数の丸め（#7）はここでは適用しない。** 15分単位に切り上げるといった集計の規則は
+ * 設定（#22）で決める話で、書き出しが勝手に決めてよいものではない。
  */
-function formatMinutes(ms: number): string {
-  const scale = 10 ** DURATION_DECIMALS;
-
-  return String(Math.round((ms / MS_PER_MINUTE) * scale) / scale);
+function formatMinutes(entry: Entry): string {
+  return String(durationMinutes(entry));
 }
 
 /**

--- a/tests/commands/export.test.ts
+++ b/tests/commands/export.test.ts
@@ -1,0 +1,343 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createExportCommand } from "../../src/commands/export.js";
+import { createStartCommand } from "../../src/commands/start.js";
+import { createStopCommand } from "../../src/commands/stop.js";
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+let idCounter = 0;
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-export-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+  idCounter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return {
+    store,
+    now: () => now,
+    newId: () => {
+      idCounter += 1;
+      return `id-${String(idCounter)}`;
+    },
+  };
+}
+
+/** ローカルの壁時計で日時を組み立てる。テストを実行環境の TZ に依存させない。 */
+function local(day: number, hours: number, minutes = 0, seconds = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, day);
+  date.setHours(hours, minutes, seconds, 0);
+
+  return date;
+}
+
+/** 指定した時刻に開始して指定した時刻に終了した記録を作る。 */
+async function record(start: Date, end: Date, description: string): Promise<void> {
+  await createStartCommand(deps(start)).run([description], io);
+  await createStopCommand(deps(end)).run([], io);
+  out = [];
+}
+
+/** 停止していない記録を作る。 */
+async function startOnly(start: Date, description: string): Promise<void> {
+  await createStartCommand(deps(start)).run([description], io);
+  out = [];
+}
+
+const NOW = local(13, 12);
+
+/** CSV の1行を列に割る。引用符を含まない行にだけ使う。 */
+function columns(line: string): string[] {
+  return line.split(",");
+}
+
+describe("export の引数", () => {
+  it("--format が無ければエラーにし、使える値を示す", async () => {
+    await expect(createExportCommand(deps(NOW)).run([], io)).rejects.toThrow(UserError);
+    await expect(createExportCommand(deps(NOW)).run([], io)).rejects.toThrow(
+      /csv.*json|json.*csv/s,
+    );
+  });
+
+  it("知らない形式はエラーにする", async () => {
+    await expect(createExportCommand(deps(NOW)).run(["--format", "xml"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("空文字の形式もエラーにする（境界）", async () => {
+    await expect(createExportCommand(deps(NOW)).run(["--format", ""], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("大文字で書かれた形式も受け付ける", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "CSV"], io);
+
+    expect(out[0]).toBe("id,start,end,duration_min,tags,note");
+  });
+
+  it("知らないオプションはエラーにする", async () => {
+    await expect(
+      createExportCommand(deps(NOW)).run(["--format", "csv", "--limit", "3"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("解釈できない期間はエラーにする", async () => {
+    await expect(
+      createExportCommand(deps(NOW)).run(["--format", "csv", "--period", "nonsense"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("引数の検査は store を読む前に行う（記録が壊れていても打ち間違いを先に返す）", async () => {
+    const broken: Store = {
+      append: () => Promise.reject(new Error("読めません")),
+      update: () => Promise.reject(new Error("読めません")),
+      delete: () => Promise.reject(new Error("読めません")),
+      listByRange: () => Promise.reject(new Error("読めません")),
+      findRunning: () => Promise.reject(new Error("読めません")),
+    };
+
+    await expect(
+      createExportCommand({ ...deps(NOW), store: broken }).run(["--format", "xml"], io),
+    ).rejects.toThrow(UserError);
+  });
+});
+
+describe("export --format csv", () => {
+  it("記録を古い順に1行ずつ出す", async () => {
+    await record(local(13, 11), local(13, 12), "レビュー #work");
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(out).toHaveLength(3);
+    expect(out[1]).toContain("設計");
+    expect(out[2]).toContain("レビュー");
+    expect(err).toEqual([]);
+  });
+
+  it("記録が1件も無くても見出し行を出す（境界）", async () => {
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(out).toEqual(["id,start,end,duration_min,tags,note"]);
+  });
+
+  it("長さを分で出す", async () => {
+    await record(local(13, 9), local(13, 10, 30), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(columns(out[1] ?? "")[3]).toBe("90");
+  });
+
+  it("実行中の記録は end と duration_min を空欄にする（終端のないデータ）", async () => {
+    await startOnly(local(13, 9), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    const cells = columns(out[1] ?? "");
+    expect(cells[2]).toBe("");
+    expect(cells[3]).toBe("");
+    expect(cells[4]).toBe("work");
+  });
+
+  it("エスケープが必要な文字を含む作業名を1つの列に収める（DoD）", async () => {
+    const entry = createEntry(
+      {
+        start: local(13, 9),
+        end: local(13, 10),
+        tags: ["work"],
+        note: '"至急", 対応',
+      },
+      { newId: () => "id-escape" },
+    );
+    await store.append(entry);
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(out[1]).toBe(`id-escape,${entry.start},${entry.end ?? ""},60,work,"""至急"", 対応"`);
+  });
+
+  it("改行を含む作業名も引用符で囲んで出す（DoD）", async () => {
+    const entry = createEntry(
+      { start: local(13, 9), end: local(13, 10), note: "1行目\n2行目" },
+      { newId: () => "id-newline" },
+    );
+    await store.append(entry);
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(out[1]?.endsWith(',"1行目\n2行目"')).toBe(true);
+  });
+});
+
+describe("export --period（DoD）", () => {
+  it("期間を指定すると、その期間に重なる記録だけを出す", async () => {
+    await record(local(12, 9), local(12, 10), "前日 #work");
+    await record(local(13, 9), local(13, 10), "当日 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv", "--period", "today"], io);
+
+    expect(out).toHaveLength(2);
+    expect(out[1]).toContain("当日");
+  });
+
+  it("日付の範囲を指定できる", async () => {
+    await record(local(11, 9), local(11, 10), "11日 #work");
+    await record(local(12, 9), local(12, 10), "12日 #work");
+    await record(local(13, 9), local(13, 10), "13日 #work");
+
+    await createExportCommand(deps(NOW)).run(
+      ["--format", "csv", "--period", "2026-08-11..2026-08-12"],
+      io,
+    );
+
+    expect(out).toHaveLength(3);
+    expect(out[1]).toContain("11日");
+    expect(out[2]).toContain("12日");
+  });
+
+  it("期間を省略するとすべての記録を出す", async () => {
+    await record(local(1, 9), local(1, 10), "8月1日 #work");
+    await record(local(13, 9), local(13, 10), "8月13日 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv"], io);
+
+    expect(out).toHaveLength(3);
+  });
+
+  it("該当する記録が無ければ見出し行だけを出す（境界）", async () => {
+    await record(local(12, 9), local(12, 10), "前日 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv", "--period", "today"], io);
+
+    expect(out).toEqual(["id,start,end,duration_min,tags,note"]);
+  });
+
+  it("期間より前に始まって、まだ終わっていない記録も出す（終端のないデータ）", async () => {
+    await startOnly(local(12, 23), "夜間作業 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv", "--period", "today"], io);
+
+    expect(out).toHaveLength(2);
+    expect(out[1]).toContain("夜間作業");
+  });
+
+  it("期間をまたぐ記録は切り出さず、元の長さのまま出す", async () => {
+    await record(local(12, 23), local(13, 1), "夜間作業 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "csv", "--period", "today"], io);
+
+    expect(out).toHaveLength(2);
+    expect(columns(out[1] ?? "")[3]).toBe("120");
+  });
+
+  it("期間の指定は json でも効く", async () => {
+    await record(local(12, 9), local(12, 10), "前日 #work");
+    await record(local(13, 9), local(13, 10), "当日 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "json", "--period", "today"], io);
+
+    const parsed = JSON.parse(out.join("\n")) as Entry[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.note).toBe("当日");
+  });
+});
+
+describe("export --format json（DoD）", () => {
+  it("出力全体が1つの JSON の配列になっている", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "json"], io);
+
+    const parsed: unknown = JSON.parse(out.join("\n"));
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it("記録が1件も無ければ空の配列を出す（境界）", async () => {
+    await createExportCommand(deps(NOW)).run(["--format", "json"], io);
+
+    expect(JSON.parse(out.join("\n"))).toEqual([]);
+  });
+
+  it("出力をそのまま Entry として作り直せる（再取り込み可能）", async () => {
+    const original = createEntry(
+      {
+        start: local(13, 9),
+        end: local(13, 10),
+        tags: ["work", "proj/tock"],
+        note: '"至急", 対応\n続き',
+      },
+      { newId: () => "id-roundtrip" },
+    );
+    await store.append(original);
+    await startOnly(local(13, 11), "実装 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "json"], io);
+
+    const parsed = JSON.parse(out.join("\n")) as Entry[];
+    const rebuilt = parsed.map((entry) => createEntry(entry, { newId: () => entry.id }));
+
+    expect(rebuilt).toEqual(parsed);
+    expect(rebuilt[0]).toEqual(original);
+  });
+
+  it("読み戻した記録をそのまま保存し直せる", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+    await createExportCommand(deps(NOW)).run(["--format", "json"], io);
+
+    const parsed = JSON.parse(out.join("\n")) as Entry[];
+    const otherDir = await mkdtemp(join(tmpdir(), "tock-export-import-"));
+    const otherStore = createJsonlStore(join(otherDir, "entries.jsonl"));
+    for (const entry of parsed) {
+      await otherStore.append(createEntry(entry, { newId: () => entry.id }));
+    }
+
+    const restored = await otherStore.listByRange({
+      start: local(13, 0),
+      end: local(14, 0),
+    });
+    await rm(otherDir, { recursive: true, force: true });
+
+    expect(restored).toEqual(parsed);
+  });
+
+  it("実行中の記録は end を持たないまま出す（終端のないデータ）", async () => {
+    await startOnly(local(13, 9), "設計 #work");
+
+    await createExportCommand(deps(NOW)).run(["--format", "json"], io);
+
+    const [entry] = JSON.parse(out.join("\n")) as Record<string, unknown>[];
+    expect(entry).not.toHaveProperty("end");
+  });
+});

--- a/tests/domain/export.test.ts
+++ b/tests/domain/export.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import { selectExportEntries } from "../../src/domain/export.js";
+import type { Period } from "../../src/domain/period.js";
+
+let counter = 0;
+
+function entry(start: string, end?: string, tags: readonly string[] = []): Entry {
+  counter += 1;
+  const id = `id-${String(counter)}`;
+
+  return createEntry({ start, ...(end === undefined ? {} : { end }), tags }, { newId: () => id });
+}
+
+/** 2026-08-13 の1日（UTC）。境界の検証に使う。 */
+const DAY: Period = {
+  start: new Date("2026-08-13T00:00:00.000Z"),
+  end: new Date("2026-08-14T00:00:00.000Z"),
+};
+
+describe("selectExportEntries の期間による絞り込み", () => {
+  it("期間に重なる記録だけを返す", () => {
+    const inside = entry("2026-08-13T09:00:00.000Z", "2026-08-13T10:00:00.000Z");
+    const before = entry("2026-08-12T09:00:00.000Z", "2026-08-12T10:00:00.000Z");
+    const after = entry("2026-08-14T09:00:00.000Z", "2026-08-14T10:00:00.000Z");
+
+    const selected = selectExportEntries([before, inside, after], DAY);
+
+    expect(selected.map((row) => row.id)).toEqual([inside.id]);
+  });
+
+  it("期間をまたぐ記録は切り出さず、元の長さのまま返す", () => {
+    const crossing = entry("2026-08-12T23:00:00.000Z", "2026-08-13T01:00:00.000Z");
+
+    const selected = selectExportEntries([crossing], DAY);
+
+    expect(selected).toEqual([crossing]);
+  });
+
+  it("期間の終わりに接するだけの記録は含めない（半開区間）", () => {
+    const touching = entry("2026-08-12T23:00:00.000Z", "2026-08-13T00:00:00.000Z");
+
+    expect(selectExportEntries([touching], DAY)).toEqual([]);
+  });
+
+  it("期間の始まりに接するだけの記録は含める（半開区間）", () => {
+    const touching = entry("2026-08-13T00:00:00.000Z", "2026-08-13T00:30:00.000Z");
+
+    expect(selectExportEntries([touching], DAY)).toEqual([touching]);
+  });
+
+  it("開始が期間内なら長さ 0 の記録も残す", () => {
+    const zero = entry("2026-08-13T09:00:00.000Z", "2026-08-13T09:00:00.000Z");
+
+    expect(selectExportEntries([zero], DAY)).toEqual([zero]);
+  });
+
+  it("長さ 0 の記録が期間の終わりちょうどなら含めない（境界）", () => {
+    const zero = entry("2026-08-14T00:00:00.000Z", "2026-08-14T00:00:00.000Z");
+
+    expect(selectExportEntries([zero], DAY)).toEqual([]);
+  });
+
+  it("記録が1件も無ければ空を返す（境界）", () => {
+    expect(selectExportEntries([], DAY)).toEqual([]);
+  });
+});
+
+describe("selectExportEntries と終端のない記録", () => {
+  it("期間より前に始まって、まだ終わっていない記録を含める", () => {
+    const running = entry("2026-08-12T23:00:00.000Z");
+
+    expect(selectExportEntries([running], DAY)).toEqual([running]);
+  });
+
+  it("期間の中で始まって、まだ終わっていない記録を含める", () => {
+    const running = entry("2026-08-13T09:00:00.000Z");
+
+    expect(selectExportEntries([running], DAY)).toEqual([running]);
+  });
+
+  it("期間より後に始まった実行中の記録は含めない", () => {
+    const running = entry("2026-08-14T09:00:00.000Z");
+
+    expect(selectExportEntries([running], DAY)).toEqual([]);
+  });
+
+  it("実行中の記録の開始が期間の始まりとちょうど一致すれば含める", () => {
+    const running = entry("2026-08-13T00:00:00.000Z");
+
+    expect(selectExportEntries([running], DAY)).toEqual([running]);
+  });
+
+  it("実行中の記録の開始が期間の終わりとちょうど一致すれば含めない", () => {
+    const running = entry("2026-08-14T00:00:00.000Z");
+
+    expect(selectExportEntries([running], DAY)).toEqual([]);
+  });
+});
+
+describe("selectExportEntries の並び順", () => {
+  it("開始が古い順に並べる（表計算に貼ったときの自然な順）", () => {
+    const late = entry("2026-08-13T15:00:00.000Z", "2026-08-13T16:00:00.000Z");
+    const early = entry("2026-08-13T09:00:00.000Z", "2026-08-13T10:00:00.000Z");
+    const middle = entry("2026-08-13T12:00:00.000Z", "2026-08-13T13:00:00.000Z");
+
+    const selected = selectExportEntries([late, early, middle], DAY);
+
+    expect(selected.map((row) => row.id)).toEqual([early.id, middle.id, late.id]);
+  });
+
+  it("開始が同時刻の記録は保存された順を保つ", () => {
+    const first = entry("2026-08-13T09:00:00.000Z", "2026-08-13T09:30:00.000Z");
+    const second = entry("2026-08-13T09:00:00.000Z", "2026-08-13T10:00:00.000Z");
+
+    const selected = selectExportEntries([first, second], DAY);
+
+    expect(selected.map((row) => row.id)).toEqual([first.id, second.id]);
+  });
+
+  it("渡された配列を書き換えない", () => {
+    const late = entry("2026-08-13T15:00:00.000Z", "2026-08-13T16:00:00.000Z");
+    const early = entry("2026-08-13T09:00:00.000Z", "2026-08-13T10:00:00.000Z");
+    const source = [late, early];
+
+    selectExportEntries(source, DAY);
+
+    expect(source.map((row) => row.id)).toEqual([late.id, early.id]);
+  });
+});

--- a/tests/format/csv.test.ts
+++ b/tests/format/csv.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { csvField, csvLine } from "../../src/format/csv.js";
+
+describe("csvField のエスケープ", () => {
+  it("特別な文字を含まない値はそのまま返す", () => {
+    expect(csvField("設計")).toBe("設計");
+  });
+
+  it("空文字はそのまま返す（境界）", () => {
+    expect(csvField("")).toBe("");
+  });
+
+  it("カンマを含む値は引用符で囲む", () => {
+    expect(csvField("設計, 実装")).toBe('"設計, 実装"');
+  });
+
+  it("引用符を含む値は引用符を2つ重ねて囲む", () => {
+    expect(csvField('"至急"の対応')).toBe('"""至急""の対応"');
+  });
+
+  it("引用符だけの値も壊れない（境界）", () => {
+    expect(csvField('"')).toBe('""""');
+  });
+
+  it("改行（LF）を含む値は引用符で囲む", () => {
+    expect(csvField("1行目\n2行目")).toBe('"1行目\n2行目"');
+  });
+
+  it("復帰（CR）を含む値は引用符で囲む", () => {
+    expect(csvField("1行目\r2行目")).toBe('"1行目\r2行目"');
+  });
+
+  it("CRLF を含む値は引用符で囲む", () => {
+    expect(csvField("1行目\r\n2行目")).toBe('"1行目\r\n2行目"');
+  });
+
+  it("カンマ・引用符・改行が同時にあっても1つのフィールドにまとまる", () => {
+    expect(csvField('a,b"c\nd')).toBe('"a,b""c\nd"');
+  });
+});
+
+describe("csvLine", () => {
+  it("フィールドをカンマでつなぐ", () => {
+    expect(csvLine(["a", "b", "c"])).toBe("a,b,c");
+  });
+
+  it("エスケープが必要なフィールドだけを引用符で囲む", () => {
+    expect(csvLine(["a", "b,c", "d"])).toBe('a,"b,c",d');
+  });
+
+  it("空のフィールドを含む行も列の数を保つ（境界）", () => {
+    expect(csvLine(["a", "", "c"])).toBe("a,,c");
+  });
+
+  it("フィールドが1つも無ければ空行になる（境界）", () => {
+    expect(csvLine([])).toBe("");
+  });
+});

--- a/tests/format/export.test.ts
+++ b/tests/format/export.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import { CSV_HEADER, formatCsvLines, formatJsonLines } from "../../src/format/export.js";
+
+let counter = 0;
+
+function entry(input: {
+  start: string;
+  end?: string;
+  tags?: readonly string[];
+  note?: string;
+}): Entry {
+  counter += 1;
+  const id = `id-${String(counter)}`;
+
+  return createEntry(input, { newId: () => id });
+}
+
+/** CSV の1行を列に割る。引用符を含まない行にだけ使う。 */
+function columns(line: string): string[] {
+  return line.split(",");
+}
+
+describe("formatCsvLines の見出し行", () => {
+  it("列の順序が id, start, end, duration_min, tags, note で固定されている", () => {
+    const lines = formatCsvLines([]);
+
+    expect(lines[0]).toBe("id,start,end,duration_min,tags,note");
+    expect(CSV_HEADER).toEqual(["id", "start", "end", "duration_min", "tags", "note"]);
+  });
+
+  it("記録が0件でも見出し行だけは出す（境界）", () => {
+    expect(formatCsvLines([])).toEqual(["id,start,end,duration_min,tags,note"]);
+  });
+});
+
+describe("formatCsvLines の各列", () => {
+  it("時刻は保存されている ISO 8601（UTC）をそのまま出す", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T10:30:00.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[1]).toBe("2026-08-13T09:00:00.000Z");
+    expect(columns(line)[2]).toBe("2026-08-13T10:30:00.000Z");
+  });
+
+  it("duration_min は分で出す", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T10:30:00.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[3]).toBe("90");
+  });
+
+  it("1分に満たない長さは小数で出す", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T09:00:30.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[3]).toBe("0.5");
+  });
+
+  it("割り切れない秒は小数第2位までにする", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T09:01:01.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[3]).toBe("1.02");
+  });
+
+  it("長さ 0 の記録は 0 と出す（境界）", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T09:00:00.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[3]).toBe("0");
+  });
+
+  it("日をまたぐ記録も分割せず1行で出す", () => {
+    const row = entry({ start: "2026-08-13T23:00:00.000Z", end: "2026-08-14T01:00:00.000Z" });
+
+    const lines = formatCsvLines([row]);
+
+    expect(lines).toHaveLength(2);
+    expect(columns(lines[1] ?? "")[3]).toBe("120");
+  });
+
+  it("タグは空白区切りで出す（# は付けない）", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      tags: ["work", "proj/tock"],
+    });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[4]).toBe("work proj/tock");
+  });
+
+  it("タグが無ければ空欄にする（境界）", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T10:00:00.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[4]).toBe("");
+  });
+
+  it("作業名が無ければ空欄にする（境界）", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T10:00:00.000Z" });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)[5]).toBe("");
+  });
+});
+
+describe("formatCsvLines と終端のない記録", () => {
+  it("実行中の記録は end と duration_min を空欄にする", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z", tags: ["work"] });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(columns(line)).toEqual([row.id, "2026-08-13T09:00:00.000Z", "", "", "work", ""]);
+  });
+
+  it("実行中の記録でも列の数は変わらない", () => {
+    const running = entry({ start: "2026-08-13T09:00:00.000Z" });
+    const done = entry({ start: "2026-08-13T10:00:00.000Z", end: "2026-08-13T11:00:00.000Z" });
+
+    const [, first = "", second = ""] = formatCsvLines([running, done]);
+
+    expect(columns(first)).toHaveLength(CSV_HEADER.length);
+    expect(columns(second)).toHaveLength(CSV_HEADER.length);
+  });
+});
+
+describe("formatCsvLines のエスケープ", () => {
+  it("カンマを含む作業名を1つの列に収める", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      note: "設計, 実装",
+    });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(line.endsWith(',"設計, 実装"')).toBe(true);
+  });
+
+  it("引用符を含む作業名は引用符を2つ重ねる", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      note: '"至急"の対応',
+    });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(line.endsWith(',"""至急""の対応"')).toBe(true);
+  });
+
+  it("改行を含む作業名は引用符で囲む（行数は増える）", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      note: "1行目\n2行目",
+    });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(line.endsWith(',"1行目\n2行目"')).toBe(true);
+  });
+});
+
+describe("formatJsonLines", () => {
+  it("記録の配列をそのまま JSON にする", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      tags: ["work"],
+      note: "設計",
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonLines([row]).join("\n"));
+
+    expect(parsed).toEqual([row]);
+  });
+
+  it("記録が0件なら空の配列にする（境界）", () => {
+    const parsed: unknown = JSON.parse(formatJsonLines([]).join("\n"));
+
+    expect(parsed).toEqual([]);
+  });
+
+  it("実行中の記録では end の欄を持たない（実行中のまま読み戻せる）", () => {
+    const row = entry({ start: "2026-08-13T09:00:00.000Z" });
+
+    const [parsed] = JSON.parse(formatJsonLines([row]).join("\n")) as Record<string, unknown>[];
+
+    expect(parsed).not.toHaveProperty("end");
+    expect(parsed?.["start"]).toBe("2026-08-13T09:00:00.000Z");
+  });
+
+  it("エスケープが必要な文字を含む作業名も読み戻せる", () => {
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      note: '"至急", 1行目\n2行目',
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonLines([row]).join("\n"));
+
+    expect(parsed).toEqual([row]);
+  });
+
+  it("そのまま Entry として作り直せる（再取り込み可能）", () => {
+    const rows = [
+      entry({
+        start: "2026-08-13T09:00:00.000Z",
+        end: "2026-08-13T10:00:00.000Z",
+        tags: ["work", "proj/tock"],
+        note: '"至急", 対応\n続き',
+      }),
+      entry({ start: "2026-08-13T23:00:00.000Z", end: "2026-08-14T01:00:00.000Z" }),
+      entry({ start: "2026-08-14T09:00:00.000Z", tags: ["work"] }),
+    ];
+
+    const parsed = JSON.parse(formatJsonLines(rows).join("\n")) as Entry[];
+    const rebuilt = parsed.map((row) => createEntry(row, { newId: () => row.id }));
+
+    expect(rebuilt).toEqual(rows);
+  });
+});

--- a/tests/format/export.test.ts
+++ b/tests/format/export.test.ts
@@ -61,12 +61,29 @@ describe("formatCsvLines の各列", () => {
     expect(columns(line)[3]).toBe("0.5");
   });
 
-  it("割り切れない秒は小数第2位までにする", () => {
+  it("割り切れない秒でも桁を落とさない（行ごとに丸めない）", () => {
     const row = entry({ start: "2026-08-13T09:00:00.000Z", end: "2026-08-13T09:01:01.000Z" });
 
     const [, line = ""] = formatCsvLines([row]);
 
-    expect(columns(line)[3]).toBe("1.02");
+    expect(columns(line)[3]).toBe(String(61 / 60));
+  });
+
+  it("duration_min を足した合計が、実際の経過時間の合計と一致する", () => {
+    // 行ごとに丸めると誤差が同じ向きに積み上がる。1秒の記録40件で
+    // 実際の 0.667分 に対し、小数第2位に丸めた列の合計は 0.8分 になっていた
+    const rows = Array.from({ length: 40 }, (_index, offset) =>
+      entry({
+        start: `2026-08-13T09:${String(offset).padStart(2, "0")}:00.000Z`,
+        end: `2026-08-13T09:${String(offset).padStart(2, "0")}:01.000Z`,
+      }),
+    );
+
+    const total = formatCsvLines(rows)
+      .slice(1)
+      .reduce((sum, line) => sum + Number(columns(line)[3]), 0);
+
+    expect(total).toBeCloseTo((40 * 1000) / 60_000, 10);
   });
 
   it("長さ 0 の記録は 0 と出す（境界）", () => {
@@ -158,6 +175,21 @@ describe("formatCsvLines のエスケープ", () => {
     const [, line = ""] = formatCsvLines([row]);
 
     expect(line.endsWith(',"""至急""の対応"')).toBe(true);
+  });
+
+  it("カンマを含むタグも1つの列に収める", () => {
+    // normalizeTag は空白を弾くがカンマは通す（`#a,b` は妥当なタグ）。
+    // タグ列の引用を外すと、この行だけ列がずれる
+    const row = entry({
+      start: "2026-08-13T09:00:00.000Z",
+      end: "2026-08-13T10:00:00.000Z",
+      tags: ["a,b", "work"],
+      note: "設計",
+    });
+
+    const [, line = ""] = formatCsvLines([row]);
+
+    expect(line).toBe(`${row.id},${row.start},${row.end ?? ""},60,"a,b work",設計`);
   });
 
   it("改行を含む作業名は引用符で囲む（行数は増える）", () => {


### PR DESCRIPTION
## 概要

`tock export --format csv|json [--period <期間>]` を追加した。記録を機械が読む形で
標準出力に出し、`>` でファイルに保存できるようにする。

- `src/domain/export.ts` — 期間で選び出し、古い順に並べる（`selectExportEntries`）
- `src/format/csv.ts` — CSV の引用規則（`csvField` / `csvLine`）
- `src/format/export.ts` — 列の並びと各列の値（`CSV_HEADER` / `formatCsvLines` / `formatJsonLines`）
- `src/commands/export.ts` — 引数の解釈と出力

Closes #23

### 設計の理由

**時刻は保存されている ISO 8601（UTC）をそのまま出す。** 書き出したものは表計算や
別のツールが読むので、表記の揺れを持ち込まない形が要る。人が読む表記に直す話（#45）は
画面向けの出力の担当で、ここには入れない。

**JSON は保存されている `Entry` をそのまま並べる。** 列名を付け替えたり長さを足したり
すると、読み戻して記録として扱えなくなる。長さは `start` と `end` から計算できるので
持たせない。実行中の記録は `end` の欄を持たない（`null` を入れると `Entry` の
「実行中は未設定」と別の意味になる）。

**`duration_min` は桁を落とさない。** レビューで修正（下記）。

**`--format` は省略できない。** 既定を決めると、書き出したファイルの形式がコマンドの
見た目から分からなくなる。Issue の書き方（`--format csv|json [期間指定]`）にも揃えた。

**出力先のオプションは持たない。** リダイレクトに任せる。保存先を自前で扱うと、上書きの
確認や書き込み失敗の扱いをこのコマンドが抱えることになる。

**並びは `log` と逆の古い順。** `log` は「直近を見る」ので新しい順が読みやすいが、
書き出したものは表計算に貼って上から時系列に読む。

## 受け入れ条件

- [x] **エスケープが必要な文字を含むデータの出力テストがある**
      → `tests/format/csv.test.ts`「csvField のエスケープ」（カンマ / 引用符 / LF / CR /
      CRLF / それらの同時出現 / 引用符だけ）、`tests/format/export.test.ts`
      「formatCsvLines のエスケープ」（**カンマを含むタグ**を含む）、
      `tests/commands/export.test.ts`「エスケープが必要な文字を含む作業名を1つの列に収める（DoD）」

      実行結果（作業名 `"至急", 対応`、タグ `#a,b`）:
      ```
      $ tock export --format csv
      id,start,end,duration_min,tags,note
      7d55a6df-...,2026-08-14T02:05:58.377Z,2026-08-14T02:05:59.456Z,0.017983333333333334,work,設計
      5ee56515-...,2026-08-14T02:05:59.525Z,2026-08-14T02:05:59.595Z,0.0011666666666666668,"a,b work","""至急"", 対応"
      $ echo $?
      0
      ```
      `normalizeTag` は空白を弾くがカンマは通すので、**タグ列にもカンマが入りうる。**

- [x] **期間指定が効くテストがある**
      → `tests/commands/export.test.ts`「export --period（DoD）」7件
      （`today` / 日付範囲 / 省略時は全件 / 該当0件 / 期間より前に始まった実行中 /
      期間をまたぐ記録 / json でも効く）、`tests/domain/export.test.ts`
      「selectExportEntries の期間による絞り込み」7件

      実行結果:
      ```
      $ tock export --format csv --period yesterday
      id,start,end,duration_min,tags,note
      $ echo $?
      0
      $ tock export --format csv --period today | wc -l
      4
      $ tock export --format csv --period 2026-08-11..2026-08-12 | wc -l
      4
      ```
      該当0件でも見出し行だけは出す（列名の無いファイルは取り込み側が読めない）。

- [x] **JSON 出力がそのまま再取り込み可能な形式であるテストがある**
      → `tests/format/export.test.ts`「そのまま Entry として作り直せる（再取り込み可能）」、
      `tests/commands/export.test.ts`「出力をそのまま Entry として作り直せる（再取り込み可能）」
      および「読み戻した記録をそのまま保存し直せる」（別の一時ディレクトリの store に
      `append` し直して、読み出した結果が一致することまで確認している）

      **「再取り込み可能」を「`JSON.parse` した各要素が `createEntry` を通り、元の記録と
      一致すること」と読んだ。** 取り込みコマンド自体はこの Issue のスコープに無いため、
      検証できるのは「出力が妥当な `Entry` の集合であること」まで。

      実行結果（書き出したファイルを読み直す）:
      ```
      $ tock export --format json > export.json
      $ node -e '...'
      件数: 3
      実行中の記録に end はあるか: false
      復元した作業名: "\"至急\", 対応"
      ```

### 引数のエラー（実測。パイプなしで終了コードを測っている）

```
$ tock export
--format を指定してください（csv / json）
exit=1
$ tock export --format xml
--format に指定できるのは csv / json です: "xml"
exit=1
$ tock export --format csv --period nonsense
期間の指定を解釈できません: nonsense
使える形式: today / yesterday / this-week / last-week / this-month / YYYY-MM-DD（例: 2026-08-01） / YYYY-MM-DD..YYYY-MM-DD（例: 2026-08-01..2026-08-07） / -7d（今日を含む直近7日）
exit=1
```

## レビュー指摘への対応（4件。うち修正2件）

### 1. [変更] `duration_min` の行ごとの丸めが合計を壊していた（`0f7d4d3`）

初版は小数第2位で四捨五入していた。**この列は表計算で `SUM` される前提のものなので、
行ごとに丸めると誤差が同じ向きに積み上がる。** 指摘の数字をそのまま再現した。

```
1秒を分に直した正確な値: 0.016666666666666666
小数第2位に丸めた値:     0.02
40件の合計（正確）:      0.6666666666666666
40件の合計（丸めた列）:  0.8
```

初版の本文に書いた「端数は取り込み側で計算し直せる」は、**列がある以上そちらが足される**
ため成り立っていなかった。`durationMinutes`（#6）の値をそのまま `String` で出す形に直した。

分は 60 で割った値なので**そもそも有限小数で正確に表せない**（1秒 = 0.016666…分）。
桁を決めて丸める限りずれは消えないため、桁を落とさない側を選んだ。列名を `duration_sec`
に変える案もあったが、**Issue #23 が列の並びを固定している**ので DoD を書き換えることになる。

テストを2件追加し、丸めを戻すと**2件とも落ちる**ことを確認した。

### 2. [変更] 並べ替えが `Date.parse` を直接呼んでいた（`0f7d4d3`）

`period.ts` に「ISO 文字列を自前で解釈せず `startedAt` / `endedAt` を通す」と書いてあるのに、
`domain/export.ts` だけ破っていた。並びの結果は変わらないが、規約を外れてよい理由にはならない。

### 3. [テスト追加] タグ列のカンマ（`0f7d4d3`）

`normalizeTag("a,b")` → `"a,b"` を実際に確認したうえで、行全体を固定するテストを追加した。
タグ列の引用を外す改変で落ちることも確認済み。

### 4. [返信のみ] CSV インジェクションの Issue

**#62 として起票済み**（再現手順と実際の出力を含む）。初版の本文に番号を書いていなかった。

## mutation test

DoD の中心にある振る舞いを10箇所壊した。**すべてでテストが落ちた（穴なし）。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| `csvField` が引用符で囲まない（エスケープをやめる） | 13件 |
| `csvField` が値の中の引用符を2つ重ねない | 5件 |
| CSV から `end` 列を落とす | 14件 |
| JSON で実行中の記録に `end: null` を入れる | 4件 |
| `selectExportEntries` が期間で絞り込まない | 5件 |
| `selectExportEntries` が新しい順に並べる | 4件 |
| 知らない `--format` を弾かず csv にフォールバックする | 3件 |
| **`duration_min` を小数第2位に丸める**（レビュー指摘後） | **2件**（当初 0件） |
| **タグ列のカンマを落とす**（レビュー指摘後） | **1件**（当初 0件） |
| **行の組み立てから `csvLine` を外す**（レビュー指摘後） | **4件** |

元に戻して 1010 件すべて通ることを確認済み。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 記録0件（csv は見出し行のみ / json は `[]`）、タグ無し、作業名無し、空文字の `--format`、フィールド0個の行、空文字のフィールド |
| 同時刻 | 長さ 0 の記録（`duration_min` は `0`、開始が期間内なら残す）、開始が同時刻の記録の並び順（保存順を保つ） |
| 日跨ぎ | 23:00〜翌 01:00 の記録を**分割せず1行**で出す（`splitByUtcDay` は通さない）。期間の外にはみ出す部分も切り出さない |
| 上限値・範囲外 | 知らない `--format`、解釈できない `--period`、知らないオプション |
| **終端のないデータ** | **下記のとおり固定した** |

実行中エントリ（`end` を持たない）の扱い。`selectExportEntries` について
`CLAUDE.md` が挙げる4つをすべて書いた。

- 期間より**前**に始まって、まだ終わっていない → 含める
- 期間の**中**で始まって、まだ終わっていない → 含める
- 期間より**後**に始まっている → 含めない
- 開始が期間の境界と**ちょうど一致**する → 始まりなら含める / 終わりなら含めない
- CSV: `end` と `duration_min` を**空欄**にする（列の数は変わらない）
- JSON: `end` の欄を**持たない**（実行中のまま読み戻せる）

**実行中の記録に経過時間を入れなかったのは意図的。** 入れると、同じ記録を書き出す
たびに値が変わる報告ができてしまう。

## `main` への追従（`3523fe2`）

PR #60（#17 `edit` / `rm`）のマージに追従した。コンフリクトは2箇所で、どちらも両方を残した。

- `src/cli.ts` — 登録するコマンドが増えただけ
- `src/commands/log.ts` — **#60 が `ALL_TIME` を `commands/lookup.ts` へ移していた**ため、
  初版で `log.ts` に付けた `export` を取り下げ、`export.ts` の import 先を `lookup.js` に変えた

**初版の本文には「`commands/log.ts` の `ALL_TIME` を公開した」と書いてあったが、追従後は
そうなっていない。** 置き場所は #60 のほうが正しく（id で1件引く操作と同じく `Store` の
制約への回避策であり、`log` に属するものではない）、この PR の差分から `log.ts` への変更は
消えた。**#57 で解消される回避策である**点は変わらない。

`src/commands/args.ts` には触れていない（初版の本文はここも誤りだったので削除した）。

## スコープに入れなかったもの

- **CSV インジェクションの無害化** → #62。RFC 4180 の引用規則では防げず、値を書き換えると
  記録の忠実さと衝突するため、方針の判断が要る
- **タグにカンマを許すかどうか** → `normalizeTag` の仕様の話で、この PR の範囲外
- **`export` への設定の適用** → #22 が `--period this-week` の週の開始曜日を設定から
  取る形にしている。**#22 と この PR のどちらが後にマージされても、`export.ts` の
  `parsePeriodExpression` に `weekStartsOn` を渡す1行が必要になる**（忘れないよう明記する）

## スタック

- base: `main`（スタックなし）
- 依存の E5-4（#21）は PR #53 でマージ済み

## 依存の追加

なし（CSV の組み立ては RFC 4180 の引用規則だけなので自前で持った）。

## 検証

`npm run check` green（34 files / 1010 tests）。

- 実装フェーズの修正試行 **0回**
- レビュー対応フェーズの修正試行 **0回**（指摘への修正は1回で通った）