### PR TITLE
[E6-1][P2] 設定ファイルの仕組みと週の開始曜日

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { createConfigCommand } from "./commands/config.js";
 import { createEditCommand } from "./commands/edit.js";
 import { createLogCommand } from "./commands/log.js";
 import { createRmCommand } from "./commands/rm.js";
@@ -14,8 +15,9 @@ import { createSummaryCommand, createTodayCommand } from "./commands/summary.js"
 import { createSwitchCommand } from "./commands/switch.js";
 import { createWeekCommand } from "./commands/week.js";
 import { randomId } from "./id.js";
+import { createJsonConfigStore, loadEffectiveConfig } from "./store/config-store.js";
 import { createJsonlStore } from "./store/jsonl-store.js";
-import { resolveStorePath } from "./store/store.js";
+import { resolveConfigPath, resolveStorePath } from "./store/store.js";
 import { readVersion } from "./version.js";
 
 /** 正常終了。 */
@@ -194,6 +196,11 @@ function buildCommands(): readonly Command[] {
     newId: randomId,
   };
 
+  // 設定は必要になったコマンドがその場で読む。すべての起動でファイルを読むと、
+  // 設定を使わない打刻まで設定ファイルの状態に引きずられる
+  const configStore = createJsonConfigStore(resolveConfigPath(process.env, homedir()));
+  const loadConfig = () => loadEffectiveConfig(configStore, process.env);
+
   return [
     createStartCommand(deps),
     createStopCommand(deps),
@@ -201,10 +208,11 @@ function buildCommands(): readonly Command[] {
     createSwitchCommand(deps),
     createTodayCommand(deps),
     createSummaryCommand(deps),
-    createLogCommand(deps),
-    createWeekCommand(deps),
+    createLogCommand(deps, loadConfig),
+    createWeekCommand(deps, loadConfig),
     createEditCommand(deps),
     createRmCommand(deps, confirmOnStdin),
+    createConfigCommand(configStore, process.env),
   ];
 }
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,10 +1,12 @@
 import { type CliIo, type Command, UserError } from "../cli.js";
 import {
   assertConfigKey,
+  type Config,
   type ConfigKey,
   CONFIG_KEYS,
   envNameOf,
   formatConfigValue,
+  overrideFromEnv,
   withConfigValue,
 } from "../domain/config.js";
 import { type ConfigStore, loadEffectiveConfig } from "../store/config-store.js";
@@ -112,7 +114,7 @@ async function runSet(
   io.out(`設定しました: ${key}=${formatConfigValue(updated, key)}`);
   io.out(store.path);
 
-  warnIfMaskedByEnv(key, env, io);
+  warnIfMaskedByEnv(updated, key, env, io);
 }
 
 /**
@@ -120,19 +122,30 @@ async function runSet(
  *
  * 環境変数のほうが優先されるので、`set` は成功しているのに `get` の結果が変わらない。
  * 気づく手掛かりがないと、設定ファイルを何度も書き直すことになる。
+ *
+ * **「環境変数がある」ではなく「実際に値が変わる」ことを条件にする。** 環境変数の値が
+ * 不正なら `overrideFromEnv` はそれを無視してファイルの値を使うので、変数があるだけで
+ * 「効きません」と出すのは事実と食い違う（レビューで指摘。`get` 側は「値が不正です。
+ * 無視します」と出るため、同じ状況で説明が割れていた）。
+ *
+ * 判定を自前で書かず `overrideFromEnv` に通した結果と比べるのは、優先順位の規則を
+ * 2箇所に持たないため。書き写すと、片方だけ直したときに注意の出方がずれる。
  */
 function warnIfMaskedByEnv(
+  written: Config,
   key: ConfigKey,
   env: Readonly<Record<string, string | undefined>>,
   io: CliIo,
 ): void {
-  const name = envNameOf(key);
-  const value = env[name];
-  if (value === undefined || value === "") {
+  const effective = overrideFromEnv({ config: written, warnings: [] }, env).config;
+  const shown = formatConfigValue(effective, key);
+  if (shown === formatConfigValue(written, key)) {
     return;
   }
 
-  io.err(`注意: 環境変数 ${name}=${value} が設定されているため、この設定は今の環境では効きません`);
+  io.err(
+    `注意: 環境変数 ${envNameOf(key)} が優先されるため、この設定は今の環境では効きません（実効値: ${shown}）`,
+  );
 }
 
 function resolveAction(value: string | undefined): Action {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,178 @@
+import { type CliIo, type Command, UserError } from "../cli.js";
+import {
+  assertConfigKey,
+  type ConfigKey,
+  CONFIG_KEYS,
+  envNameOf,
+  formatConfigValue,
+  withConfigValue,
+} from "../domain/config.js";
+import { type ConfigStore, loadEffectiveConfig } from "../store/config-store.js";
+
+/** 受け付ける操作。 */
+const ACTIONS = ["get", "set"] as const;
+
+type Action = (typeof ACTIONS)[number];
+
+/**
+ * 設定を読み書きする。
+ *
+ * ```
+ * tock config get                 すべての設定を key=value で表示する
+ * tock config get weekStartsOn    値だけを表示する（スクリプトから使える）
+ * tock config set weekStartsOn 0  設定ファイルに書き込む
+ * ```
+ *
+ * **`get` は実際に効いている値を表示する。** 環境変数はファイルより優先されるため、
+ * ファイルの中身をそのまま出すと「設定したのに効かない」理由が分からなくなる。
+ *
+ * **`set` は設定ファイルだけを書き換える。** 環境変数は一時的な上書きであり、
+ * コマンドで永続化する対象ではない。書き込んだ値が環境変数に隠される場合は、
+ * その場で警告する（後から気づくのは難しい）。
+ */
+export function createConfigCommand(
+  store: ConfigStore,
+  env: Readonly<Record<string, string | undefined>>,
+): Command {
+  return {
+    name: "config",
+    summary: "設定を読み書きする",
+
+    async run(argv: readonly string[], io: CliIo): Promise<void> {
+      const [actionValue, ...rest] = argv;
+      const action = resolveAction(actionValue);
+
+      // 引数の検査をすべて済ませてからファイルに触る。打ち間違いのときに
+      // 読み書きする必要はなく、失敗の理由も引数だけで決まる
+      if (action === "get") {
+        await runGet(store, env, rest, io);
+
+        return;
+      }
+
+      await runSet(store, env, rest, io);
+    },
+  };
+}
+
+/** 設定を表示する。キーを省略するとすべて表示する。 */
+async function runGet(
+  store: ConfigStore,
+  env: Readonly<Record<string, string | undefined>>,
+  argv: readonly string[],
+  io: CliIo,
+): Promise<void> {
+  const key = resolveOptionalKey(argv, "get");
+  const { config, warnings } = await loadEffectiveConfig(store, env);
+  writeWarnings(warnings, io);
+
+  if (key !== undefined) {
+    // 1つを指定したときは値だけを出す。`$(tock config get weekStartsOn)` で使えるようにする
+    io.out(formatConfigValue(config, key));
+
+    return;
+  }
+
+  for (const each of CONFIG_KEYS) {
+    io.out(`${each}=${formatConfigValue(config, each)}`);
+  }
+}
+
+/** 設定を書き込む。 */
+async function runSet(
+  store: ConfigStore,
+  env: Readonly<Record<string, string | undefined>>,
+  argv: readonly string[],
+  io: CliIo,
+): Promise<void> {
+  const [keyValue, value, ...extra] = argv;
+  if (keyValue === undefined || value === undefined) {
+    throw new UserError(
+      `tock config set にはキーと値が必要です（例: tock config set ${CONFIG_KEYS[0]} 0）`,
+    );
+  }
+  if (extra.length > 0) {
+    throw new UserError(`tock config set が解釈できない引数です: ${extra.join(" ")}`);
+  }
+
+  const key = toKey(keyValue);
+
+  // 書き込む前に読む。他のキーを既定値で上書きしないため
+  const current = await store.read();
+  writeWarnings(current.warnings, io);
+
+  let updated;
+  try {
+    updated = withConfigValue(current.config, key, value);
+  } catch (error) {
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+
+  await store.write(updated);
+  io.out(`設定しました: ${key}=${formatConfigValue(updated, key)}`);
+  io.out(store.path);
+
+  warnIfMaskedByEnv(key, env, io);
+}
+
+/**
+ * 書き込んだ値が環境変数に隠される場合に知らせる。
+ *
+ * 環境変数のほうが優先されるので、`set` は成功しているのに `get` の結果が変わらない。
+ * 気づく手掛かりがないと、設定ファイルを何度も書き直すことになる。
+ */
+function warnIfMaskedByEnv(
+  key: ConfigKey,
+  env: Readonly<Record<string, string | undefined>>,
+  io: CliIo,
+): void {
+  const name = envNameOf(key);
+  const value = env[name];
+  if (value === undefined || value === "") {
+    return;
+  }
+
+  io.err(`注意: 環境変数 ${name}=${value} が設定されているため、この設定は今の環境では効きません`);
+}
+
+function resolveAction(value: string | undefined): Action {
+  if (value === undefined) {
+    throw new UserError(`tock config には操作が必要です（${ACTIONS.join(" / ")}）`);
+  }
+  if (!(ACTIONS as readonly string[]).includes(value)) {
+    throw new UserError(
+      `tock config が知らない操作です: ${JSON.stringify(value)}（使えるのは ${ACTIONS.join(" / ")}）`,
+    );
+  }
+
+  return value as Action;
+}
+
+/** `get` のキー。省略できる。 */
+function resolveOptionalKey(argv: readonly string[], action: Action): ConfigKey | undefined {
+  const [keyValue, ...extra] = argv;
+  if (extra.length > 0) {
+    throw new UserError(`tock config ${action} が解釈できない引数です: ${extra.join(" ")}`);
+  }
+  if (keyValue === undefined) {
+    return undefined;
+  }
+
+  return toKey(keyValue);
+}
+
+/** domain のエラーは利用者向けに翻訳する（domain は `UserError` を知らない）。 */
+function toKey(value: string): ConfigKey {
+  try {
+    return assertConfigKey(value);
+  } catch (error) {
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** 設定の読み取りで出た警告を stderr に出す。答えそのものではないので stdout に混ぜない。 */
+function writeWarnings(warnings: readonly string[], io: CliIo): void {
+  for (const warning of warnings) {
+    io.err(warning);
+  }
+}

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -50,8 +50,12 @@ export function createExportCommand(deps: CommandDeps, loadConfig: LoadConfig): 
         allowPositional: false,
       });
 
-      // 引数の検査をすべて済ませてから store に触る。打ち間違いのときに
-      // ファイルを読む必要はなく、失敗の理由も引数だけで決まる
+      // 引数の検査を済ませてからファイルに触る。打ち間違いのときに設定ファイルや記録を
+      // 読む必要はなく、失敗の理由も引数だけで決まる。
+      //
+      // **`--period` の解決だけは設定を読んだ後になる**（週の開始曜日に依存するため）。
+      // それ以外を先に片付けておけば、`--format` の打ち間違いで設定ファイルの警告が
+      // 先に出ることはない
       const format = resolveFormat(formatValue);
 
       const { config, warnings } = await loadConfig();

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -41,17 +41,22 @@ export function createLogCommand(deps: CommandDeps, loadConfig: LoadConfig): Com
         allowPositional: false,
       });
 
-      // 引数の検査をすべて済ませてから store に触る。打ち間違いのときに
-      // ファイルを読む必要はなく、失敗の理由も引数だけで決まる
+      // 引数の検査を済ませてからファイルに触る。打ち間違いのときに設定ファイルや記録を
+      // 読む必要はなく、失敗の理由も引数だけで決まる。
+      //
+      // **`--period` の解決だけは設定を読んだ後になる**（週の開始曜日に依存するため）。
+      // それ以外を先に片付けておけば、`--limit` の打ち間違いで設定ファイルの警告が
+      // 先に出ることはない
       const now = deps.now();
+      const tag = resolveTag(tagValue);
+      const limit = resolveLimit(limitValue);
+
       const { config, warnings } = await loadConfig();
       for (const warning of warnings) {
         io.err(warning);
       }
 
       const period = resolvePeriod(periodValue, now, config.weekStartsOn);
-      const tag = resolveTag(tagValue);
-      const limit = resolveLimit(limitValue);
 
       const entries = await deps.store.listByRange(period);
       const rows = selectLogRows(

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -4,6 +4,7 @@ import { parsePeriodExpression } from "../domain/period-expression.js";
 import type { Period } from "../domain/period.js";
 import { normalizeTag } from "../domain/tag.js";
 import { formatLogLines } from "../format/log.js";
+import type { LoadConfig } from "../store/config-store.js";
 import { type CommandDeps, rejectUnknownArgs, takeOption } from "./args.js";
 import { ALL_TIME } from "./lookup.js";
 
@@ -25,7 +26,7 @@ const DECIMAL_POSITIVE_INTEGER = /^[1-9]\d*$/;
  * 読むだけで何も書かない。該当0件でもエラーにしない（`status` と同じ考え方で、
  * 「まだ記録がない」は正常な答えである）。
  */
-export function createLogCommand(deps: CommandDeps): Command {
+export function createLogCommand(deps: CommandDeps, loadConfig: LoadConfig): Command {
   return {
     name: "log",
     summary: "記録を新しい順に一覧表示する",
@@ -43,7 +44,12 @@ export function createLogCommand(deps: CommandDeps): Command {
       // 引数の検査をすべて済ませてから store に触る。打ち間違いのときに
       // ファイルを読む必要はなく、失敗の理由も引数だけで決まる
       const now = deps.now();
-      const period = resolvePeriod(periodValue, now);
+      const { config, warnings } = await loadConfig();
+      for (const warning of warnings) {
+        io.err(warning);
+      }
+
+      const period = resolvePeriod(periodValue, now, config.weekStartsOn);
       const tag = resolveTag(tagValue);
       const limit = resolveLimit(limitValue);
 
@@ -61,14 +67,19 @@ export function createLogCommand(deps: CommandDeps): Command {
   };
 }
 
-/** `--period` の解決。domain のエラーは利用者向けに翻訳する（domain は `UserError` を知らない）。 */
-function resolvePeriod(value: string | undefined, now: Date): Period {
+/**
+ * `--period` の解決。domain のエラーは利用者向けに翻訳する（domain は `UserError` を知らない）。
+ *
+ * **`this-week` / `last-week` は設定の週の開始曜日に従う。** `week` コマンドだけが設定を
+ * 見て `log` が見ないと、同じ「今週」が2つの意味を持つ。
+ */
+function resolvePeriod(value: string | undefined, now: Date, weekStartsOn: number): Period {
   if (value === undefined) {
     return ALL_TIME;
   }
 
   try {
-    return parsePeriodExpression(value, now);
+    return parsePeriodExpression(value, now, { weekStartsOn });
   } catch (error) {
     throw new UserError(error instanceof Error ? error.message : String(error));
   }

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -1,4 +1,5 @@
 import { type CliIo, type Command, UserError } from "../cli.js";
+import { describeConfigKey, parseConfigText } from "../domain/config.js";
 import { summarizeWeek } from "../domain/week-summary.js";
 import { weekPeriodOf } from "../domain/week.js";
 import { formatWeekLines } from "../format/week.js";
@@ -83,6 +84,10 @@ function resolveOffset(value: string | undefined): number {
 /**
  * `--week-starts-on` の解決。省略時は `undefined`（設定に委ねる）。
  *
+ * **検査は `parseConfigText` に任せる。** 同じ「週の開始曜日」を、環境変数・`config set`・
+ * このオプションの3経路で受け取るので、ここだけ独自に判定すると通る値が食い違う
+ * （当初は1桁に限っていたため `00` がオプションからだけ弾かれていた）。
+ *
  * 範囲の検査は `weekPeriodOf` も行うが、そちらの `Error` は内部エラー（終了コード 2）に
  * なる。打ち間違いは利用者起因なので、ここで `UserError` に翻訳しておく。
  */
@@ -90,11 +95,13 @@ function resolveWeekStartsOn(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  if (!/^\d$/.test(value) || Number(value) > 6) {
+
+  const parsed = parseConfigText("weekStartsOn", value);
+  if (parsed === undefined) {
     throw new UserError(
-      `--week-starts-on は 0（日曜）〜6（土曜）で指定してください: ${JSON.stringify(value)}`,
+      `--week-starts-on には${describeConfigKey("weekStartsOn")}を指定してください: ${JSON.stringify(value)}`,
     );
   }
 
-  return Number(value);
+  return parsed;
 }

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -2,6 +2,7 @@ import { type CliIo, type Command, UserError } from "../cli.js";
 import { summarizeWeek } from "../domain/week-summary.js";
 import { weekPeriodOf } from "../domain/week.js";
 import { formatWeekLines } from "../format/week.js";
+import type { LoadConfig } from "../store/config-store.js";
 import { type CommandDeps, rejectUnknownArgs, takeOption } from "./args.js";
 
 /** 十進の整数。符号は付けられるが、先頭の余分な `0`・小数点・指数・空白は許さない。 */
@@ -13,28 +14,37 @@ const DECIMAL_INTEGER = /^[+-]?(0|[1-9]\d*)$/;
  * 読むだけで何も書かない。記録が無くてもエラーにしない（`status` / `summary` と同じ考え方で、
  * 「その週はまだ記録していない」は正常な答えである）。
  *
- * **週の開始曜日は既定（月曜）のまま。** `weekPeriodOf` は開始曜日を受け取れるが、
- * Issue #19 のスコープは「設定で変更可能（E6-1（#22）と連動）」であり、設定ファイルは
- * #22 の担当範囲。ここで独自の `--week-start` を足すと、#22 が入ったときに指定方法が
- * 2つになる。domain 側は開始曜日を受け取れる形にしてあるので、#22 はそれを渡すだけでよい。
+ * **週の開始曜日は `--week-starts-on` > 環境変数 > 設定ファイル > 既定（月曜）の順に決まる。**
+ * 設定ファイルの読み取り（環境変数の重ねまで）は `loadConfig` が行い、このコマンドは
+ * 最後にコマンドラインオプションを重ねるだけにする。優先順位の規則を各コマンドが
+ * 持つと、コマンドごとに効き方が食い違う。
  */
-export function createWeekCommand(deps: CommandDeps): Command {
+export function createWeekCommand(deps: CommandDeps, loadConfig: LoadConfig): Command {
   return {
     name: "week",
     summary: "週のタグ別・曜日別の集計を表示する",
 
     async run(argv: readonly string[], io: CliIo): Promise<void> {
-      const { value: offsetValue, rest } = takeOption(argv, "--offset");
+      const { value: offsetValue, rest: afterOffset } = takeOption(argv, "--offset");
+      const { value: weekStartValue, rest } = takeOption(afterOffset, "--week-starts-on");
       rejectUnknownArgs(rest, {
         command: "week",
-        allowedOptions: ["--offset"],
+        allowedOptions: ["--offset", "--week-starts-on"],
         allowPositional: false,
       });
 
       // 引数の検査を済ませてから store に触る。打ち間違いでファイルを読む必要はない
       const offsetWeeks = resolveOffset(offsetValue);
+      const fromOption = resolveWeekStartsOn(weekStartValue);
+
+      const { config, warnings } = await loadConfig();
+      for (const warning of warnings) {
+        io.err(warning);
+      }
+
+      const weekStartsOn = fromOption ?? config.weekStartsOn;
       const now = deps.now();
-      const week = weekPeriodOf(now, { offsetWeeks });
+      const week = weekPeriodOf(now, { offsetWeeks, weekStartsOn });
 
       // 読み出す範囲を週そのものにしているのは、listByRange が範囲に重なるエントリを
       // （日跨ぎ・実行中のものも含めて）返すため。曜日への振り分けは summarizeWeek が行う
@@ -64,6 +74,25 @@ function resolveOffset(value: string | undefined): number {
   if (!DECIMAL_INTEGER.test(value)) {
     throw new UserError(
       `--offset は整数で指定してください: ${JSON.stringify(value)}（例: --offset -1）`,
+    );
+  }
+
+  return Number(value);
+}
+
+/**
+ * `--week-starts-on` の解決。省略時は `undefined`（設定に委ねる）。
+ *
+ * 範囲の検査は `weekPeriodOf` も行うが、そちらの `Error` は内部エラー（終了コード 2）に
+ * なる。打ち間違いは利用者起因なので、ここで `UserError` に翻訳しておく。
+ */
+function resolveWeekStartsOn(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^\d$/.test(value) || Number(value) > 6) {
+    throw new UserError(
+      `--week-starts-on は 0（日曜）〜6（土曜）で指定してください: ${JSON.stringify(value)}`,
     );
   }
 

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -1,0 +1,268 @@
+import { assertWeekStartsOn, DEFAULT_WEEK_STARTS_ON } from "./week.js";
+
+/**
+ * 利用者ごとの設定。
+ *
+ * **値の解釈と検査だけを持ち、ファイルにも環境変数にも触らない**（`CLAUDE.md` の
+ * 「domain に I/O を置かない」）。読み書きは `store/config-store.ts`、
+ * 利用者への提示は `commands/config.ts` が受け持つ。
+ *
+ * 設定は**壊れていても止まらない**方針にする。設定は主目的ではなく好みの記録なので、
+ * 1つの値が読めないことで打刻や集計ができなくなるのは割に合わない。読めなかった値は
+ * 既定値に落とし、何が起きたかを警告として返す（黙って既定に落とすと、設定したはずの
+ * 値が効いていないことに気づけない）。
+ *
+ * ただし**`config set` は例外で、不正な値を Error にする。** そちらは利用者がいま
+ * 打った操作であり、受け付けられなかったことをその場で伝えられる。
+ */
+
+/** 設定できるキー。**`config get|set` が受け付けるのはこの一覧だけ。** */
+export const CONFIG_KEYS = ["weekStartsOn"] as const;
+
+export type ConfigKey = (typeof CONFIG_KEYS)[number];
+
+export interface Config {
+  /** 週の開始曜日（0=日曜 … 6=土曜）。 */
+  readonly weekStartsOn: number;
+}
+
+/**
+ * 設定を1つも書いていないときの値。
+ *
+ * **既定値をここで新しく決めない。** 週の開始曜日の既定は `domain/week.ts` が持っており、
+ * 二重に持つと片方だけ変えたときに「設定なしの挙動」と「設定を消したときの挙動」が
+ * 食い違う。
+ */
+export const DEFAULT_CONFIG: Config = { weekStartsOn: DEFAULT_WEEK_STARTS_ON };
+
+/** 設定の読み取り結果。警告は利用者に見せる（`config` 以外のコマンドでも stderr に出す）。 */
+export interface ConfigResult {
+  readonly config: Config;
+  readonly warnings: readonly string[];
+}
+
+/** 十進の整数だけ。`0x6`・`1e0`・前後の空白・符号を通さない。 */
+const DECIMAL_INTEGER = /^\d+$/;
+
+/** そのキーに書ける値の説明。エラーと警告の両方で使うので1箇所に持つ。 */
+function describeKey(key: ConfigKey): string {
+  switch (key) {
+    case "weekStartsOn": {
+      return "0（日曜）〜6（土曜）の整数";
+    }
+    default: {
+      // キーを増やして case を書き忘れると、ここで型検査が落ちる
+      const unhandled: never = key;
+      throw new Error(`設定キーの説明がありません: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+/** JSON から読んだ値を検査する。書けない値なら `undefined`。 */
+function fromJson(key: ConfigKey, value: unknown): number | undefined {
+  switch (key) {
+    case "weekStartsOn": {
+      return isWeekStartsOn(value) ? value : undefined;
+    }
+    default: {
+      const unhandled: never = key;
+      throw new Error(`設定キーの読み取りがありません: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+/**
+ * 文字列で書かれた値を検査する。書けない値なら `undefined`。
+ *
+ * 環境変数と `config set` はどちらも文字列で値を受け取るので、同じ関数を通す。
+ * 片方だけ緩いと、`config set` で拒否された値が環境変数からは通ってしまう。
+ */
+function fromText(key: ConfigKey, text: string): number | undefined {
+  switch (key) {
+    case "weekStartsOn": {
+      return DECIMAL_INTEGER.test(text) && isWeekStartsOn(Number(text)) ? Number(text) : undefined;
+    }
+    default: {
+      const unhandled: never = key;
+      throw new Error(`設定キーの読み取りがありません: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+/** 検査済みの値を設定に載せる。元の設定は書き換えない。 */
+function withValue(config: Config, key: ConfigKey, value: number): Config {
+  switch (key) {
+    case "weekStartsOn": {
+      return { ...config, weekStartsOn: value };
+    }
+    default: {
+      const unhandled: never = key;
+      throw new Error(`設定キーの書き込みがありません: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+/** 週の開始曜日として妥当か。判定の規則は `domain/week.ts` に一本化する。 */
+function isWeekStartsOn(value: unknown): value is number {
+  if (typeof value !== "number") {
+    return false;
+  }
+
+  try {
+    assertWeekStartsOn(value);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 設定の値を文字列で読み出す（`config get` の出力）。 */
+export function formatConfigValue(config: Config, key: ConfigKey): string {
+  switch (key) {
+    case "weekStartsOn": {
+      return String(config.weekStartsOn);
+    }
+    default: {
+      const unhandled: never = key;
+      throw new Error(`設定キーの表示がありません: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+export function isConfigKey(value: string): value is ConfigKey {
+  return (CONFIG_KEYS as readonly string[]).includes(value);
+}
+
+/**
+ * 使えるキーかを確かめる。**未知のキーはここで弾く。**
+ *
+ * 大文字小文字の違いも別のキーとして扱わず拒否する。`weekstartson` を通して
+ * `weekStartsOn` に読み替えると、設定ファイルに書いた形とコマンドで打った形が
+ * 食い違ったまま残る。
+ */
+export function assertConfigKey(value: string): ConfigKey {
+  if (!isConfigKey(value)) {
+    throw new Error(
+      `知らない設定キーです: ${JSON.stringify(value)}（使えるキー: ${CONFIG_KEYS.join(" / ")}）`,
+    );
+  }
+
+  return value;
+}
+
+/** そのキーに対応する環境変数の名前。キーから決まるので一覧を二重に持たない。 */
+export function envNameOf(key: ConfigKey): string {
+  return `TOCK_${key.replaceAll(/[A-Z]/g, (upper) => `_${upper}`).toUpperCase()}`;
+}
+
+/**
+ * 設定ファイルの中身（`JSON.parse` した値）を読む。
+ *
+ * ファイルが無い場合は `undefined` を渡す。**その場合は警告を出さない**——設定を
+ * 書いていないことは異常ではない。
+ *
+ * 読めなかった値は既定値に落とし、警告を返す。**1つの値が壊れていても、他の値は読む。**
+ * 全部を捨てると、1文字の打ち間違いで設定全体が無効になる。
+ */
+export function parseConfigFile(raw: unknown): ConfigResult {
+  if (raw === undefined) {
+    return { config: DEFAULT_CONFIG, warnings: [] };
+  }
+  if (!isRecordObject(raw)) {
+    return {
+      config: DEFAULT_CONFIG,
+      warnings: ["中身が JSON のオブジェクトではありません。すべて既定値を使います"],
+    };
+  }
+
+  const warnings: string[] = [];
+  let config = DEFAULT_CONFIG;
+
+  for (const key of Object.keys(raw)) {
+    if (!isConfigKey(key)) {
+      warnings.push(
+        `知らない設定キーは無視します: ${JSON.stringify(key)}（使えるキー: ${CONFIG_KEYS.join(" / ")}）`,
+      );
+    }
+  }
+
+  for (const key of CONFIG_KEYS) {
+    if (!Object.hasOwn(raw, key)) {
+      continue;
+    }
+
+    const value = fromJson(key, raw[key]);
+    if (value === undefined) {
+      warnings.push(
+        `${key} の値が不正です: ${JSON.stringify(raw[key])}（${describeKey(key)}）。` +
+          `既定値 ${formatConfigValue(DEFAULT_CONFIG, key)} を使います`,
+      );
+      continue;
+    }
+
+    config = withValue(config, key, value);
+  }
+
+  return { config, warnings };
+}
+
+/**
+ * 環境変数を設定ファイルの値の上に重ねる。**環境変数のほうが優先される。**
+ *
+ * 一時的に別の設定で動かしたいとき（スクリプトや検証）に、ファイルを書き換えずに
+ * 済ませるための層。優先順位は `コマンドラインオプション > 環境変数 > 設定ファイル > 既定値`
+ * で、コマンドラインオプションの適用は各コマンドが行う。
+ *
+ * **空文字は「指定なし」として扱う。** シェルで `TOCK_WEEK_STARTS_ON=` と書いたときに
+ * 不正な値の警告を出すと、変数を消したつもりの人に無関係な警告が出る。
+ *
+ * 設定ファイル側の警告は消さずに引き継ぐ。
+ */
+export function overrideFromEnv(
+  base: ConfigResult,
+  env: Readonly<Record<string, string | undefined>>,
+): ConfigResult {
+  let config = base.config;
+  const warnings = [...base.warnings];
+
+  for (const key of CONFIG_KEYS) {
+    const name = envNameOf(key);
+    const text = env[name];
+    if (text === undefined || text === "") {
+      continue;
+    }
+
+    const value = fromText(key, text);
+    if (value === undefined) {
+      warnings.push(
+        `環境変数 ${name} の値が不正です: ${JSON.stringify(text)}（${describeKey(key)}）。無視します`,
+      );
+      continue;
+    }
+
+    config = withValue(config, key, value);
+  }
+
+  return { config, warnings };
+}
+
+/**
+ * 文字列で与えられた値を設定に反映する。`config set` が使う。
+ *
+ * **ここは警告ではなく `Error` にする。** 利用者がいま打った操作なので、受け付けられ
+ * なかったことをその場で伝えられる。黙って既定値を書き込むと、打った値と保存された値が
+ * 食い違う。
+ */
+export function withConfigValue(config: Config, key: ConfigKey, text: string): Config {
+  const value = fromText(key, text);
+  if (value === undefined) {
+    throw new Error(`${key} には ${describeKey(key)} を指定してください: ${JSON.stringify(text)}`);
+  }
+
+  return withValue(config, key, value);
+}
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -195,7 +195,8 @@ export function parseConfigFile(raw: unknown): ConfigResult {
   for (const key of Object.keys(raw)) {
     if (!isConfigKey(key)) {
       warnings.push(
-        `知らない設定キーは無視します: ${JSON.stringify(key)}（使えるキー: ${CONFIG_KEYS.join(" / ")}）`,
+        `知らない設定キーです: ${JSON.stringify(key)}（使えるキー: ${CONFIG_KEYS.join(" / ")}）。` +
+          `この版では読みませんが、設定ファイルからは消しません`,
       );
     }
   }

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -41,11 +41,21 @@ export interface ConfigResult {
   readonly warnings: readonly string[];
 }
 
-/** 十進の整数だけ。`0x6`・`1e0`・前後の空白・符号を通さない。 */
-const DECIMAL_INTEGER = /^\d+$/;
+/**
+ * 十進の整数だけ。`0x6`・`1e0`・前後の空白・符号・先頭の余分な `0` を通さない。
+ *
+ * 先頭ゼロを弾くのは `--limit`（#16）や `--offset`（#19）と同じ理由で、`00` を
+ * 受け付けると「整数で指定してください」という説明と実際に通る範囲が食い違うため。
+ */
+const DECIMAL_INTEGER = /^(0|[1-9]\d*)$/;
 
-/** そのキーに書ける値の説明。エラーと警告の両方で使うので1箇所に持つ。 */
-function describeKey(key: ConfigKey): string {
+/**
+ * そのキーに書ける値の説明。エラーと警告の両方で使うので1箇所に持つ。
+ *
+ * コマンドラインオプション（`--week-starts-on`）のエラーからも使うため公開している。
+ * 経路ごとに文言を書くと、同じ値を拒否したのに説明が食い違う。
+ */
+export function describeConfigKey(key: ConfigKey): string {
   switch (key) {
     case "weekStartsOn": {
       return "0（日曜）〜6（土曜）の整数";
@@ -74,10 +84,13 @@ function fromJson(key: ConfigKey, value: unknown): number | undefined {
 /**
  * 文字列で書かれた値を検査する。書けない値なら `undefined`。
  *
- * 環境変数と `config set` はどちらも文字列で値を受け取るので、同じ関数を通す。
- * 片方だけ緩いと、`config set` で拒否された値が環境変数からは通ってしまう。
+ * **文字列から値を取る経路はすべてこれを通す。** 環境変数・`config set`・
+ * コマンドラインオプション（`--week-starts-on`）の3つがあり、どれか1つでも独自に
+ * 検査すると、同じ値が経路によって通ったり通らなかったりする。実際に、
+ * オプションだけ1桁に限っていたため `00` が環境変数からは通ってオプションからは
+ * 弾かれていた（レビューで指摘）。
  */
-function fromText(key: ConfigKey, text: string): number | undefined {
+export function parseConfigText(key: ConfigKey, text: string): number | undefined {
   switch (key) {
     case "weekStartsOn": {
       return DECIMAL_INTEGER.test(text) && isWeekStartsOn(Number(text)) ? Number(text) : undefined;
@@ -195,7 +208,7 @@ export function parseConfigFile(raw: unknown): ConfigResult {
     const value = fromJson(key, raw[key]);
     if (value === undefined) {
       warnings.push(
-        `${key} の値が不正です: ${JSON.stringify(raw[key])}（${describeKey(key)}）。` +
+        `${key} の値が不正です: ${JSON.stringify(raw[key])}（${describeConfigKey(key)}）。` +
           `既定値 ${formatConfigValue(DEFAULT_CONFIG, key)} を使います`,
       );
       continue;
@@ -233,10 +246,10 @@ export function overrideFromEnv(
       continue;
     }
 
-    const value = fromText(key, text);
+    const value = parseConfigText(key, text);
     if (value === undefined) {
       warnings.push(
-        `環境変数 ${name} の値が不正です: ${JSON.stringify(text)}（${describeKey(key)}）。無視します`,
+        `環境変数 ${name} の値が不正です: ${JSON.stringify(text)}（${describeConfigKey(key)}）。無視します`,
       );
       continue;
     }
@@ -255,9 +268,11 @@ export function overrideFromEnv(
  * 食い違う。
  */
 export function withConfigValue(config: Config, key: ConfigKey, text: string): Config {
-  const value = fromText(key, text);
+  const value = parseConfigText(key, text);
   if (value === undefined) {
-    throw new Error(`${key} には ${describeKey(key)} を指定してください: ${JSON.stringify(text)}`);
+    throw new Error(
+      `${key} には${describeConfigKey(key)}を指定してください: ${JSON.stringify(text)}`,
+    );
   }
 
   return withValue(config, key, value);

--- a/src/store/config-store.ts
+++ b/src/store/config-store.ts
@@ -4,7 +4,6 @@ import { dirname } from "node:path";
 import {
   type Config,
   type ConfigResult,
-  DEFAULT_CONFIG,
   overrideFromEnv,
   parseConfigFile,
 } from "../domain/config.js";
@@ -20,7 +19,7 @@ export interface ConfigStore {
   readonly path: string;
   /** 設定を読む。**存在しない・壊れている場合も失敗させず、既定値と警告を返す。** */
   read(): Promise<ConfigResult>;
-  /** 設定を丸ごと書き換える。親ディレクトリが無ければ作る。 */
+  /** 知っているキーを更新する。**知らないキーは残す。** 親ディレクトリが無ければ作る。 */
   write(config: Config): Promise<void>;
 }
 
@@ -42,47 +41,74 @@ export function createJsonConfigStore(path: string): ConfigStore {
   /** 警告にファイルのパスを添える。どのファイルを直せばよいかが分からないと動けない。 */
   const locate = (warning: string): string => `設定ファイル（${path}）: ${warning}`;
 
+  /**
+   * ファイルの中身を `JSON.parse` した値と、読めなかった理由を返す。
+   *
+   * 読み出し（`read`）と書き込み（`write`）の両方が生の値を要る。`write` は**知らないキーを
+   * 残す**ために、いま何が書かれているかを知る必要がある。
+   */
+  async function readRaw(): Promise<{ raw: unknown; warnings: string[] }> {
+    let text: string;
+    try {
+      text = await readFile(path, "utf8");
+    } catch (error) {
+      if (isNotFound(error)) {
+        // 設定を書いていないのは異常ではないので、警告も出さない
+        return { raw: undefined, warnings: [] };
+      }
+
+      // 権限が無いなど、存在するのに読めない場合は黙って既定値に落とさない
+      return {
+        raw: undefined,
+        warnings: [locate(`読み込めません（${messageOf(error)}）。すべて既定値を使います`)],
+      };
+    }
+
+    try {
+      return { raw: JSON.parse(text), warnings: [] };
+    } catch {
+      return {
+        raw: undefined,
+        warnings: [locate("JSON として読めません。すべて既定値を使います")],
+      };
+    }
+  }
+
   return {
     path,
 
     async read(): Promise<ConfigResult> {
-      let text: string;
-      try {
-        text = await readFile(path, "utf8");
-      } catch (error) {
-        if (isNotFound(error)) {
-          // 設定を書いていないのは異常ではないので、警告も出さない
-          return { config: DEFAULT_CONFIG, warnings: [] };
-        }
-
-        // 権限が無いなど、存在するのに読めない場合は黙って既定値に落とさない
-        return {
-          config: DEFAULT_CONFIG,
-          warnings: [locate(`読み込めません（${messageOf(error)}）。すべて既定値を使います`)],
-        };
-      }
-
-      let raw: unknown;
-      try {
-        raw = JSON.parse(text);
-      } catch {
-        return {
-          config: DEFAULT_CONFIG,
-          warnings: [locate("JSON として読めません。すべて既定値を使います")],
-        };
-      }
-
+      const { raw, warnings } = await readRaw();
       const result = parseConfigFile(raw);
 
-      return { config: result.config, warnings: result.warnings.map(locate) };
+      return { config: result.config, warnings: [...warnings, ...result.warnings.map(locate)] };
     },
 
+    /**
+     * 設定を書き込む。**知らないキーは消さずに残す。**
+     *
+     * `Config` をそのまま書き出すと、いま解釈できないキーがファイルから消える。
+     * 設定項目は後から足していく前提（#63 / #64 / #65）なので、**新しい版が書いたキーを
+     * 古い版の `set` が消す**ことになる。手で足した書きかけの設定も同じように消える。
+     * 読み出し時に「知らないキーは読まない」と警告しているのに、書き込みが削除になるのは
+     * 説明と食い違う（レビューで指摘）。
+     *
+     * 既にある値の上に `Config` を重ねるので、**知っているキーだけが更新される**。
+     * ファイルが JSON として読めない場合だけは残しようがないため、`Config` だけを書く。
+     */
     async write(config: Config): Promise<void> {
+      const { raw } = await readRaw();
+      const merged = isRecordObject(raw) ? { ...raw, ...config } : { ...config };
+
       await mkdir(dirname(path), { recursive: true });
       // 末尾の改行を付けるのは、テキストとして扱う道具（diff・エディタ）と噛み合わせるため
-      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+      await writeFile(path, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
     },
   };
+}
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/src/store/config-store.ts
+++ b/src/store/config-store.ts
@@ -1,0 +1,99 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import {
+  type Config,
+  type ConfigResult,
+  DEFAULT_CONFIG,
+  overrideFromEnv,
+  parseConfigFile,
+} from "../domain/config.js";
+
+/**
+ * 設定ファイルの読み書き。
+ *
+ * ファイルに触るのはここだけで、値の解釈と検査は `domain/config.ts` が持つ。
+ * 差し替え可能にしてあるので、テストは一時ディレクトリを指した実装を渡せる。
+ */
+export interface ConfigStore {
+  /** 読み書きするファイルのパス。`config` コマンドが利用者に示すために持つ。 */
+  readonly path: string;
+  /** 設定を読む。**存在しない・壊れている場合も失敗させず、既定値と警告を返す。** */
+  read(): Promise<ConfigResult>;
+  /** 設定を丸ごと書き換える。親ディレクトリが無ければ作る。 */
+  write(config: Config): Promise<void>;
+}
+
+/** 設定の読み出し。コマンドはこれだけを受け取り、どこから来た値かを気にしない。 */
+export type LoadConfig = () => Promise<ConfigResult>;
+
+/** ファイルが無いことを表すエラーか。 */
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createJsonConfigStore(path: string): ConfigStore {
+  /** 警告にファイルのパスを添える。どのファイルを直せばよいかが分からないと動けない。 */
+  const locate = (warning: string): string => `設定ファイル（${path}）: ${warning}`;
+
+  return {
+    path,
+
+    async read(): Promise<ConfigResult> {
+      let text: string;
+      try {
+        text = await readFile(path, "utf8");
+      } catch (error) {
+        if (isNotFound(error)) {
+          // 設定を書いていないのは異常ではないので、警告も出さない
+          return { config: DEFAULT_CONFIG, warnings: [] };
+        }
+
+        // 権限が無いなど、存在するのに読めない場合は黙って既定値に落とさない
+        return {
+          config: DEFAULT_CONFIG,
+          warnings: [locate(`読み込めません（${messageOf(error)}）。すべて既定値を使います`)],
+        };
+      }
+
+      let raw: unknown;
+      try {
+        raw = JSON.parse(text);
+      } catch {
+        return {
+          config: DEFAULT_CONFIG,
+          warnings: [locate("JSON として読めません。すべて既定値を使います")],
+        };
+      }
+
+      const result = parseConfigFile(raw);
+
+      return { config: result.config, warnings: result.warnings.map(locate) };
+    },
+
+    async write(config: Config): Promise<void> {
+      await mkdir(dirname(path), { recursive: true });
+      // 末尾の改行を付けるのは、テキストとして扱う道具（diff・エディタ）と噛み合わせるため
+      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+    },
+  };
+}
+
+/**
+ * 実際に使う設定を組み立てる。**優先順位は 環境変数 > 設定ファイル > 既定値。**
+ *
+ * コマンドラインオプションはこれより優先されるが、コマンドごとに名前も有無も違うので
+ * 各コマンドが最後に重ねる。ここでは全コマンドに共通する2層だけを合成する。
+ */
+export async function loadEffectiveConfig(
+  store: ConfigStore,
+  env: Readonly<Record<string, string | undefined>>,
+): Promise<ConfigResult> {
+  return overrideFromEnv(await store.read(), env);
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -49,24 +49,45 @@ const DEFAULT_DIR_NAME = ".tock";
 /** 保存先を差し替えるための環境変数。 */
 const DIR_ENV_NAME = "TOCK_DIR";
 
-/** 保存するファイル名。 */
+/** 記録を保存するファイル名。 */
 const FILE_NAME = "entries.jsonl";
 
+/** 設定を保存するファイル名。 */
+const CONFIG_FILE_NAME = "config.json";
+
 /**
- * 保存先のパスを決める。
+ * 保存先のディレクトリを決める。
  *
  * 環境変数とホームディレクトリを引数で受け取るので、テストから実際の `~/.tock` を
  * 触らずに検証できる。
  */
+function resolveDir(env: Readonly<Record<string, string | undefined>>, homeDir: string): string {
+  const configured = env[DIR_ENV_NAME];
+
+  if (configured !== undefined && configured.trim() !== "") {
+    return configured;
+  }
+
+  return join(homeDir, DEFAULT_DIR_NAME);
+}
+
+/** 記録の保存先のパスを決める。 */
 export function resolveStorePath(
   env: Readonly<Record<string, string | undefined>>,
   homeDir: string,
 ): string {
-  const configured = env[DIR_ENV_NAME];
+  return join(resolveDir(env, homeDir), FILE_NAME);
+}
 
-  if (configured !== undefined && configured.trim() !== "") {
-    return join(configured, FILE_NAME);
-  }
-
-  return join(homeDir, DEFAULT_DIR_NAME, FILE_NAME);
+/**
+ * 設定ファイルのパスを決める。
+ *
+ * 記録と同じディレクトリに置く。`TOCK_DIR` を切り替えれば設定ごと差し替わるので、
+ * テストや検証で実際の `~/.tock/config.json` を読み書きしない。
+ */
+export function resolveConfigPath(
+  env: Readonly<Record<string, string | undefined>>,
+  homeDir: string,
+): string {
+  return join(resolveDir(env, homeDir), CONFIG_FILE_NAME);
 }

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -1,0 +1,194 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createConfigCommand } from "../../src/commands/config.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import { type ConfigStore, createJsonConfigStore } from "../../src/store/config-store.js";
+
+let dir = "";
+let path = "";
+let store: ConfigStore;
+let out: string[];
+let err: string[];
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-config-cmd-"));
+  path = join(dir, "config.json");
+  store = createJsonConfigStore(path);
+  out = [];
+  err = [];
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** 環境変数を渡さない既定の呼び出し。 */
+function command(env: Readonly<Record<string, string | undefined>> = {}) {
+  return createConfigCommand(store, env);
+}
+
+describe("config の操作の指定", () => {
+  it("操作が無ければエラーにし、使える操作を示す", async () => {
+    await expect(command().run([], io)).rejects.toThrow(UserError);
+    await expect(command().run([], io)).rejects.toThrow(/get.*set|set.*get/s);
+  });
+
+  it("知らない操作はエラーにする", async () => {
+    await expect(command().run(["list"], io)).rejects.toThrow(UserError);
+  });
+
+  it("空文字の操作もエラーにする（境界）", async () => {
+    await expect(command().run([""], io)).rejects.toThrow(UserError);
+  });
+
+  it("エラーのときは設定ファイルを作らない", async () => {
+    await expect(command().run(["list"], io)).rejects.toThrow(UserError);
+
+    await expect(readFile(path, "utf8")).rejects.toThrow();
+  });
+});
+
+describe("config get", () => {
+  it("キーを省略するとすべての設定を key=value で出す", async () => {
+    await command().run(["get"], io);
+
+    expect(out).toEqual([`weekStartsOn=${String(DEFAULT_CONFIG.weekStartsOn)}`]);
+    expect(err).toEqual([]);
+  });
+
+  it("キーを指定すると値だけを出す（スクリプトから使える）", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    await command().run(["get", "weekStartsOn"], io);
+
+    expect(out).toEqual(["0"]);
+  });
+
+  it("設定ファイルが無くても既定値を出す（境界）", async () => {
+    await command().run(["get", "weekStartsOn"], io);
+
+    expect(out).toEqual([String(DEFAULT_CONFIG.weekStartsOn)]);
+    expect(err).toEqual([]);
+  });
+
+  it("環境変数が設定ファイルより優先された値を出す（DoD）", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    await command({ TOCK_WEEK_STARTS_ON: "5" }).run(["get", "weekStartsOn"], io);
+
+    expect(out).toEqual(["5"]);
+  });
+
+  it("知らないキーは拒否する（DoD）", async () => {
+    await expect(command().run(["get", "timezone"], io)).rejects.toThrow(UserError);
+    await expect(command().run(["get", "timezone"], io)).rejects.toThrow(/weekStartsOn/);
+  });
+
+  it("余分な引数はエラーにする", async () => {
+    await expect(command().run(["get", "weekStartsOn", "0"], io)).rejects.toThrow(UserError);
+  });
+
+  it("壊れた設定ファイルの警告は stderr に出し、値は stdout に出す（DoD）", async () => {
+    await writeFile(path, "壊れています", "utf8");
+
+    await command().run(["get", "weekStartsOn"], io);
+
+    expect(out).toEqual([String(DEFAULT_CONFIG.weekStartsOn)]);
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain(path);
+  });
+});
+
+describe("config set", () => {
+  it("設定ファイルに書き込む", async () => {
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ weekStartsOn: 0 });
+  });
+
+  it("書き込んだ値を get で読み戻せる", async () => {
+    await command().run(["set", "weekStartsOn", "6"], io);
+    out = [];
+
+    await command().run(["get", "weekStartsOn"], io);
+
+    expect(out).toEqual(["6"]);
+  });
+
+  it("書き込んだ内容と保存先を伝える", async () => {
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    expect(out[0]).toBe("設定しました: weekStartsOn=0");
+    expect(out[1]).toBe(path);
+  });
+
+  it("知らないキーは拒否し、ファイルを作らない（DoD）", async () => {
+    await expect(command().run(["set", "timezone", "Asia/Tokyo"], io)).rejects.toThrow(UserError);
+    await expect(command().run(["set", "timezone", "Asia/Tokyo"], io)).rejects.toThrow(/timezone/);
+
+    await expect(readFile(path, "utf8")).rejects.toThrow();
+  });
+
+  it("大文字小文字が違うキーも拒否する（DoD）", async () => {
+    await expect(command().run(["set", "weekstartson", "0"], io)).rejects.toThrow(UserError);
+  });
+
+  it("範囲外の値は拒否し、ファイルを書き換えない", async () => {
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    await expect(command().run(["set", "weekStartsOn", "7"], io)).rejects.toThrow(UserError);
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ weekStartsOn: 0 });
+  });
+
+  it("十進の整数でない値は拒否する（境界）", async () => {
+    for (const value of ["1.5", "0x6", "1e0", " 3 ", "", "月曜", "-1"]) {
+      await expect(command().run(["set", "weekStartsOn", value], io)).rejects.toThrow(UserError);
+    }
+  });
+
+  it("キーだけ・値だけの指定はエラーにする（境界）", async () => {
+    await expect(command().run(["set"], io)).rejects.toThrow(UserError);
+    await expect(command().run(["set", "weekStartsOn"], io)).rejects.toThrow(UserError);
+  });
+
+  it("余分な引数はエラーにする", async () => {
+    await expect(command().run(["set", "weekStartsOn", "0", "1"], io)).rejects.toThrow(UserError);
+  });
+
+  it("環境変数に隠される場合は警告する（設定自体は成功する）", async () => {
+    await command({ TOCK_WEEK_STARTS_ON: "5" }).run(["set", "weekStartsOn", "0"], io);
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ weekStartsOn: 0 });
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("TOCK_WEEK_STARTS_ON");
+  });
+
+  it("環境変数が無ければ余計な警告は出さない", async () => {
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    expect(err).toEqual([]);
+  });
+
+  it("壊れた設定ファイルの上に書ける（警告は出す）", async () => {
+    await writeFile(path, "壊れています", "utf8");
+
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ weekStartsOn: 0 });
+    expect(err).toHaveLength(1);
+  });
+});

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -229,3 +229,25 @@ describe("環境変数に隠される場合の注意（レビュー指摘）", (
     await expect(command().run(["set", "weekStartsOn", "05"], io)).rejects.toThrow(UserError);
   });
 });
+
+describe("set が知らないキーを消さない（レビュー指摘）", () => {
+  it("知らないキーを残したまま更新する", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 1, timezone: "Asia/Tokyo" }), "utf8");
+
+    await command().run(["set", "weekStartsOn", "0"], io);
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      weekStartsOn: 0,
+      timezone: "Asia/Tokyo",
+    });
+  });
+
+  it("知らないキーの警告は「消しません」と伝える（実際に消さないことと揃える）", async () => {
+    await writeFile(path, JSON.stringify({ timezone: "Asia/Tokyo" }), "utf8");
+
+    await command().run(["get"], io);
+
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("消しません");
+  });
+});

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -192,3 +192,40 @@ describe("config set", () => {
     expect(err).toHaveLength(1);
   });
 });
+
+describe("環境変数に隠される場合の注意（レビュー指摘）", () => {
+  it("環境変数の値が不正なら注意を出さない（実際にはファイルの値が効く）", async () => {
+    await command({ TOCK_WEEK_STARTS_ON: "月曜" }).run(["set", "weekStartsOn", "0"], io);
+
+    expect(err).toEqual([]);
+
+    // 実効値もファイルの値になっている（注意を出さないことと辻褄が合う）
+    out = [];
+    err = [];
+    await command({ TOCK_WEEK_STARTS_ON: "月曜" }).run(["get", "weekStartsOn"], io);
+    expect(out).toEqual(["0"]);
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("無視します");
+  });
+
+  it("環境変数が書き込んだ値と同じなら注意を出さない（隠れていない）", async () => {
+    await command({ TOCK_WEEK_STARTS_ON: "0" }).run(["set", "weekStartsOn", "0"], io);
+
+    expect(err).toEqual([]);
+  });
+
+  it("環境変数が別の妥当な値なら、実効値を添えて注意する", async () => {
+    await command({ TOCK_WEEK_STARTS_ON: "5" }).run(["set", "weekStartsOn", "0"], io);
+
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("TOCK_WEEK_STARTS_ON");
+    expect(err[0]).toContain("5");
+  });
+
+  it("先頭ゼロの環境変数は不正なので注意を出さない（判定が config set と揃っている）", async () => {
+    await command({ TOCK_WEEK_STARTS_ON: "05" }).run(["set", "weekStartsOn", "0"], io);
+
+    expect(err).toEqual([]);
+    await expect(command().run(["set", "weekStartsOn", "05"], io)).rejects.toThrow(UserError);
+  });
+});

--- a/tests/commands/edit.test.ts
+++ b/tests/commands/edit.test.ts
@@ -10,6 +10,8 @@ import { createStartCommand } from "../../src/commands/start.js";
 import { createStopCommand } from "../../src/commands/stop.js";
 import type { Entry } from "../../src/domain/entry.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import type { LoadConfig } from "../../src/store/config-store.js";
 import type { Store } from "../../src/store/store.js";
 
 let dir = "";
@@ -26,6 +28,9 @@ const io = {
     err.push(line);
   },
 };
+
+/** 一覧の確認に使う `log` は設定を読まない（既定値のみ）。 */
+const defaultConfig: LoadConfig = () => Promise.resolve({ config: DEFAULT_CONFIG, warnings: [] });
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-edit-"));
@@ -406,7 +411,7 @@ describe("edit の結果は log に反映される", () => {
 
     await createEditCommand(deps(NOW)).run([id, "--note", "実装"], io);
     out = [];
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out[0]).toContain("実装");
     expect(out[0]).not.toContain("設計");
@@ -465,7 +470,7 @@ describe("edit と日跨ぎの記録", () => {
 
     await createEditCommand(deps(local(14, 10))).run([id, "--end", "02:30"], io);
     out = [];
-    await createLogCommand(deps(local(14, 10))).run([], io);
+    await createLogCommand(deps(local(14, 10)), defaultConfig).run([], io);
 
     // 23:00 → 翌 02:30 は 3h 30m
     expect(out[0]).toContain("3h 30m");

--- a/tests/commands/export.test.ts
+++ b/tests/commands/export.test.ts
@@ -424,3 +424,29 @@ describe("export --period this-week と週の開始曜日の設定", () => {
     expect(err[0]).toContain("config.json");
   });
 });
+
+describe("引数の打ち間違いで設定ファイルを読まない（レビュー指摘）", () => {
+  function loadFrom(env: Readonly<Record<string, string | undefined>>): LoadConfig {
+    return () => loadEffectiveConfig(createJsonConfigStore(join(dir, "config.json")), env);
+  }
+
+  it("--format の打ち間違いでは、壊れた設定ファイルの警告が出ない", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await expect(
+      createExportCommand(deps(NOW), loadFrom({})).run(["--format", "xml"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(err).toEqual([]);
+  });
+
+  it("知らないオプションでも同じ", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await expect(
+      createExportCommand(deps(NOW), loadFrom({})).run(["--format", "csv", "--limit", "3"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(err).toEqual([]);
+  });
+});

--- a/tests/commands/log.test.ts
+++ b/tests/commands/log.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,6 +8,12 @@ import { createLogCommand } from "../../src/commands/log.js";
 import { createStartCommand } from "../../src/commands/start.js";
 import { createStopCommand } from "../../src/commands/stop.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import {
+  createJsonConfigStore,
+  type LoadConfig,
+  loadEffectiveConfig,
+} from "../../src/store/config-store.js";
 import type { Store } from "../../src/store/store.js";
 
 let dir = "";
@@ -24,6 +30,14 @@ const io = {
     err.push(line);
   },
 };
+
+/**
+ * 設定を読まない読み取り（既定値のみ）。
+ *
+ * このファイルは集計の中身を見るので、設定の層は固定しておく。設定が効くことの検証は
+ * `tests/commands/config.test.ts` と、このファイルの「週の開始曜日の優先順位」に置く。
+ */
+const defaultConfig: LoadConfig = () => Promise.resolve({ config: DEFAULT_CONFIG, warnings: [] });
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-log-"));
@@ -77,7 +91,7 @@ describe("log", () => {
     await record(local(13, 9), local(13, 10), "設計 #work");
     await record(local(13, 10), local(13, 11), "実装 #work");
 
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out).toHaveLength(2);
     expect(out[0]).toContain("実装");
@@ -88,7 +102,7 @@ describe("log", () => {
   it("各行に編集で使える ID が含まれている", async () => {
     await record(local(13, 9), local(13, 10), "設計");
 
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     // 保存された ID がそのまま行に出ていること
     const entries = await store.listByRange({ start: local(1, 0), end: local(28, 0) });
@@ -99,7 +113,7 @@ describe("log", () => {
   });
 
   it("記録が1件も無いときは「該当なし」を出して成功する（終了コード 0）", async () => {
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out).toEqual(["該当する記録はありません"]);
     expect(err).toEqual([]);
@@ -108,7 +122,7 @@ describe("log", () => {
   it("実行中の記録も一覧に出る", async () => {
     await startOnly(local(13, 11), "レビュー #work");
 
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("レビュー");
@@ -119,7 +133,7 @@ describe("log", () => {
     await record(local(13, 9), local(13, 10), "設計");
     const before = await store.listByRange({ start: local(1, 0), end: local(28, 0) });
 
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(await store.listByRange({ start: local(1, 0), end: local(28, 0) })).toEqual(before);
   });
@@ -132,59 +146,64 @@ describe("log --period", () => {
   });
 
   it("today を指定すると当日の記録だけ出る", async () => {
-    await createLogCommand(deps(NOW)).run(["--period", "today"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--period", "today"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("当日");
   });
 
   it("yesterday を指定すると前日の記録だけ出る", async () => {
-    await createLogCommand(deps(NOW)).run(["--period", "yesterday"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--period", "yesterday"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("前日");
   });
 
   it("日付を直接指定できる", async () => {
-    await createLogCommand(deps(NOW)).run(["--period", "2026-08-12"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--period", "2026-08-12"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("前日");
   });
 
   it("日付の範囲を指定できる（終端の日を含む）", async () => {
-    await createLogCommand(deps(NOW)).run(["--period", "2026-08-12..2026-08-13"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(
+      ["--period", "2026-08-12..2026-08-13"],
+      io,
+    );
 
     expect(out).toHaveLength(2);
   });
 
   it("--period を省略すると期間で絞り込まない", async () => {
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out).toHaveLength(2);
   });
 
   it("該当0件でもエラーにせず「該当なし」を出す", async () => {
-    await createLogCommand(deps(NOW)).run(["--period", "2026-08-01"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--period", "2026-08-01"], io);
 
     expect(out).toEqual(["該当する記録はありません"]);
     expect(err).toEqual([]);
   });
 
   it("解釈できない期間は UserError で失敗する", async () => {
-    await expect(createLogCommand(deps(NOW)).run(["--period", "nonsense"], io)).rejects.toThrow(
-      UserError,
-    );
+    await expect(
+      createLogCommand(deps(NOW), defaultConfig).run(["--period", "nonsense"], io),
+    ).rejects.toThrow(UserError);
   });
 
   it("存在しない日付は UserError で失敗する（境界）", async () => {
-    await expect(createLogCommand(deps(NOW)).run(["--period", "2026-02-30"], io)).rejects.toThrow(
-      UserError,
-    );
+    await expect(
+      createLogCommand(deps(NOW), defaultConfig).run(["--period", "2026-02-30"], io),
+    ).rejects.toThrow(UserError);
   });
 
   it("--period の値が無い場合は UserError で失敗する", async () => {
-    await expect(createLogCommand(deps(NOW)).run(["--period"], io)).rejects.toThrow(UserError);
+    await expect(createLogCommand(deps(NOW), defaultConfig).run(["--period"], io)).rejects.toThrow(
+      UserError,
+    );
   });
 });
 
@@ -196,42 +215,47 @@ describe("log --tag", () => {
   });
 
   it("指定したタグの記録だけ出る", async () => {
-    await createLogCommand(deps(NOW)).run(["--tag", "work"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--tag", "work"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("設計");
   });
 
   it("親タグを指定すると子タグの記録も出る（階層）", async () => {
-    await createLogCommand(deps(NOW)).run(["--tag", "proj"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--tag", "proj"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("実装");
   });
 
   it("`#` 付きで指定してもよい", async () => {
-    await createLogCommand(deps(NOW)).run(["--tag", "#work"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--tag", "#work"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("設計");
   });
 
   it("該当0件でもエラーにせず「該当なし」を出す", async () => {
-    await createLogCommand(deps(NOW)).run(["--tag", "nothing"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--tag", "nothing"], io);
 
     expect(out).toEqual(["該当する記録はありません"]);
     expect(err).toEqual([]);
   });
 
   it("不正なタグは UserError で失敗する", async () => {
-    await expect(createLogCommand(deps(NOW)).run(["--tag", "#"], io)).rejects.toThrow(UserError);
+    await expect(
+      createLogCommand(deps(NOW), defaultConfig).run(["--tag", "#"], io),
+    ).rejects.toThrow(UserError);
   });
 
   it("期間とタグを同時に指定できる", async () => {
     await record(local(12, 9), local(12, 10), "前日の設計 #work");
     out = [];
 
-    await createLogCommand(deps(NOW)).run(["--period", "today", "--tag", "work"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(
+      ["--period", "today", "--tag", "work"],
+      io,
+    );
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("設計");
@@ -247,7 +271,7 @@ describe("log --limit", () => {
   });
 
   it("新しい順に指定件数だけ出す", async () => {
-    await createLogCommand(deps(NOW)).run(["--limit", "2"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--limit", "2"], io);
 
     expect(out).toHaveLength(2);
     expect(out[0]).toContain("3件目");
@@ -255,14 +279,14 @@ describe("log --limit", () => {
   });
 
   it("1件だけに絞れる（境界）", async () => {
-    await createLogCommand(deps(NOW)).run(["--limit", "1"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--limit", "1"], io);
 
     expect(out).toHaveLength(1);
     expect(out[0]).toContain("3件目");
   });
 
   it("件数が記録数より多くてもあるだけ出す（境界）", async () => {
-    await createLogCommand(deps(NOW)).run(["--limit", "100"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--limit", "100"], io);
 
     expect(out).toHaveLength(3);
   });
@@ -270,9 +294,9 @@ describe("log --limit", () => {
   it.each([["0"], ["-1"], ["1.5"], ["abc"], [""]])(
     "--limit が不正（%s）なら UserError で失敗する",
     async (limit) => {
-      await expect(createLogCommand(deps(NOW)).run(["--limit", limit], io)).rejects.toThrow(
-        UserError,
-      );
+      await expect(
+        createLogCommand(deps(NOW), defaultConfig).run(["--limit", limit], io),
+      ).rejects.toThrow(UserError);
     },
   );
 
@@ -287,24 +311,73 @@ describe("log --limit", () => {
     ["全角数字", "１"],
     ["区切り付き", "1_000"],
   ])("--limit が十進の整数でない（%s）なら UserError で失敗する", async (_label, limit) => {
-    await expect(createLogCommand(deps(NOW)).run(["--limit", limit], io)).rejects.toThrow(
-      UserError,
-    );
+    await expect(
+      createLogCommand(deps(NOW), defaultConfig).run(["--limit", limit], io),
+    ).rejects.toThrow(UserError);
   });
 
   it("大きな件数は通る（境界: 十進なら桁数を縛らない）", async () => {
-    await createLogCommand(deps(NOW)).run(["--limit", "1000"], io);
+    await createLogCommand(deps(NOW), defaultConfig).run(["--limit", "1000"], io);
 
     expect(out).toHaveLength(3);
   });
 
   it("--limit の値が無い場合は UserError で失敗する", async () => {
-    await expect(createLogCommand(deps(NOW)).run(["--limit"], io)).rejects.toThrow(UserError);
+    await expect(createLogCommand(deps(NOW), defaultConfig).run(["--limit"], io)).rejects.toThrow(
+      UserError,
+    );
   });
 });
 
 describe("log の未知のオプション", () => {
   it.each([["--help"], ["--unknown"], ["設計"]])("%s は UserError で失敗する", async (token) => {
-    await expect(createLogCommand(deps(NOW)).run([token], io)).rejects.toThrow(UserError);
+    await expect(createLogCommand(deps(NOW), defaultConfig).run([token], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});
+
+describe("log --period this-week と週の開始曜日の設定", () => {
+  /** 一時ディレクトリの設定ファイルから、実際に使う設定を組み立てる。 */
+  function loadFrom(env: Readonly<Record<string, string | undefined>>): LoadConfig {
+    return () => loadEffectiveConfig(createJsonConfigStore(join(dir, "config.json")), env);
+  }
+
+  it("設定した開始曜日に従って this-week の範囲が変わる", async () => {
+    // 2026-08-13 は木曜。日曜（8/9）の記録は、月曜始まりの今週には入らない
+    await record(local(9, 9), local(9, 10), "日曜の作業 #work");
+
+    await createLogCommand(deps(NOW), loadFrom({})).run(["--period", "this-week"], io);
+    expect(out).toEqual(["該当する記録はありません"]);
+
+    out = [];
+    await writeFile(join(dir, "config.json"), JSON.stringify({ weekStartsOn: 0 }), "utf8");
+    await createLogCommand(deps(NOW), loadFrom({})).run(["--period", "this-week"], io);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("日曜の作業");
+  });
+
+  it("環境変数が設定ファイルより優先される", async () => {
+    await record(local(9, 9), local(9, 10), "日曜の作業 #work");
+    await writeFile(join(dir, "config.json"), JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    await createLogCommand(deps(NOW), loadFrom({ TOCK_WEEK_STARTS_ON: "1" })).run(
+      ["--period", "this-week"],
+      io,
+    );
+
+    expect(out).toEqual(["該当する記録はありません"]);
+  });
+
+  it("設定ファイルが壊れていれば警告を出し、一覧は既定で出す", async () => {
+    await record(local(13, 9), local(13, 10), "設計 #work");
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await createLogCommand(deps(NOW), loadFrom({})).run([], io);
+
+    expect(out).toHaveLength(1);
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("config.json");
   });
 });

--- a/tests/commands/log.test.ts
+++ b/tests/commands/log.test.ts
@@ -381,3 +381,39 @@ describe("log --period this-week と週の開始曜日の設定", () => {
     expect(err[0]).toContain("config.json");
   });
 });
+
+describe("引数の打ち間違いで設定ファイルを読まない（レビュー指摘）", () => {
+  function loadFrom(env: Readonly<Record<string, string | undefined>>): LoadConfig {
+    return () => loadEffectiveConfig(createJsonConfigStore(join(dir, "config.json")), env);
+  }
+
+  it("--limit の打ち間違いでは、壊れた設定ファイルの警告が出ない", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await expect(
+      createLogCommand(deps(NOW), loadFrom({})).run(["--limit", "foo"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(err).toEqual([]);
+  });
+
+  it("--tag の打ち間違いでも同じ", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await expect(createLogCommand(deps(NOW), loadFrom({})).run(["--tag", "#"], io)).rejects.toThrow(
+      UserError,
+    );
+
+    expect(err).toEqual([]);
+  });
+
+  it("知らないオプションでも同じ", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await expect(
+      createLogCommand(deps(NOW), loadFrom({})).run(["--nope", "1"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(err).toEqual([]);
+  });
+});

--- a/tests/commands/rm.test.ts
+++ b/tests/commands/rm.test.ts
@@ -9,6 +9,8 @@ import { type Confirm, createRmCommand } from "../../src/commands/rm.js";
 import { createStartCommand } from "../../src/commands/start.js";
 import { createStopCommand } from "../../src/commands/stop.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import type { LoadConfig } from "../../src/store/config-store.js";
 import type { Store } from "../../src/store/store.js";
 
 let dir = "";
@@ -45,6 +47,9 @@ const confirmNo: Confirm = (question) => {
 const confirmNever: Confirm = () => {
   throw new Error("確認が呼ばれました（--yes のときは聞かないはず）");
 };
+
+/** 一覧の確認に使う `log` は設定を読まない（既定値のみ）。 */
+const defaultConfig: LoadConfig = () => Promise.resolve({ config: DEFAULT_CONFIG, warnings: [] });
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-rm-"));
@@ -104,7 +109,7 @@ describe("rm の削除（DoD）", () => {
 
     await createRmCommand(deps(NOW), confirmYes).run([id, "--yes"], io);
     out = [];
-    await createLogCommand(deps(NOW)).run([], io);
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out.join("\n")).not.toContain("設計");
     expect(out.join("\n")).toContain("会議");

--- a/tests/commands/week.test.ts
+++ b/tests/commands/week.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,6 +8,12 @@ import { createStartCommand } from "../../src/commands/start.js";
 import { createStopCommand } from "../../src/commands/stop.js";
 import { createWeekCommand } from "../../src/commands/week.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import {
+  createJsonConfigStore,
+  type LoadConfig,
+  loadEffectiveConfig,
+} from "../../src/store/config-store.js";
 import type { Store } from "../../src/store/store.js";
 
 let dir = "";
@@ -24,6 +30,14 @@ const io = {
     err.push(line);
   },
 };
+
+/**
+ * 設定を読まない読み取り（既定値のみ）。
+ *
+ * このファイルは集計の中身を見るので、設定の層は固定しておく。設定が効くことの検証は
+ * `tests/commands/config.test.ts` と、このファイルの「週の開始曜日の優先順位」に置く。
+ */
+const defaultConfig: LoadConfig = () => Promise.resolve({ config: DEFAULT_CONFIG, warnings: [] });
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-week-"));
@@ -72,7 +86,7 @@ describe("week", () => {
   it("今週の範囲を見出しに出す", async () => {
     await record(local(10, 9), local(10, 10), "設計 #work");
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out[0]).toContain("2026-08-10");
     expect(out[0]).toContain("2026-08-16");
@@ -82,7 +96,7 @@ describe("week", () => {
   it("曜日の見出しとタグ別の行を出す", async () => {
     await record(local(10, 9), local(10, 10), "設計 #work");
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out[1]).toContain("月");
     expect(out[1]).toContain("合計");
@@ -93,7 +107,7 @@ describe("week", () => {
     // 月曜だけに記録がある週
     await record(local(10, 9), local(10, 10), "設計 #work");
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
     const workLine = out.find((line) => line.startsWith("work")) ?? "";
 
     expect(workLine).toContain("1h");
@@ -105,7 +119,7 @@ describe("week", () => {
     await record(local(10, 9), local(10, 10), "設計 #work"); // 月
     await record(local(12, 9), local(12, 11), "実装 #work"); // 水
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
     const workLine = out.find((line) => line.startsWith("work")) ?? "";
 
     expect(workLine).toContain("1h");
@@ -117,13 +131,13 @@ describe("week", () => {
   it("最後に合計の行を出す", async () => {
     await record(local(10, 9), local(10, 10), "設計 #work");
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect((out.at(-1) ?? "").startsWith("合計")).toBe(true);
   });
 
   it("記録が1件も無ければ「記録がありません」を出して成功する（終了コード 0）", async () => {
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out[0]).toContain("2026-08-10");
     expect(out.some((line) => line.includes("記録がありません"))).toBe(true);
@@ -133,7 +147,7 @@ describe("week", () => {
   it("今週の外の記録は出さない", async () => {
     await record(local(3, 9), local(3, 10), "先週 #old");
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(out.some((line) => line.startsWith("old"))).toBe(false);
   });
@@ -142,7 +156,7 @@ describe("week", () => {
     await createStartCommand(deps(local(13, 9))).run(["レビュー #work"], io);
     out = [];
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
     const workLine = out.find((line) => line.startsWith("work")) ?? "";
 
     // 木曜の 09:00 開始、現在 12:00 なので 3h
@@ -156,7 +170,7 @@ describe("week", () => {
     await createStartCommand(deps(local(9, 22))).run(["徹夜 #work"], io);
     out = [];
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
     const workLine = out.find((line) => line.startsWith("work")) ?? "";
 
     // 月・火・水は丸1日（24h）、木は 12h
@@ -168,7 +182,7 @@ describe("week", () => {
     await record(local(10, 9), local(10, 10), "設計 #work");
     const before = await store.listByRange(allTime);
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(await store.listByRange(allTime)).toEqual(before);
   });
@@ -181,7 +195,7 @@ describe("week --offset", () => {
   });
 
   it("--offset -1 で先週になる（DoD）", async () => {
-    await createWeekCommand(deps(NOW)).run(["--offset", "-1"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "-1"], io);
 
     expect(out[0]).toContain("2026-08-03");
     expect(out[0]).toContain("2026-08-09");
@@ -190,24 +204,24 @@ describe("week --offset", () => {
   });
 
   it("--offset -2 で2週前になる（記録なし）", async () => {
-    await createWeekCommand(deps(NOW)).run(["--offset", "-2"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "-2"], io);
 
     expect(out[0]).toContain("2026-07-27");
     expect(out.some((line) => line.includes("記録がありません"))).toBe(true);
   });
 
   it("--offset 0 は今週（省略時と同じ）", async () => {
-    await createWeekCommand(deps(NOW)).run(["--offset", "0"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "0"], io);
     const withOffset = [...out];
     out = [];
 
-    await createWeekCommand(deps(NOW)).run([], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run([], io);
 
     expect(withOffset).toEqual(out);
   });
 
   it("--offset 1 で翌週になる", async () => {
-    await createWeekCommand(deps(NOW)).run(["--offset", "1"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "1"], io);
 
     expect(out[0]).toContain("2026-08-17");
   });
@@ -215,9 +229,9 @@ describe("week --offset", () => {
   it.each([["abc"], ["1.5"], [""], ["--"]])(
     "--offset が不正（%s）なら UserError で失敗する",
     async (offset) => {
-      await expect(createWeekCommand(deps(NOW)).run(["--offset", offset], io)).rejects.toThrow(
-        UserError,
-      );
+      await expect(
+        createWeekCommand(deps(NOW), defaultConfig).run(["--offset", offset], io),
+      ).rejects.toThrow(UserError);
     },
   );
 
@@ -231,33 +245,156 @@ describe("week --offset", () => {
     ["全角数字", "－１"],
     ["区切り付き", "1_0"],
   ])("--offset が十進の整数でない（%s）なら UserError で失敗する", async (_label, offset) => {
-    await expect(createWeekCommand(deps(NOW)).run(["--offset", offset], io)).rejects.toThrow(
-      UserError,
-    );
+    await expect(
+      createWeekCommand(deps(NOW), defaultConfig).run(["--offset", offset], io),
+    ).rejects.toThrow(UserError);
   });
 
   it("符号付きの十進は通る（境界: +1 と -1）", async () => {
-    await createWeekCommand(deps(NOW)).run(["--offset", "+1"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "+1"], io);
     expect(out[0]).toContain("2026-08-17");
 
     out = [];
-    await createWeekCommand(deps(NOW)).run(["--offset", "-1"], io);
+    await createWeekCommand(deps(NOW), defaultConfig).run(["--offset", "-1"], io);
     expect(out[0]).toContain("2026-08-03");
   });
 
   it("--offset の値が無い場合は UserError で失敗する", async () => {
-    await expect(createWeekCommand(deps(NOW)).run(["--offset"], io)).rejects.toThrow(UserError);
+    await expect(createWeekCommand(deps(NOW), defaultConfig).run(["--offset"], io)).rejects.toThrow(
+      UserError,
+    );
   });
 });
 
 describe("week の未知のオプション", () => {
   it.each([["--help"], ["--unknown"], ["設計"]])("%s は UserError で失敗する", async (token) => {
-    await expect(createWeekCommand(deps(NOW)).run([token], io)).rejects.toThrow(UserError);
+    await expect(createWeekCommand(deps(NOW), defaultConfig).run([token], io)).rejects.toThrow(
+      UserError,
+    );
   });
 
   it("失敗したときは何も出力しない", async () => {
-    await Promise.resolve(createWeekCommand(deps(NOW)).run(["--help"], io)).catch(() => undefined);
+    await Promise.resolve(createWeekCommand(deps(NOW), defaultConfig).run(["--help"], io)).catch(
+      () => undefined,
+    );
 
     expect(out).toEqual([]);
+  });
+});
+
+describe("週の開始曜日の優先順位（DoD）", () => {
+  /** 一時ディレクトリの設定ファイルと環境変数から、実際に使う設定を組み立てる。 */
+  function loadFrom(env: Readonly<Record<string, string | undefined>>): LoadConfig {
+    return () => loadEffectiveConfig(createJsonConfigStore(join(dir, "config.json")), env);
+  }
+
+  async function writeConfig(weekStartsOn: number): Promise<void> {
+    await writeFile(join(dir, "config.json"), JSON.stringify({ weekStartsOn }), "utf8");
+  }
+
+  /** 出力の見出し行から、週の初日を取り出す。 */
+  function firstDayOfWeek(): string {
+    return out[0] ?? "";
+  }
+
+  it("何も指定しなければ既定（月曜始まり）", async () => {
+    // 2026-08-13 は木曜。月曜始まりなら 8/10 から
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run([], io);
+
+    expect(firstDayOfWeek()).toContain("2026-08-10");
+  });
+
+  it("設定ファイルが既定より優先される", async () => {
+    await writeConfig(0);
+
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run([], io);
+
+    // 日曜始まりなら 8/9 から
+    expect(firstDayOfWeek()).toContain("2026-08-09");
+  });
+
+  it("環境変数が設定ファイルより優先される", async () => {
+    await writeConfig(0);
+
+    await createWeekCommand(deps(local(13, 12)), loadFrom({ TOCK_WEEK_STARTS_ON: "2" })).run(
+      [],
+      io,
+    );
+
+    // 火曜始まりなら 8/11 から
+    expect(firstDayOfWeek()).toContain("2026-08-11");
+  });
+
+  it("--week-starts-on が環境変数より優先される", async () => {
+    await writeConfig(0);
+
+    await createWeekCommand(deps(local(13, 12)), loadFrom({ TOCK_WEEK_STARTS_ON: "2" })).run(
+      ["--week-starts-on", "3"],
+      io,
+    );
+
+    // 水曜始まりなら 8/12 から
+    expect(firstDayOfWeek()).toContain("2026-08-12");
+  });
+
+  it("--week-starts-on だけでも効く（設定ファイルなし）", async () => {
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "0"], io);
+
+    expect(firstDayOfWeek()).toContain("2026-08-09");
+  });
+
+  it("--offset と併用できる", async () => {
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run(
+      ["--week-starts-on", "0", "--offset", "-1"],
+      io,
+    );
+
+    expect(firstDayOfWeek()).toContain("2026-08-02");
+  });
+
+  it("設定ファイルが壊れていれば警告を出し、既定で集計する（DoD）", async () => {
+    await writeFile(join(dir, "config.json"), "壊れています", "utf8");
+
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run([], io);
+
+    expect(firstDayOfWeek()).toContain("2026-08-10");
+    expect(err).toHaveLength(1);
+    expect(err[0]).toContain("config.json");
+  });
+
+  it("--week-starts-on の範囲外は UserError にする（境界）", async () => {
+    await expect(
+      createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "7"], io),
+    ).rejects.toThrow(UserError);
+    await expect(
+      createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "-1"], io),
+    ).rejects.toThrow(UserError);
+    await expect(
+      createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", ""], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("--week-starts-on の下限・上限を受け付ける（境界）", async () => {
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "0"], io);
+    expect(firstDayOfWeek()).toContain("2026-08-09");
+
+    out = [];
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "6"], io);
+    expect(firstDayOfWeek()).toContain("2026-08-08");
+  });
+
+  it("集計した記録の中身は開始曜日に従って振り分けられる", async () => {
+    // 日曜（8/9）の記録は、月曜始まりの週には入らない
+    await record(local(9, 9), local(9, 10), "日曜の作業 #work");
+
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run([], io);
+    const mondayWeek = out.join("\n");
+
+    out = [];
+    await createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "0"], io);
+    const sundayWeek = out.join("\n");
+
+    expect(mondayWeek).not.toContain("work");
+    expect(sundayWeek).toContain("work");
   });
 });

--- a/tests/commands/week.test.ts
+++ b/tests/commands/week.test.ts
@@ -8,7 +8,7 @@ import { createStartCommand } from "../../src/commands/start.js";
 import { createStopCommand } from "../../src/commands/stop.js";
 import { createWeekCommand } from "../../src/commands/week.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
-import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import { DEFAULT_CONFIG, describeConfigKey } from "../../src/domain/config.js";
 import {
   createJsonConfigStore,
   type LoadConfig,
@@ -396,5 +396,32 @@ describe("週の開始曜日の優先順位（DoD）", () => {
 
     expect(mondayWeek).not.toContain("work");
     expect(sundayWeek).toContain("work");
+  });
+});
+
+describe("--week-starts-on の判定が他の経路と揃っている（レビュー指摘）", () => {
+  function loadFrom(env: Readonly<Record<string, string | undefined>>): LoadConfig {
+    return () => loadEffectiveConfig(createJsonConfigStore(join(dir, "config.json")), env);
+  }
+
+  it("先頭ゼロはオプションでも環境変数でも弾く", async () => {
+    await expect(
+      createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "00"], io),
+    ).rejects.toThrow(UserError);
+
+    // 環境変数側も同じく弾かれ、既定（月曜始まり）のままになる
+    out = [];
+    await createWeekCommand(deps(local(13, 12)), loadFrom({ TOCK_WEEK_STARTS_ON: "00" })).run(
+      [],
+      io,
+    );
+    expect(out[0]).toContain("2026-08-10");
+    expect(err).toHaveLength(1);
+  });
+
+  it("エラーの文言は設定キーの説明から作る（経路ごとに書き分けない）", async () => {
+    await expect(
+      createWeekCommand(deps(local(13, 12)), loadFrom({})).run(["--week-starts-on", "9"], io),
+    ).rejects.toThrow(new RegExp(describeConfigKey("weekStartsOn")));
   });
 });

--- a/tests/domain/config.test.ts
+++ b/tests/domain/config.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertConfigKey,
+  CONFIG_KEYS,
+  DEFAULT_CONFIG,
+  envNameOf,
+  formatConfigValue,
+  overrideFromEnv,
+  parseConfigFile,
+  withConfigValue,
+} from "../../src/domain/config.js";
+import { DEFAULT_WEEK_STARTS_ON } from "../../src/domain/week.js";
+
+describe("設定の既定値", () => {
+  it("週の開始曜日の既定は domain の既定と同じ（二重に持たない）", () => {
+    expect(DEFAULT_CONFIG.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+  });
+
+  it("使えるキーの一覧が空でない", () => {
+    expect(CONFIG_KEYS.length).toBeGreaterThan(0);
+  });
+});
+
+describe("parseConfigFile の正常系", () => {
+  it("設定された値を読む", () => {
+    const { config, warnings } = parseConfigFile({ weekStartsOn: 0 });
+
+    expect(config.weekStartsOn).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("ファイルが無い（undefined）場合は既定値で、警告も出さない（境界）", () => {
+    expect(parseConfigFile(undefined)).toEqual({ config: DEFAULT_CONFIG, warnings: [] });
+  });
+
+  it("空のオブジェクトは既定値で、警告も出さない（境界）", () => {
+    expect(parseConfigFile({})).toEqual({ config: DEFAULT_CONFIG, warnings: [] });
+  });
+
+  it("週の開始曜日の下限（0=日曜）を受け付ける（境界）", () => {
+    expect(parseConfigFile({ weekStartsOn: 0 }).config.weekStartsOn).toBe(0);
+  });
+
+  it("週の開始曜日の上限（6=土曜）を受け付ける（境界）", () => {
+    expect(parseConfigFile({ weekStartsOn: 6 }).config.weekStartsOn).toBe(6);
+  });
+});
+
+describe("parseConfigFile の壊れた設定（DoD）", () => {
+  it("オブジェクトでなければ既定値へフォールバックし、警告を出す", () => {
+    const { config, warnings } = parseConfigFile("weekStartsOn=0");
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("オブジェクト");
+  });
+
+  it("配列も既定値へフォールバックする（境界）", () => {
+    const { config, warnings } = parseConfigFile([{ weekStartsOn: 0 }]);
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("null も既定値へフォールバックする（境界）", () => {
+    const { config, warnings } = parseConfigFile(null);
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("範囲外の値は既定値へフォールバックし、キー名を含む警告を出す", () => {
+    const { config, warnings } = parseConfigFile({ weekStartsOn: 7 });
+
+    expect(config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("weekStartsOn");
+  });
+
+  it("負の値も弾く（境界）", () => {
+    const { config, warnings } = parseConfigFile({ weekStartsOn: -1 });
+
+    expect(config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("小数は弾く（境界）", () => {
+    expect(parseConfigFile({ weekStartsOn: 1.5 }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+  });
+
+  it("数値でない型は弾く", () => {
+    expect(parseConfigFile({ weekStartsOn: "1" }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+    expect(parseConfigFile({ weekStartsOn: null }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+    expect(parseConfigFile({ weekStartsOn: true }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+  });
+
+  it("知らないキーは無視して警告を出す（正しいキーは読む）", () => {
+    const { config, warnings } = parseConfigFile({ weekStartsOn: 0, timezone: "Asia/Tokyo" });
+
+    expect(config.weekStartsOn).toBe(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("timezone");
+  });
+
+  it("壊れたキーと知らないキーが同時にあれば警告は2件になる", () => {
+    const { warnings } = parseConfigFile({ weekStartsOn: 99, rounding: 15 });
+
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("overrideFromEnv（優先順位: 環境変数 > 設定ファイル）", () => {
+  const fromFile = { config: { weekStartsOn: 0 }, warnings: [] };
+
+  it("環境変数があれば設定ファイルの値より優先する（DoD）", () => {
+    const { config } = overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "6" });
+
+    expect(config.weekStartsOn).toBe(6);
+  });
+
+  it("環境変数が無ければ設定ファイルの値を残す（DoD）", () => {
+    expect(overrideFromEnv(fromFile, {}).config.weekStartsOn).toBe(0);
+  });
+
+  it("環境変数が空文字なら「指定なし」として扱う（境界）", () => {
+    expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "" }).config.weekStartsOn).toBe(0);
+  });
+
+  it("環境変数の値が不正なら無視して警告を出す（設定ファイルの値が残る）", () => {
+    const { config, warnings } = overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "月曜" });
+
+    expect(config.weekStartsOn).toBe(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("TOCK_WEEK_STARTS_ON");
+  });
+
+  it("十進の整数だけを受け付ける（0x6 や 1e0 を通さない）", () => {
+    expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "0x6" }).config.weekStartsOn).toBe(0);
+    expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "1e0" }).config.weekStartsOn).toBe(0);
+    expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: " 6 " }).config.weekStartsOn).toBe(0);
+  });
+
+  it("設定ファイルの警告は消さずに引き継ぐ", () => {
+    const withWarning = { config: DEFAULT_CONFIG, warnings: ["設定ファイルが壊れています"] };
+
+    const { warnings } = overrideFromEnv(withWarning, { TOCK_WEEK_STARTS_ON: "6" });
+
+    expect(warnings).toEqual(["設定ファイルが壊れています"]);
+  });
+
+  it("環境変数名はキーから決まる", () => {
+    expect(envNameOf("weekStartsOn")).toBe("TOCK_WEEK_STARTS_ON");
+  });
+});
+
+describe("assertConfigKey（未知のキーの拒否・DoD）", () => {
+  it("使えるキーはそのまま返す", () => {
+    expect(assertConfigKey("weekStartsOn")).toBe("weekStartsOn");
+  });
+
+  it("知らないキーは Error にし、使えるキーを示す", () => {
+    expect(() => assertConfigKey("timezone")).toThrow(/timezone/);
+    expect(() => assertConfigKey("timezone")).toThrow(/weekStartsOn/);
+  });
+
+  it("大文字小文字が違うキーも拒否する（別のキーとして扱わない）", () => {
+    expect(() => assertConfigKey("weekstartson")).toThrow();
+  });
+
+  it("空文字も拒否する（境界）", () => {
+    expect(() => assertConfigKey("")).toThrow();
+  });
+});
+
+describe("withConfigValue / formatConfigValue", () => {
+  it("文字列で与えた値を設定に反映する", () => {
+    expect(withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "0").weekStartsOn).toBe(0);
+  });
+
+  it("元の設定を書き換えない", () => {
+    const before = { ...DEFAULT_CONFIG };
+    withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "0");
+
+    expect(DEFAULT_CONFIG).toEqual(before);
+  });
+
+  it("範囲外の値は Error にする", () => {
+    expect(() => withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "7")).toThrow(/weekStartsOn/);
+  });
+
+  it("整数でない値は Error にする（境界）", () => {
+    expect(() => withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "1.5")).toThrow();
+    expect(() => withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "")).toThrow();
+    expect(() => withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "月曜")).toThrow();
+  });
+
+  it("設定した値を文字列で読み出せる", () => {
+    const config = withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "6");
+
+    expect(formatConfigValue(config, "weekStartsOn")).toBe("6");
+  });
+});

--- a/tests/domain/config.test.ts
+++ b/tests/domain/config.test.ts
@@ -4,10 +4,12 @@ import {
   assertConfigKey,
   CONFIG_KEYS,
   DEFAULT_CONFIG,
+  describeConfigKey,
   envNameOf,
   formatConfigValue,
   overrideFromEnv,
   parseConfigFile,
+  parseConfigText,
   withConfigValue,
 } from "../../src/domain/config.js";
 import { DEFAULT_WEEK_STARTS_ON } from "../../src/domain/week.js";
@@ -139,7 +141,8 @@ describe("overrideFromEnv（優先順位: 環境変数 > 設定ファイル）",
     expect(warnings[0]).toContain("TOCK_WEEK_STARTS_ON");
   });
 
-  it("十進の整数だけを受け付ける（0x6 や 1e0 を通さない）", () => {
+  it("十進の整数だけを受け付ける（0x6 や 1e0 や先頭ゼロを通さない）", () => {
+    expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "06" }).config.weekStartsOn).toBe(0);
     expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "0x6" }).config.weekStartsOn).toBe(0);
     expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: "1e0" }).config.weekStartsOn).toBe(0);
     expect(overrideFromEnv(fromFile, { TOCK_WEEK_STARTS_ON: " 6 " }).config.weekStartsOn).toBe(0);
@@ -203,5 +206,44 @@ describe("withConfigValue / formatConfigValue", () => {
     const config = withConfigValue(DEFAULT_CONFIG, "weekStartsOn", "6");
 
     expect(formatConfigValue(config, "weekStartsOn")).toBe("6");
+  });
+});
+
+describe("文字列の解釈が経路によって食い違わない", () => {
+  // 週の開始曜日は 環境変数 / config set / --week-starts-on の3経路で文字列として渡る。
+  // 当初は --week-starts-on だけ1桁に限っていたため、`00` が経路によって通ったり
+  // 弾かれたりしていた（レビューで指摘）
+  const accepted = ["0", "1", "6"];
+  const rejected = ["00", "06", "7", "-1", "1.5", "0x6", "1e0", " 3 ", "", "月曜"];
+
+  it("受け付ける文字列は parseConfigText で1つに決まる", () => {
+    for (const text of accepted) {
+      expect(parseConfigText("weekStartsOn", text)).toBe(Number(text));
+    }
+  });
+
+  it("弾く文字列も parseConfigText で1つに決まる（先頭ゼロを含む）", () => {
+    for (const text of rejected) {
+      expect(parseConfigText("weekStartsOn", text)).toBeUndefined();
+    }
+  });
+
+  it("環境変数と config set が同じ判定になる", () => {
+    for (const text of rejected) {
+      expect(
+        overrideFromEnv(
+          { config: { weekStartsOn: 4 }, warnings: [] },
+          {
+            TOCK_WEEK_STARTS_ON: text,
+          },
+        ).config.weekStartsOn,
+      ).toBe(4);
+      expect(() => withConfigValue(DEFAULT_CONFIG, "weekStartsOn", text)).toThrow();
+    }
+  });
+
+  it("キーに書ける値の説明も1箇所から取る", () => {
+    expect(describeConfigKey("weekStartsOn")).toContain("0");
+    expect(describeConfigKey("weekStartsOn")).toContain("6");
   });
 });

--- a/tests/domain/config.test.ts
+++ b/tests/domain/config.test.ts
@@ -247,3 +247,11 @@ describe("文字列の解釈が経路によって食い違わない", () => {
     expect(describeConfigKey("weekStartsOn")).toContain("6");
   });
 });
+
+describe("Config の形と CONFIG_KEYS が一致している", () => {
+  // config-store の write は `{ ...生の値, ...config }` で知らないキーを残す。
+  // Config に CONFIG_KEYS 以外のフィールドがあると、それが設定ファイルに混ざる
+  it("Config のフィールドは CONFIG_KEYS と過不足なく同じ", () => {
+    expect(Object.keys(DEFAULT_CONFIG).toSorted()).toEqual([...CONFIG_KEYS].toSorted());
+  });
+});

--- a/tests/domain/config.test.ts
+++ b/tests/domain/config.test.ts
@@ -91,8 +91,12 @@ describe("parseConfigFile の壊れた設定（DoD）", () => {
 
   it("数値でない型は弾く", () => {
     expect(parseConfigFile({ weekStartsOn: "1" }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
-    expect(parseConfigFile({ weekStartsOn: null }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
-    expect(parseConfigFile({ weekStartsOn: true }).config.weekStartsOn).toBe(DEFAULT_WEEK_STARTS_ON);
+    expect(parseConfigFile({ weekStartsOn: null }).config.weekStartsOn).toBe(
+      DEFAULT_WEEK_STARTS_ON,
+    );
+    expect(parseConfigFile({ weekStartsOn: true }).config.weekStartsOn).toBe(
+      DEFAULT_WEEK_STARTS_ON,
+    );
   });
 
   it("知らないキーは無視して警告を出す（正しいキーは読む）", () => {

--- a/tests/store/config-store.test.ts
+++ b/tests/store/config-store.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -199,5 +199,55 @@ describe("loadEffectiveConfig（優先順位・DoD）", () => {
 
     expect(config.weekStartsOn).toBe(3);
     expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("書き込みが知らないキーを消さない（レビュー指摘）", () => {
+  it("知らないキーを残したまま、知っているキーだけを更新する", async () => {
+    await writeFile(
+      path,
+      JSON.stringify({ weekStartsOn: 1, timezone: "Asia/Tokyo", rounding: { unitMinutes: 15 } }),
+      "utf8",
+    );
+
+    await createJsonConfigStore(path).write({ weekStartsOn: 0 });
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      weekStartsOn: 0,
+      timezone: "Asia/Tokyo",
+      rounding: { unitMinutes: 15 },
+    });
+  });
+
+  it("設定項目が増えても、古い版が新しい版のキーを消さない", async () => {
+    // #63 / #64 / #65 で足すキーを、この版が知らない状態として置く
+    const store = createJsonConfigStore(path);
+    await writeFile(path, JSON.stringify({ timezone: "Asia/Tokyo" }), "utf8");
+
+    await store.write({ weekStartsOn: 6 });
+    await store.write({ weekStartsOn: 2 });
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      timezone: "Asia/Tokyo",
+      weekStartsOn: 2,
+    });
+  });
+
+  it("JSON として読めないファイルは残しようがないので、設定だけを書く", async () => {
+    await writeFile(path, "壊れています", "utf8");
+
+    await createJsonConfigStore(path).write({ weekStartsOn: 0 });
+
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ weekStartsOn: 0 });
+  });
+
+  it("知らないキーは読まない（値は既定のまま）が、警告は「消さない」と伝える", async () => {
+    await writeFile(path, JSON.stringify({ timezone: "Asia/Tokyo" }), "utf8");
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("消しません");
   });
 });

--- a/tests/store/config-store.test.ts
+++ b/tests/store/config-store.test.ts
@@ -1,0 +1,203 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import { createJsonConfigStore, loadEffectiveConfig } from "../../src/store/config-store.js";
+import { resolveConfigPath, resolveStorePath } from "../../src/store/store.js";
+
+let dir = "";
+let path = "";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-config-"));
+  path = join(dir, "config.json");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("resolveConfigPath", () => {
+  it("TOCK_DIR があればその中の config.json を指す", () => {
+    expect(resolveConfigPath({ TOCK_DIR: "/tmp/example" }, "/home/someone")).toBe(
+      join("/tmp/example", "config.json"),
+    );
+  });
+
+  it("TOCK_DIR が無ければホームの .tock を指す", () => {
+    expect(resolveConfigPath({}, "/home/someone")).toBe(
+      join("/home/someone", ".tock", "config.json"),
+    );
+  });
+
+  it("空文字の TOCK_DIR は指定なしとして扱う（境界）", () => {
+    expect(resolveConfigPath({ TOCK_DIR: "   " }, "/home/someone")).toBe(
+      join("/home/someone", ".tock", "config.json"),
+    );
+  });
+
+  it("記録と同じディレクトリに置く（TOCK_DIR を切り替えると設定ごと差し替わる）", () => {
+    const env = { TOCK_DIR: "/tmp/example" };
+
+    expect(resolveConfigPath(env, "/home/someone")).toBe(join("/tmp/example", "config.json"));
+    expect(resolveStorePath(env, "/home/someone")).toBe(join("/tmp/example", "entries.jsonl"));
+  });
+});
+
+describe("設定ファイルの読み込み", () => {
+  it("書かれている値を読む", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config.weekStartsOn).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("ファイルが無ければ既定値を返し、警告も出さない（境界）", async () => {
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toEqual([]);
+  });
+
+  it("空のファイルは JSON として読めないので警告を出す（境界）", async () => {
+    await writeFile(path, "", "utf8");
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("壊れた JSON は既定値へフォールバックし、パスを含む警告を出す（DoD）", async () => {
+    await writeFile(path, "{ weekStartsOn: 0", "utf8");
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(path);
+    expect(warnings[0]).toContain("JSON");
+  });
+
+  it("値が壊れている場合の警告にもパスを添える（DoD）", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 99 }), "utf8");
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(path);
+    expect(warnings[0]).toContain("weekStartsOn");
+  });
+
+  it("存在するのに読めない場合は、黙って既定値に落とさず警告を出す", async () => {
+    // パスがディレクトリだと readFile は EISDIR で失敗する。「ファイルが無い（ENOENT）」
+    // と区別せずに既定値へ落とすと、設定が読めていないことに気づけない。
+    // 権限（chmod）で試すと root では再現しないため、実行者に依存しないこの形で固定する
+    await mkdir(join(dir, "as-dir.json"), { recursive: true });
+
+    const { config, warnings } = await createJsonConfigStore(join(dir, "as-dir.json")).read();
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("as-dir.json");
+  });
+
+  it("読めるが権限が無い場合も、黙って既定値に落とさない", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+    await chmod(path, 0o000);
+
+    const { config, warnings } = await createJsonConfigStore(path).read();
+    await chmod(path, 0o600);
+
+    // root で実行すると権限に関わらず読めてしまうため、その場合は素通しでよい
+    if (warnings.length === 0) {
+      expect(config.weekStartsOn).toBe(0);
+
+      return;
+    }
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+    expect(warnings[0]).toContain(path);
+  });
+});
+
+describe("設定ファイルの書き込み", () => {
+  it("書いた値を読み戻せる", async () => {
+    const store = createJsonConfigStore(path);
+
+    await store.write({ weekStartsOn: 6 });
+
+    expect((await store.read()).config.weekStartsOn).toBe(6);
+  });
+
+  it("親ディレクトリが無ければ作る", async () => {
+    const nested = join(dir, "a", "b", "config.json");
+    const store = createJsonConfigStore(nested);
+
+    await store.write({ weekStartsOn: 0 });
+
+    expect((await store.read()).config.weekStartsOn).toBe(0);
+  });
+
+  it("既にあるディレクトリでも失敗しない", async () => {
+    await mkdir(join(dir, "c"), { recursive: true });
+    const store = createJsonConfigStore(join(dir, "c", "config.json"));
+
+    await store.write({ weekStartsOn: 0 });
+
+    expect((await store.read()).config.weekStartsOn).toBe(0);
+  });
+
+  it("壊れたファイルの上にも書ける（書き込みで直せる）", async () => {
+    await writeFile(path, "壊れています", "utf8");
+    const store = createJsonConfigStore(path);
+
+    await store.write({ weekStartsOn: 5 });
+
+    const { config, warnings } = await store.read();
+    expect(config.weekStartsOn).toBe(5);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("loadEffectiveConfig（優先順位・DoD）", () => {
+  it("環境変数が設定ファイルより優先される", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    const { config } = await loadEffectiveConfig(createJsonConfigStore(path), {
+      TOCK_WEEK_STARTS_ON: "3",
+    });
+
+    expect(config.weekStartsOn).toBe(3);
+  });
+
+  it("環境変数が無ければ設定ファイルの値になる", async () => {
+    await writeFile(path, JSON.stringify({ weekStartsOn: 0 }), "utf8");
+
+    const { config } = await loadEffectiveConfig(createJsonConfigStore(path), {});
+
+    expect(config.weekStartsOn).toBe(0);
+  });
+
+  it("どちらも無ければ既定値になる（境界）", async () => {
+    const { config } = await loadEffectiveConfig(createJsonConfigStore(path), {});
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("設定ファイルが壊れていても、環境変数は効く", async () => {
+    await writeFile(path, "壊れています", "utf8");
+
+    const { config, warnings } = await loadEffectiveConfig(createJsonConfigStore(path), {
+      TOCK_WEEK_STARTS_ON: "3",
+    });
+
+    expect(config.weekStartsOn).toBe(3);
+    expect(warnings).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要

`~/.tock/config.json` を読み書きする仕組みと、`tock config get|set` を追加した。
設定項目は**週の開始曜日1つだけ**で、残りは切り出した Issue で足していく。

- `src/domain/config.ts` — 値の解釈と検査（純関数。ファイルにも環境変数にも触らない）
- `src/store/config-store.ts` — 読み書きと、環境変数を重ねた実効値の組み立て
- `src/commands/config.ts` — `tock config get|set`
- `src/store/store.ts` — `resolveConfigPath`（記録と同じディレクトリ）

Closes #22

### スコープの絞り込みについて

**この Issue は着手前に一度停止していた。** 利用者の判断で
[案A](https://github.com/okrago10/loop-demo/issues/22#issuecomment-5286760339)
（「設定ファイルの仕組み＋週の開始曜日」に絞り、残りを別 Issue にする）が選ばれたので、
その範囲で実装している。切り出した3件は #63（丸め）・#64（タイムゾーン）・#65（既定の出力形式）。

**DoD は絞り込みの前後で変えていない。** 3項目とも週の開始曜日1つで満たせる。

### 設計の理由

**設定が壊れていても止めない。** 設定は主目的ではなく好みの記録なので、1つの値が
読めないことで打刻や集計ができなくなるのは割に合わない。読めなかった値は既定値に落とし、
何が起きたかを**警告として stderr に出す**。黙って既定に落とすと、設定したはずの値が
効いていないことに気づけない。

**ただし `config set` は不正な値を `Error` にする。** そちらは利用者がいま打った操作で、
受け付けられなかったことをその場で伝えられる。

**1つの値が壊れていても、他の値は読む。** 全部を捨てると、1文字の打ち間違いで設定全体が
無効になる。

**優先順位のうち、環境変数と設定ファイルの合成は `loadEffectiveConfig` に一本化した。**
コマンドラインオプションだけは名前も有無もコマンドごとに違うので各コマンドが最後に重ねる。

**文字列から値を取る経路はすべて `parseConfigText` を通す。** 環境変数・`config set`・
`--week-starts-on` の3つがあり、どれか1つでも独自に検査すると同じ値が経路によって
通ったり通らなかったりする（レビューで指摘を受けて修正。下記）。

**既定値を新しく決めていない。** `DEFAULT_CONFIG.weekStartsOn` は `domain/week.ts` の
`DEFAULT_WEEK_STARTS_ON` をそのまま使う（テストで固定した）。

**キーごとの処理は `switch` + `never` にした。** キーを増やして `case` を書き忘れると
**型検査で落ちる**。

## 受け入れ条件

- [x] **優先順位のテストがある**
      → `tests/commands/week.test.ts`「週の開始曜日の優先順位（DoD）」11件
      （既定 / 設定ファイル / 環境変数 / `--week-starts-on` の4層すべてと、その競合）、
      `tests/store/config-store.test.ts`「loadEffectiveConfig（優先順位・DoD）」4件、
      `tests/domain/config.test.ts`「overrideFromEnv」8件

      実行結果（2026-08-13 木曜時点。週の初日が変わっている）:
      ```
      $ tock week                                  # 既定（月曜始まり）
      2026-08-10 〜 2026-08-16
      $ tock config set weekStartsOn 0             # 設定ファイル（日曜始まり）
      $ tock week
      2026-08-09 〜 2026-08-15
      $ TOCK_WEEK_STARTS_ON=2 tock week            # 環境変数が設定ファイルより優先
      2026-08-11 〜 2026-08-17
      $ TOCK_WEEK_STARTS_ON=2 tock week --week-starts-on 3   # オプションが最優先
      2026-08-12 〜 2026-08-18
      ```

- [x] **設定ファイルが壊れている場合に、既定値へフォールバックしつつ警告を出すテストがある**
      → `tests/domain/config.test.ts`「parseConfigFile の壊れた設定（DoD）」8件
      （オブジェクトでない / 配列 / null / 範囲外 / 負 / 小数 / 型違い / 知らないキー）、
      `tests/store/config-store.test.ts`「設定ファイルの読み込み」8件、
      `tests/commands/config.test.ts` と `week` / `log` / `export` の各コマンドでも固定

      実行結果:
      ```
      $ echo '壊れています' > ~/.tock/config.json
      $ tock config get
      設定ファイル（/tmp/.../config.json）: JSON として読めません。すべて既定値を使います
      weekStartsOn=1
      $ echo $?
      0
      $ tock week
      設定ファイル（/tmp/.../config.json）: JSON として読めません。すべて既定値を使います
      2026-08-10 〜 2026-08-16
      ```
      **警告は stderr、答えは stdout に出す**（`$(tock config get weekStartsOn)` で使っても壊れない）。
      終了コードは 0（設定が無いのは異常ではない）。

- [x] **未知のキーを `set` した場合に拒否されるテストがある**
      → `tests/commands/config.test.ts`「知らないキーは拒否し、ファイルを作らない（DoD）」
      「大文字小文字が違うキーも拒否する（DoD）」、
      `tests/domain/config.test.ts`「assertConfigKey（未知のキーの拒否・DoD）」4件

      実行結果:
      ```
      $ tock config set timezone Asia/Tokyo
      知らない設定キーです: "timezone"（使えるキー: weekStartsOn）
      $ echo $?
      1
      $ tock config get timezone
      知らない設定キーです: "timezone"（使えるキー: weekStartsOn）
      $ echo $?
      1
      ```
      **拒否したときは設定ファイルを作らない**ことまでテストで固定した。

## レビュー指摘への対応（2件。どちらも修正済み・`d327e24`）

### 1. [Major] 環境変数が不正なときの `config set` の注意が事実と食い違っていた

環境変数が空でなければ無条件に「効きません」と出していたが、`overrideFromEnv` は
**不正な値を無視してファイルの値を使う**。再現:

```
$ TOCK_WEEK_STARTS_ON=月曜 tock config set weekStartsOn 0
注意: 環境変数 TOCK_WEEK_STARTS_ON=月曜 が設定されているため、この設定は今の環境では効きません   ← 嘘
$ TOCK_WEEK_STARTS_ON=月曜 tock config get weekStartsOn
環境変数 TOCK_WEEK_STARTS_ON の値が不正です: "月曜"（…）。無視します
0   ← 実際にはファイルの値が効いている
```

判定を「環境変数があるか」から「**実際に実効値が変わるか**」に変えた。`parseConfigText` を
直接呼ぶのではなく `overrideFromEnv` に通した結果と比べているのは、優先順位の規則を
2箇所に持たないため（**今回の不具合そのものが、規則を書き写した結果だった**）。

```
$ TOCK_WEEK_STARTS_ON=月曜 tock config set weekStartsOn 0
設定しました: weekStartsOn=0     ← 注意は出ない
$ TOCK_WEEK_STARTS_ON=5 tock config set weekStartsOn 0
注意: 環境変数 TOCK_WEEK_STARTS_ON が優先されるため、この設定は今の環境では効きません（実効値: 5）
```

### 2. [Minor] `--week-starts-on` だけ文字列の検査が違っていた

`/^\d$/`（1桁）だったため、`00` が環境変数と `config set` からは通り、オプションからは
弾かれていた。**`fromText` のコメントに「片方だけ緩いと経路によって通る値が変わる」と
書いておきながら、3つ目の経路を自分で作っていた。**

`parseConfigText` として公開して1箇所に寄せ、**先頭ゼロは弾く側に揃えた**（`--limit`・
`--offset` と同じ理由）。エラーの文言も `describeConfigKey` から作る。

```
$ tock week --week-starts-on 00     → exit=1
$ tock config set weekStartsOn 00   → exit=1
$ TOCK_WEEK_STARTS_ON=00 tock config get weekStartsOn
環境変数 TOCK_WEEK_STARTS_ON の値が不正です: "00"（…）。無視します
```

## mutation test

DoD の中心にある振る舞いを9箇所壊した。

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 環境変数の重ねをやめる | 7件 |
| `--week-starts-on` を無視して設定だけを見る | 5件 |
| 壊れた値を既定値に落とさずそのまま採用する | 7件 |
| 未知のキーを通す | 5件 |
| `config set` が変更前の設定を書き戻す | 5件 |
| `log` が週の開始曜日を渡さない | 1件 |
| `export` が週の開始曜日を渡さない | 1件 |
| 読み込みの失敗をすべて「ファイルが無い」として扱う | **0件 → 1件**（下記1） |
| **環境変数があるだけで「効きません」と出す**（指摘1の戻し） | **3件** |
| **`--week-starts-on` を1桁だけの判定に戻す**（指摘2の戻し） | **0件**（下記2） |

**1. 読み込み失敗の扱いは、当初テストの穴だった。** 権限を落として読めなくするテストを
書いていたが、CI・コンテナは root で動くため権限に関わらず読めてしまい素通りしていた。
**パスがディレクトリの場合（`EISDIR`）で固定し直した**ところ、実行者に依存せず落ちるようになった。

**2. 指摘2の戻しは落ちなかった。** 先頭ゼロを弾く側に揃えた結果、`/^\d$/ + 範囲検査` と
`parseConfigText` が**入力に対して等価になった**ためで、この変更の値打ちは振る舞いではなく
**規則が1箇所しかない**ことにある。テストで検出できるのは文言を書き分けた場合だけで、
そちらは落ちることを確認した。落ちなかったことを伏せるとこの表が実際より強く見えるので明記する。

元に戻して 1110 件すべて通ることを確認済み（37 files / 1110 tests。1010 → 1110 で +100件）。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 設定ファイルなし（警告も出さない）、空のオブジェクト、空のファイル、空文字のキー・値・環境変数、`config` に操作なし |
| 同時刻 | （時刻を扱わないため該当なし） |
| 日跨ぎ | 週の初日が変わることで**週の範囲そのものが動く**ことを、記録の振り分けまで含めて固定（日曜の記録が月曜始まりの週に入らない） |
| 上限値・範囲外 | `weekStartsOn` の 0 と 6（受け付ける）、7 / -1 / 1.5 / `00` / `06`（弾く）、`0x6` / `1e0` / `" 3 "`、型違い（文字列・null・真偽値） |
| 終端のないデータ | 設定は時間を持たないため該当なし。**設定を読むコマンド（`week` / `log` / `export`）の実行中エントリの扱いは変えていない** |

**環境変数の空文字は「指定なし」として扱う。** シェルで `TOCK_WEEK_STARTS_ON=` と
書いたときに不正な値の警告を出すと、変数を消したつもりの人に無関係な警告が出る。

## `week` / `log` / `export` に触った理由

**直している性質が1つ（「週の開始曜日を設定から取る」）なので、1 PR にまとめた**
（`CLAUDE.md`「1 Issue = 1 PR の例外」）。分けると、途中の状態で同じ「今週」が
コマンドによって別の範囲を指す。

- `week` — `--week-starts-on` を追加し、設定を既定にする。#19 のコメントに
  「domain 側は開始曜日を受け取れる形にしてあるので、#22 はそれを渡すだけでよい」と
  書いてあったとおりになった
- `log` / `export` — `--period this-week` / `last-week` が設定に従う。
  **`export` の配線は PR #61 の本文で「#22 とどちらが後にマージされても1行が必要になる」と
  予告していたもの**で、#61 が先にマージされたのでこの PR で入れた

```
$ tock config set weekStartsOn 0
$ tock week
2026-08-09 〜 2026-08-15
      日  月  火  水  木  金  土  合計
work  0s  0s  0s  0s  0s  1h  0s  1h
合計  0s  0s  0s  0s  0s  1h  0s  1h
$ tock log --period this-week
c3b2e2f8-...  2026-08-14  01:00-02:00  1h  設計 #work
$ tock export --format csv --period this-week
id,start,end,duration_min,tags,note
c3b2e2f8-...,2026-08-14T01:00:00.000Z,2026-08-14T02:00:00.000Z,60,work,設計
```

`week` / `log` / `export` / `edit` / `rm` のテストは、コマンドの引数が増えたぶんだけ
`loadConfig` を渡す形に直した（既定値を返す関数を渡しており、**既存の検証内容は変えていない**）。

## スコープに入れなかったもの

- **丸め単位・丸めモード** → #63。`roundMs` に呼び出し元が無く、設定キーの置き場所が
  #7 の未回答（エントリごとに丸めるか合計を丸めるか）で変わる
- **タイムゾーン** → #64。日付・時刻の計算が実行環境の TZ に暗黙に依存しており、
  注入可能にする変更が 5ファイル・14箇所に及ぶ
- **既定の出力形式** → #65。#23（PR #61）で `--format` が入ったので、それを前提に決める
- **`config unset`（設定を消す）** → 今は設定ファイルを直接編集するか、値を既定に戻す
  ことで済む。キーが1つしかない段階で操作を増やす理由が無い

`src/domain/day.ts` と `src/commands/args.ts` のコメントにある「タイムゾーンを設定で
選べるようにするのは #22 の担当範囲」は、**#64 に振り替える必要がある**（#64 の本文に明記した）。
この PR では触っていない。

## スタック

- base: `main`（スタックなし）
- 依存の E4-1（#12）は PR #38 でマージ済み。絞り込み前に依存していた E2-3（#7）は
  丸めを #63 に切り出したため外れた

## 依存の追加

なし（JSON の読み書きは標準の `JSON` と `node:fs/promises` で足りる）。

## 検証

`npm run check` green（37 files / 1110 tests）。

- プリフライトの修正試行 **0回**（PR #60 / #61 のマージ追従はコンフリクト解消のみ）
- 実装フェーズの修正試行 **0回**
- レビュー対応フェーズの修正試行 **0回**（指摘への修正は1回で通った）