### PR TITLE
[E4-11][P1] 記録の ID が UUID で長く、一覧・編集で扱いづらい

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -54,9 +54,6 @@ export function createEditCommand(deps: CommandDeps): Command {
 
       const entries = await listAllEntries(deps.store);
       const target = resolveEntry(entries, id);
-      if (target === undefined) {
-        throw new UserError(`その id の記録がありません: ${id}`);
-      }
 
       const now = deps.now();
       const changes: EntryChanges = {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -4,7 +4,8 @@ import type { Entry } from "../domain/entry.js";
 import { endedAt, startedAt } from "../domain/entry.js";
 import { normalizeTag } from "../domain/tag.js";
 import { type CommandDeps, rejectUnknownArgs, resolveClockTimeOn, takeOption } from "./args.js";
-import { findById, listAllEntries } from "./lookup.js";
+import { shortenId, shortIdLength } from "../domain/entry-id.js";
+import { listAllEntries, resolveEntry } from "./lookup.js";
 
 /**
  * 記録を修正する。
@@ -52,7 +53,7 @@ export function createEditCommand(deps: CommandDeps): Command {
       }
 
       const entries = await listAllEntries(deps.store);
-      const target = findById(entries, id);
+      const target = resolveEntry(entries, id);
       if (target === undefined) {
         throw new UserError(`その id の記録がありません: ${id}`);
       }
@@ -74,14 +75,15 @@ export function createEditCommand(deps: CommandDeps): Command {
       const conflict = findOverlapping(edited, entries);
       if (conflict !== undefined) {
         throw new UserError(
-          `編集後の時間が別の記録と重なります: ${describe(conflict)}（id: ${conflict.id}）`,
+          `編集後の時間が別の記録と重なります: ${describe(conflict)}（id: ${shortenId(conflict.id, shortIdLength(entries.map((entry) => entry.id)))}）`,
         );
       }
 
       await deps.store.update(edited);
 
       io.out(`修正しました: ${describe(edited)}`);
-      io.out(`id: ${edited.id}`);
+      // 打った文字列ではなく、引き当てた記録の短縮 id を見せる（`log` の一覧と同じ表記）
+      io.out(`id: ${shortenId(edited.id, shortIdLength(entries.map((entry) => entry.id)))}`);
     },
   };
 }

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -3,10 +3,11 @@ import { selectLogRows } from "../domain/log.js";
 import { parsePeriodExpression } from "../domain/period-expression.js";
 import type { Period } from "../domain/period.js";
 import { normalizeTag } from "../domain/tag.js";
+import { shortIdLength } from "../domain/entry-id.js";
 import { formatLogLines } from "../format/log.js";
 import type { LoadConfig } from "../store/config-store.js";
 import { type CommandDeps, rejectUnknownArgs, takeOption } from "./args.js";
-import { ALL_TIME } from "./lookup.js";
+import { ALL_TIME, listAllEntries } from "./lookup.js";
 
 /**
  * `--limit` を省略したときの件数。
@@ -58,14 +59,21 @@ export function createLogCommand(deps: CommandDeps, loadConfig: LoadConfig): Com
 
       const period = resolvePeriod(periodValue, now, config.weekStartsOn);
 
-      const entries = await deps.store.listByRange(period);
+      // **期間で絞らずに全件を読む。** 短縮 id の桁数は「保存されている全記録の中で
+      // 重複しない長さ」でなければならず、一覧に出る分だけでは決められない
+      // （期間の外の記録と先頭が同じだと、出した文字列で引けなくなる）。
+      // `listByRange` はどの範囲を渡してもファイル全体を読むので、読み込みは増えない。
+      // 期間での絞り込みは `selectLogRows` が行う
+      const entries = await listAllEntries(deps.store);
       const rows = selectLogRows(
         entries,
         { period, ...(tag === undefined ? {} : { tag }), limit },
         now,
       );
 
-      for (const line of formatLogLines(rows)) {
+      const idLength = shortIdLength(entries.map((entry) => entry.id));
+
+      for (const line of formatLogLines(rows, idLength)) {
         io.out(line);
       }
     },

--- a/src/commands/lookup.ts
+++ b/src/commands/lookup.ts
@@ -44,12 +44,7 @@ export function resolveEntry(entries: readonly Entry[], reference: string): Entr
       throw new UserError(`その id の記録がありません: ${reference}`);
     }
     case "ambiguous": {
-      const length = shortIdLength(match.candidates.map((entry) => entry.id));
-      const listed = match.candidates.map((entry) => shortenId(entry.id, length)).join(" / ");
-
-      throw new UserError(
-        `id が複数の記録に一致します: ${reference}（候補: ${listed}）。もっと長く指定してください`,
-      );
+      throw new UserError(describeAmbiguous(reference, match.candidates));
     }
     default: {
       // 種類を増やして case を書き忘れると、ここで型検査が落ちる
@@ -57,4 +52,26 @@ export function resolveEntry(entries: readonly Entry[], reference: string): Entr
       throw new Error(`引き当ての結果を扱えません: ${JSON.stringify(unhandled)}`);
     }
   }
+}
+
+/**
+ * 曖昧だったことを利用者に伝える文を作る。
+ *
+ * **候補が区別できる表記で並ぶことを確かめる。** 短縮 id で並べるのは「どこまで打てば
+ * よいか」を示すためだが、**大文字小文字だけが違う id** では短縮しても同じ文字列に
+ * なり、`候補: aaaaaaaa / aaaaaaaa` という読めない案内になる。しかもその場合は
+ * 「もっと長く指定してください」に従っても解決しない——引き当てはケースを区別しないので、
+ * どこまで打っても曖昧なまま。**従えない助言を出さない。**
+ */
+function describeAmbiguous(reference: string, candidates: readonly Entry[]): string {
+  const length = shortIdLength(candidates.map((entry) => entry.id));
+  const shortened = candidates.map((entry) => shortenId(entry.id, length));
+  const distinguishable = new Set(shortened).size === candidates.length;
+  const listed = (distinguishable ? shortened : candidates.map((entry) => entry.id)).join(" / ");
+
+  const advice = distinguishable
+    ? "もっと長く指定してください"
+    : "大文字小文字だけが違う id があります。id で区別できないため、記録を直してください";
+
+  return `id が複数の記録に一致します: ${reference}（候補: ${listed}）。${advice}`;
 }

--- a/src/commands/lookup.ts
+++ b/src/commands/lookup.ts
@@ -1,3 +1,5 @@
+import { UserError } from "../cli.js";
+import { matchById, shortenId, shortIdLength } from "../domain/entry-id.js";
 import type { Entry } from "../domain/entry.js";
 import type { Period } from "../domain/period.js";
 import type { Store } from "../store/store.js";
@@ -21,7 +23,38 @@ export async function listAllEntries(store: Store): Promise<Entry[]> {
   return store.listByRange(ALL_TIME);
 }
 
-/** id が一致する記録を返す。無ければ `undefined`。 */
-export function findById(entries: readonly Entry[], id: string): Entry | undefined {
-  return entries.find((entry) => entry.id === id);
+/**
+ * id または その接頭辞から記録を1件に決める。決まらなければ `UserError`。
+ *
+ * **引き当ての規則は `domain/entry-id.ts` が持ち、ここは翻訳だけを行う**
+ * （domain は `UserError` を知らない）。`edit` と `rm` が同じ規則で引くように、
+ * この関数を通す以外の経路を作らない。
+ *
+ * 曖昧なときは**候補を短縮 id で並べる**。「もっと長く」とだけ言われても、
+ * どこまで打てばよいかが分からない。
+ */
+export function resolveEntry(entries: readonly Entry[], reference: string): Entry {
+  const match = matchById(entries, reference);
+
+  switch (match.kind) {
+    case "found": {
+      return match.entry;
+    }
+    case "none": {
+      throw new UserError(`その id の記録がありません: ${reference}`);
+    }
+    case "ambiguous": {
+      const length = shortIdLength(match.candidates.map((entry) => entry.id));
+      const listed = match.candidates.map((entry) => shortenId(entry.id, length)).join(" / ");
+
+      throw new UserError(
+        `id が複数の記録に一致します: ${reference}（候補: ${listed}）。もっと長く指定してください`,
+      );
+    }
+    default: {
+      // 種類を増やして case を書き忘れると、ここで型検査が落ちる
+      const unhandled: never = match;
+      throw new Error(`引き当ての結果を扱えません: ${JSON.stringify(unhandled)}`);
+    }
+  }
 }

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -1,7 +1,8 @@
 import { type CliIo, type Command, UserError } from "../cli.js";
 import type { Entry } from "../domain/entry.js";
 import { type CommandDeps, rejectUnknownArgs, takeFlag } from "./args.js";
-import { findById, listAllEntries } from "./lookup.js";
+import { shortenId, shortIdLength } from "../domain/entry-id.js";
+import { listAllEntries, resolveEntry } from "./lookup.js";
 
 /**
  * 削除してよいかを尋ねる。
@@ -41,20 +42,22 @@ export function createRmCommand(deps: CommandDeps, confirm: Confirm): Command {
 
       // **消せるものかを先に確かめる。** 存在しない id で確認を出すと、
       // 「はい」と答えたのに失敗する流れになる
-      const target = findById(await listAllEntries(deps.store), id);
-      if (target === undefined) {
-        throw new UserError(`その id の記録がありません: ${id}`);
-      }
+      const entries = await listAllEntries(deps.store);
+      const target = resolveEntry(entries, id);
 
-      if (!skipConfirm && !(await confirm(`削除しますか: ${describe(target)}（id: ${id}）`))) {
+      // 打った文字列ではなく、引き当てた記録の短縮 id を見せる。接頭辞で指定したときに
+      // 「どれが消えるのか」が分かるようにする
+      const shown = shortenId(target.id, shortIdLength(entries.map((entry) => entry.id)));
+
+      if (!skipConfirm && !(await confirm(`削除しますか: ${describe(target)}（id: ${shown}）`))) {
         io.out("中止しました。削除していません");
         return;
       }
 
-      await deps.store.delete(id);
+      await deps.store.delete(target.id);
 
       io.out(`削除しました: ${describe(target)}`);
-      io.out(`id: ${id}`);
+      io.out(`id: ${shown}`);
     },
   };
 }

--- a/src/domain/entry-id.ts
+++ b/src/domain/entry-id.ts
@@ -43,11 +43,27 @@ export function shortIdLength(ids: readonly string[], minimum = MIN_SHORT_ID_LEN
   return longest;
 }
 
-/** 切り詰めた結果がすべて異なるか。 */
+/**
+ * 切り詰めた結果がすべて異なるか。
+ *
+ * **大文字小文字は区別しない。`matchById` と同じ数え方に揃える。** 区別して数えると、
+ * ケースだけが違う id を「この桁で分かれた」と判定してしまい、一覧には別物として出るのに
+ * 引き当てでは同じものに見える——取り違えになる。
+ */
 function isDistinctAt(ids: readonly string[], length: number): boolean {
-  const seen = new Set(ids.map((id) => id.slice(0, length)));
+  const seen = new Set(ids.map((id) => normalizeId(id).slice(0, length)));
 
-  return seen.size === new Set(ids).size;
+  return seen.size === new Set(ids.map(normalizeId)).size;
+}
+
+/**
+ * 引き当てのために id を正規化する。
+ *
+ * 桁数の決定（`isDistinctAt`）と引き当て（`matchById`）が**同じ関数を通る**ようにする。
+ * 別々に書くと、片方だけ直したときに「一覧に出た表記で引けない」状態が生まれる。
+ */
+function normalizeId(id: string): string {
+  return id.trim().toLowerCase();
 }
 
 /** id を指定の桁数に切る。元より長い桁数を指定してもそのまま返す。 */
@@ -79,17 +95,23 @@ export type IdMatch =
  * `none` にする（うっかり全件を候補に出しても利用者は困るだけ）。
  */
 export function matchById(entries: readonly Entry[], reference: string): IdMatch {
-  const normalized = reference.trim().toLowerCase();
+  const normalized = normalizeId(reference);
   if (normalized === "") {
     return { kind: "none" };
   }
 
-  const exact = entries.find((entry) => entry.id.toLowerCase() === normalized);
-  if (exact !== undefined) {
-    return { kind: "found", entry: exact };
+  // **完全一致が複数あっても1件を選ばない。** ケースだけが違う id が混ざっていると
+  // ここに2件来る。`find` で先頭を返すと、2件目は永久に参照できないまま、
+  // 打った人は別の記録を編集・削除したことに気づけない
+  const exact = entries.filter((entry) => normalizeId(entry.id) === normalized);
+  const [onlyExact] = exact;
+  if (onlyExact !== undefined) {
+    return exact.length === 1
+      ? { kind: "found", entry: onlyExact }
+      : { kind: "ambiguous", candidates: exact };
   }
 
-  const candidates = entries.filter((entry) => entry.id.toLowerCase().startsWith(normalized));
+  const candidates = entries.filter((entry) => normalizeId(entry.id).startsWith(normalized));
   const [only] = candidates;
 
   if (only === undefined) {

--- a/src/domain/entry-id.ts
+++ b/src/domain/entry-id.ts
@@ -1,0 +1,103 @@
+import type { Entry } from "./entry.js";
+
+/**
+ * 記録の id の短縮と、短い指定からの引き当て。
+ *
+ * `randomId` は UUID（36桁）を返すため、一覧では1行の大半が id になり、
+ * `edit` / `rm` では利用者がそれを打つことになる。**採番はそのままにして、
+ * 表示を短くし、短い指定を接頭辞として解決する**（git の短縮 SHA と同じ考え方）。
+ *
+ * 採番自体を短くする案も採らなかった。既に保存されている UUID を持つ記録が
+ * 読めなくなる余地を作らないため（#58 の DoD）。この方針なら、保存されている値は
+ * 一切変わらない。
+ *
+ * **表示を短くする以上、その表記でそのまま引けなければならない。** 一覧に出た文字列を
+ * `edit` に渡して「そんな id は無い」と言われる状態は、短縮しないより悪い。
+ * そのため桁数は固定ではなく、**全記録の中で重複しない長さまで伸ばす**。
+ */
+
+/**
+ * 短縮 id の最小の桁数。
+ *
+ * UUID の先頭8桁は 32 ビットぶんの情報がある。個人の作業記録の規模では衝突しないが、
+ * **衝突しないことを前提にはしない**（`shortIdLength` が実際に確かめて伸ばす）。
+ */
+export const MIN_SHORT_ID_LENGTH = 8;
+
+/**
+ * その一覧で id を区別できる最小の桁数を返す。
+ *
+ * `minimum` から始めて、切り詰めた結果が重複しなくなるまで1桁ずつ伸ばす。
+ * **同じ id が2つある場合は伸ばしても解消しない**ため、最長の id の長さで打ち切る
+ * （`Entry` の id は一意なので起こらないはずだが、伸ばし続けて止まらないことは避ける）。
+ */
+export function shortIdLength(ids: readonly string[], minimum = MIN_SHORT_ID_LENGTH): number {
+  const longest = Math.max(minimum, ...ids.map((id) => id.length));
+
+  for (let length = minimum; length < longest; length += 1) {
+    if (isDistinctAt(ids, length)) {
+      return length;
+    }
+  }
+
+  return longest;
+}
+
+/** 切り詰めた結果がすべて異なるか。 */
+function isDistinctAt(ids: readonly string[], length: number): boolean {
+  const seen = new Set(ids.map((id) => id.slice(0, length)));
+
+  return seen.size === new Set(ids).size;
+}
+
+/** id を指定の桁数に切る。元より長い桁数を指定してもそのまま返す。 */
+export function shortenId(id: string, length: number): string {
+  return id.slice(0, length);
+}
+
+/** 短い指定から記録を引いた結果。 */
+export type IdMatch =
+  /** 1件に決まった。 */
+  | { readonly kind: "found"; readonly entry: Entry }
+  /** 該当なし。 */
+  | { readonly kind: "none" }
+  /** 複数に一致した。**どれか1つを勝手に選ばない。** */
+  | { readonly kind: "ambiguous"; readonly candidates: readonly Entry[] };
+
+/**
+ * id または その接頭辞から記録を引く。
+ *
+ * **完全一致を接頭辞一致より優先する。** 長さの違う id が混ざると、短いほうが
+ * 長いほうの接頭辞になりうる（`id-1` と `id-10`）。優先しないと、id 全体を
+ * 正確に打った利用者に「曖昧です」と返すことになる。
+ *
+ * **複数に一致したら1つを選ばず `ambiguous` を返す。** 取り違えて別の記録を
+ * 編集・削除するより、打ち直してもらうほうがよい。
+ *
+ * 大文字小文字は区別せず、前後の空白は無視する。どちらも「一覧からコピーした」
+ * ときに起こる揺れで、別の指定として扱う意味がない。空文字は**全件に一致させず**
+ * `none` にする（うっかり全件を候補に出しても利用者は困るだけ）。
+ */
+export function matchById(entries: readonly Entry[], reference: string): IdMatch {
+  const normalized = reference.trim().toLowerCase();
+  if (normalized === "") {
+    return { kind: "none" };
+  }
+
+  const exact = entries.find((entry) => entry.id.toLowerCase() === normalized);
+  if (exact !== undefined) {
+    return { kind: "found", entry: exact };
+  }
+
+  const candidates = entries.filter((entry) => entry.id.toLowerCase().startsWith(normalized));
+  const [only] = candidates;
+
+  if (only === undefined) {
+    return { kind: "none" };
+  }
+  if (candidates.length === 1) {
+    return { kind: "found", entry: only };
+  }
+
+  return { kind: "ambiguous", candidates };
+}

--- a/src/format/log.ts
+++ b/src/format/log.ts
@@ -1,4 +1,5 @@
 import { formatDay } from "../domain/day.js";
+import { shortenId } from "../domain/entry-id.js";
 import type { LogRow } from "../domain/log.js";
 import { pad, widestWidth } from "./columns.js";
 import { formatDuration } from "./duration.js";
@@ -23,19 +24,23 @@ const GAP = "  ";
  *
  * **ID を先頭に置く。** 編集・削除（#17）で使うため、行の先頭にあると拾いやすい。
  *
+ * **ID は `idLength` 桁に切って出す（#58）。** 桁数を呼び出し側から受け取るのは、
+ * 「保存されている全記録の中で重複しない長さ」でなければ、ここに出た文字列を
+ * そのまま `edit` / `rm` に渡せないため。表示だけ短くして参照できない状態にはしない。
+ *
  * 作業名とタグを最後に置くのは、長さが揃わない列だから。前に置くと、後ろの列の桁が
  * 作業名の長さに引きずられて読みづらくなる。
  *
  * 該当0件は**エラーではなく1行のメッセージ**にする。「今日はまだ記録していない」は
  * 正常な状態であり、`status` が実行中なしを終了コード 0 で返すのと同じ考え方。
  */
-export function formatLogLines(rows: readonly LogRow[]): string[] {
+export function formatLogLines(rows: readonly LogRow[], idLength: number): string[] {
   if (rows.length === 0) {
     return [EMPTY_MESSAGE];
   }
 
   const cells = rows.map((row) => ({
-    id: row.entryId,
+    id: shortenId(row.entryId, idLength),
     day: formatDay(row.start),
     range: timeRange(row),
     duration: formatDuration(row.durationMs),

--- a/tests/commands/short-id.test.ts
+++ b/tests/commands/short-id.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { UserError } from "../../src/cli.js";
 import { createEditCommand } from "../../src/commands/edit.js";
+import { listAllEntries } from "../../src/commands/lookup.js";
 import { createLogCommand } from "../../src/commands/log.js";
 import { createRmCommand } from "../../src/commands/rm.js";
 import { DEFAULT_CONFIG } from "../../src/domain/config.js";
@@ -207,6 +208,51 @@ describe("曖昧な指定を取り違えない（DoD）", () => {
     await expect(
       createEditCommand(deps(NOW)).run(["aaaaaaaa", "--note", "どっち"], io),
     ).rejects.toThrow(/候補/);
+  });
+
+  /**
+   * 大文字小文字だけが違う id。
+   *
+   * 引き当てはケースを区別しないので、**どこまで打っても曖昧なまま。**
+   * 短縮 id で候補を並べると同じ文字列が2つ並び、「もっと長く」に従っても解決しない。
+   */
+  describe("大文字小文字だけが違う id", () => {
+    const UPPER = "aaaaaaaaAxxx";
+    const LOWER = "aaaaaaaaaxxx";
+
+    it("id 全体を打っても別の記録を書き換えない", async () => {
+      await record(UPPER, local(13, 1), local(13, 2), "大文字の記録");
+      await record(LOWER, local(13, 3), local(13, 4), "小文字の記録");
+
+      await expect(
+        createEditCommand(deps(NOW)).run([LOWER, "--note", "直したい"], io),
+      ).rejects.toThrow(UserError);
+
+      const entries = await listAllEntries(store);
+      expect(entries.map((entry) => entry.note)).toEqual(["大文字の記録", "小文字の記録"]);
+    });
+
+    it("候補は区別できる表記（id 全体）で並べる", async () => {
+      await record(UPPER, local(13, 1), local(13, 2), "大文字の記録");
+      await record(LOWER, local(13, 3), local(13, 4), "小文字の記録");
+
+      await expect(
+        createEditCommand(deps(NOW)).run([LOWER, "--note", "直したい"], io),
+      ).rejects.toThrow(new RegExp(`${UPPER} / ${LOWER}`));
+    });
+
+    // 従えない助言を出さない
+    it("「もっと長く指定してください」とは言わない", async () => {
+      await record(UPPER, local(13, 1), local(13, 2), "大文字の記録");
+      await record(LOWER, local(13, 3), local(13, 4), "小文字の記録");
+
+      await expect(
+        createEditCommand(deps(NOW)).run([LOWER, "--note", "直したい"], io),
+      ).rejects.toThrow(/大文字小文字だけが違う/);
+      await expect(
+        createEditCommand(deps(NOW)).run([LOWER, "--note", "直したい"], io),
+      ).rejects.not.toThrow(/もっと長く/);
+    });
   });
 
   it("曖昧なときは記録を書き換えない", async () => {

--- a/tests/commands/short-id.test.ts
+++ b/tests/commands/short-id.test.ts
@@ -1,0 +1,287 @@
+import { mkdtemp, rm as removeDir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { UserError } from "../../src/cli.js";
+import { createEditCommand } from "../../src/commands/edit.js";
+import { createLogCommand } from "../../src/commands/log.js";
+import { createRmCommand } from "../../src/commands/rm.js";
+import { DEFAULT_CONFIG } from "../../src/domain/config.js";
+import { MIN_SHORT_ID_LENGTH } from "../../src/domain/entry-id.js";
+import { createEntry } from "../../src/domain/entry.js";
+import type { LoadConfig } from "../../src/store/config-store.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+let dir = "";
+let store: Store;
+let out: string[];
+let err: string[];
+
+const io = {
+  out: (line: string): void => {
+    out.push(line);
+  },
+  err: (line: string): void => {
+    err.push(line);
+  },
+};
+
+const defaultConfig: LoadConfig = () => Promise.resolve({ config: DEFAULT_CONFIG, warnings: [] });
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-short-id-"));
+  store = createJsonlStore(join(dir, "entries.jsonl"));
+  out = [];
+  err = [];
+});
+
+afterEach(async () => {
+  await removeDir(dir, { recursive: true, force: true });
+});
+
+function deps(now: Date) {
+  return { store, now: () => now, newId: () => "unused" };
+}
+
+/** ローカルの壁時計で日時を組み立てる。テストを実行環境の TZ に依存させない。 */
+function local(day: number, hours: number, minutes = 0): Date {
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(2026, 7, day);
+  date.setHours(hours, minutes, 0, 0);
+
+  return date;
+}
+
+const NOW = local(13, 18);
+
+/** 実際の `randomId` と同じ形（UUID）の id を持つ記録を保存する。 */
+async function record(id: string, start: Date, end: Date, description: string): Promise<string> {
+  await store.append(createEntry({ start, end, note: description }, { newId: () => id }));
+
+  return id;
+}
+
+/** 一覧の各行から、先頭の id 列だけを取り出す。 */
+function listedIds(lines: readonly string[]): string[] {
+  return lines.map((line) => line.split("  ")[0] ?? "");
+}
+
+const ALICE = "aaaaaaaa-1111-4000-8000-000000000001";
+const BOB = "bbbbbbbb-2222-4000-8000-000000000002";
+/** ALICE と先頭8桁が同じ id（衝突する場合の境界）。 */
+const ALICE_TWIN = "aaaaaaaa-9999-4000-8000-000000000009";
+
+async function threeRecords(): Promise<void> {
+  await record(ALICE, local(13, 9), local(13, 10), "設計");
+  await record(BOB, local(13, 11), local(13, 12), "レビュー");
+}
+
+describe("log が id を短く出す", () => {
+  it("既定では先頭8桁に切る", async () => {
+    await threeRecords();
+
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+
+    expect(listedIds(out)).toEqual(["bbbbbbbb", "aaaaaaaa"]);
+  });
+
+  it("記録が1件でも短く出す（境界）", async () => {
+    await record(ALICE, local(13, 9), local(13, 10), "設計");
+
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+
+    expect(listedIds(out)).toEqual(["aaaaaaaa"]);
+  });
+
+  it("先頭8桁が衝突する記録があれば、区別できる桁数まで伸ばす（境界）", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+
+    // "aaaaaaaa-" までは同じで、その次の桁で分かれる
+    const ids = listedIds(out);
+    expect(new Set(ids).size).toBe(3);
+    for (const id of ids) {
+      expect(id.length).toBeGreaterThan(MIN_SHORT_ID_LENGTH);
+    }
+  });
+
+  it("期間で絞っても、期間の外にある記録との衝突を考えて桁数を決める", async () => {
+    // 一覧に出るのは当日の1件だけだが、前日に先頭8桁が同じ記録がある。
+    // 出た文字列で引けなければ意味がないので、桁数は全記録から決める
+    await record(ALICE, local(13, 9), local(13, 10), "当日");
+    await record(ALICE_TWIN, local(12, 9), local(12, 10), "前日");
+
+    await createLogCommand(deps(NOW), defaultConfig).run(["--period", "today"], io);
+
+    expect(out).toHaveLength(1);
+    expect(listedIds(out)[0]?.length).toBeGreaterThan(MIN_SHORT_ID_LENGTH);
+  });
+});
+
+describe("一覧に出た表記でそのまま参照できる（DoD）", () => {
+  it("log の id をそのまま edit に渡せる", async () => {
+    await threeRecords();
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+    const [shown] = listedIds(out);
+    out = [];
+
+    await createEditCommand(deps(NOW)).run([shown ?? "", "--note", "設計レビュー"], io);
+
+    expect(out[0]).toBe("修正しました: 設計レビュー");
+    expect(out[1]).toBe(`id: ${shown ?? ""}`);
+  });
+
+  it("log の id をそのまま rm に渡せる", async () => {
+    await threeRecords();
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+    const [shown] = listedIds(out);
+    out = [];
+
+    await createRmCommand(deps(NOW), () => Promise.resolve(true)).run([shown ?? "", "--yes"], io);
+
+    expect(out[0]).toBe("削除しました: レビュー");
+    expect(out[1]).toBe(`id: ${shown ?? ""}`);
+  });
+
+  it("衝突している場合でも、一覧に出た表記でそのまま引ける（境界）", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+    const shown = listedIds(out);
+    out = [];
+
+    for (const id of shown) {
+      await createEditCommand(deps(NOW)).run([id, "--note", `直した-${id}`], io);
+    }
+
+    expect(out.filter((line) => line.startsWith("修正しました"))).toHaveLength(3);
+  });
+});
+
+describe("既存の UUID もそのまま使える（DoD）", () => {
+  it("36桁の id 全体で edit できる", async () => {
+    await threeRecords();
+
+    await createEditCommand(deps(NOW)).run([ALICE, "--note", "全体で指定"], io);
+
+    expect(out[0]).toBe("修正しました: 全体で指定");
+  });
+
+  it("36桁の id 全体で rm できる", async () => {
+    await threeRecords();
+
+    await createRmCommand(deps(NOW), () => Promise.resolve(true)).run([ALICE, "--yes"], io);
+
+    expect(out[0]).toBe("削除しました: 設計");
+  });
+
+  it("大文字で書かれた id も受け付ける", async () => {
+    await threeRecords();
+
+    await createEditCommand(deps(NOW)).run([ALICE.toUpperCase(), "--note", "大文字"], io);
+
+    expect(out[0]).toBe("修正しました: 大文字");
+  });
+
+  it("8桁より短い接頭辞でも、1件に決まれば引ける", async () => {
+    await threeRecords();
+
+    await createEditCommand(deps(NOW)).run(["a", "--note", "1文字"], io);
+
+    expect(out[0]).toBe("修正しました: 1文字");
+  });
+});
+
+describe("曖昧な指定を取り違えない（DoD）", () => {
+  it("複数に一致する接頭辞は UserError にし、候補を示す", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+
+    await expect(
+      createEditCommand(deps(NOW)).run(["aaaaaaaa", "--note", "どっち"], io),
+    ).rejects.toThrow(UserError);
+    await expect(
+      createEditCommand(deps(NOW)).run(["aaaaaaaa", "--note", "どっち"], io),
+    ).rejects.toThrow(/候補/);
+  });
+
+  it("曖昧なときは記録を書き換えない", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+
+    await expect(
+      createEditCommand(deps(NOW)).run(["aaaaaaaa", "--note", "どっち"], io),
+    ).rejects.toThrow(UserError);
+
+    out = [];
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+    expect(out.join("\n")).toContain("設計");
+    expect(out.join("\n")).toContain("実装");
+    expect(out.join("\n")).not.toContain("どっち");
+  });
+
+  it("曖昧なときは削除もしない", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+
+    await expect(
+      createRmCommand(deps(NOW), () => Promise.resolve(true)).run(["aaaaaaaa", "--yes"], io),
+    ).rejects.toThrow(UserError);
+
+    out = [];
+    await createLogCommand(deps(NOW), defaultConfig).run([], io);
+    expect(out).toHaveLength(3);
+  });
+
+  it("曖昧なときは確認も出さない（消してよいか尋ねる前に止める）", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+    let asked = false;
+
+    await expect(
+      createRmCommand(deps(NOW), () => {
+        asked = true;
+        return Promise.resolve(true);
+      }).run(["aaaaaaaa"], io),
+    ).rejects.toThrow(UserError);
+
+    expect(asked).toBe(false);
+  });
+
+  it("1桁伸ばせば決まる", async () => {
+    await threeRecords();
+    await record(ALICE_TWIN, local(13, 13), local(13, 14), "実装");
+
+    await createEditCommand(deps(NOW)).run(["aaaaaaaa-1", "--note", "決まった"], io);
+
+    expect(out[0]).toBe("修正しました: 決まった");
+  });
+});
+
+describe("該当しない id（DoD）", () => {
+  it("edit は UserError にする（終了コード 1）", async () => {
+    await threeRecords();
+
+    await expect(createEditCommand(deps(NOW)).run(["zzzzzzzz", "--note", "x"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("rm は UserError にする（終了コード 1）", async () => {
+    await threeRecords();
+
+    await expect(
+      createRmCommand(deps(NOW), () => Promise.resolve(true)).run(["zzzzzzzz", "--yes"], io),
+    ).rejects.toThrow(UserError);
+  });
+
+  it("記録が1件も無いときも UserError にする（境界）", async () => {
+    await expect(createEditCommand(deps(NOW)).run(["aaaaaaaa", "--note", "x"], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+});

--- a/tests/domain/entry-id.test.ts
+++ b/tests/domain/entry-id.test.ts
@@ -182,4 +182,57 @@ describe("shortIdLength と matchById が噛み合う（一覧に出た表記で
       });
     }
   });
+
+  /**
+   * 大文字小文字だけが違う id。
+   *
+   * `randomUUID()` は小文字なので通常は起きないが、手で直した JSONL や、他の道具が
+   * 書いた記録では起き得る。**表示側がケースを区別して桁を決め、引き当て側が区別しない**と、
+   * 一覧では別物に見えるのに同じ記録を指す——取り違えそのものになる。
+   */
+  describe("大文字小文字だけが違う id（取り違えの防止）", () => {
+    // 桁数（12）と「ケースを区別すれば分かれる桁」（9）をずらしてある。
+    // 同じにすると、区別できたつもりの答えと最長の桁数が偶然一致して検査が効かない
+    const ids = ["aaaaaaaaAxxx", "aaaaaaaaaxxx"];
+
+    // **id 全体を打っても別の記録に当たらないこと。** 完全一致を `find` で1件だけ拾うと、
+    // ケース違いの2件のうち常に先頭が返り、2件目には到達できない（片方が編集・削除
+    // できないまま、打った人は成功したと思う）
+    it("id 全体を打っても別の記録を指さない", () => {
+      const entries = ids.map(entry);
+
+      for (const each of entries) {
+        const match = matchById(entries, each.id);
+
+        expect(match.kind === "found" ? match.entry.id : match.kind).not.toBe(
+          entries.find((other) => other.id !== each.id)?.id,
+        );
+      }
+    });
+
+    it("区別できないので曖昧として返す（1件を勝手に選ばない）", () => {
+      const entries = ids.map(entry);
+
+      expect(matchById(entries, "aaaaaaaaaxxx").kind).toBe("ambiguous");
+      expect(matchById(entries, "aaaaaaaaAxxx").kind).toBe("ambiguous");
+    });
+
+    // ケースを無視すると同じ id なので、**どこまで伸ばしても分かれない。** 既存の
+    // 「同じ id が2つある」場合と同じ扱いで、最小の桁数のまま伸ばさない。
+    // 伸ばしても引けるようにはならないので、長く見せる意味がない
+    it("伸ばしても分かれないので最小の桁数のまま", () => {
+      expect(shortIdLength(ids)).toBe(MIN_SHORT_ID_LENGTH);
+    });
+
+    // 桁を伸ばさない代わりに、引き当てが「曖昧」と答えることで取り違えを防いでいる。
+    // 短い表記で引いても、勝手に1件を選ばない
+    it("一覧に出た表記で引いても1件を勝手に選ばない", () => {
+      const entries = ids.map(entry);
+      const shown = ids.map((id) => shortenId(id, shortIdLength(ids)));
+
+      for (const each of shown) {
+        expect(matchById(entries, each).kind).toBe("ambiguous");
+      }
+    });
+  });
 });

--- a/tests/domain/entry-id.test.ts
+++ b/tests/domain/entry-id.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { createEntry, type Entry } from "../../src/domain/entry.js";
+import {
+  matchById,
+  MIN_SHORT_ID_LENGTH,
+  shortenId,
+  shortIdLength,
+} from "../../src/domain/entry-id.js";
+
+function entry(id: string): Entry {
+  return createEntry({ start: "2026-08-13T09:00:00.000Z" }, { newId: () => id });
+}
+
+/** UUID の形をした id。先頭 `prefix` 桁だけを差し替える。 */
+function uuid(prefix: string): string {
+  return `${prefix}${"0123456789abcdef0123456789abcdef".slice(prefix.length, 32 - 4)}-4000-8000-000000000000`.slice(
+    0,
+    36,
+  );
+}
+
+describe("shortIdLength", () => {
+  it("衝突がなければ最小の桁数を返す", () => {
+    expect(shortIdLength(["abcdefgh1111", "12345678aaaa"])).toBe(MIN_SHORT_ID_LENGTH);
+  });
+
+  it("記録が1件でも最小の桁数を返す（境界）", () => {
+    expect(shortIdLength(["abcdefgh1111"])).toBe(MIN_SHORT_ID_LENGTH);
+  });
+
+  it("記録が0件でも最小の桁数を返す（境界）", () => {
+    expect(shortIdLength([])).toBe(MIN_SHORT_ID_LENGTH);
+  });
+
+  it("最小の桁数で衝突するなら、区別できるまで伸ばす", () => {
+    // 先頭9桁目で分かれる
+    expect(shortIdLength(["abcdefgh1zzz", "abcdefgh2zzz"])).toBe(9);
+  });
+
+  it("さらに深いところで分かれる場合も伸ばす", () => {
+    expect(shortIdLength(["abcdefgh1111zzz", "abcdefgh1111yyy"])).toBe(13);
+  });
+
+  it("3件以上のうち1組だけ衝突していても伸ばす", () => {
+    const length = shortIdLength(["abcdefgh1zzz", "abcdefgh2zzz", "00000000aaaa"]);
+
+    expect(length).toBe(9);
+  });
+
+  it("最小より短い id はそのまま扱う（テスト用の短い id が壊れない）", () => {
+    expect(shortIdLength(["id-1", "id-2"])).toBe(MIN_SHORT_ID_LENGTH);
+  });
+
+  it("片方が他方の接頭辞になっていても、長いほうの全体まで伸ばす（境界）", () => {
+    // "id-1" は "id-10" の接頭辞。8桁ではどちらも全体なので区別できる
+    expect(shortIdLength(["id-1", "id-10"])).toBe(MIN_SHORT_ID_LENGTH);
+    // 最小を短くすると、区別できるところまで伸びる
+    expect(shortIdLength(["id-1", "id-10"], 3)).toBe(5);
+  });
+
+  it("同じ id が2つあっても無限に伸ばさない（境界）", () => {
+    // 起こらないはずだが、伸ばし続けて止まらないことがないよう上限を確かめる
+    expect(shortIdLength(["abcdefgh1111", "abcdefgh1111"])).toBe(MIN_SHORT_ID_LENGTH);
+  });
+});
+
+describe("shortenId", () => {
+  it("指定した桁数に切る", () => {
+    expect(shortenId("abcdefgh1234", 8)).toBe("abcdefgh");
+  });
+
+  it("桁数より短い id はそのまま返す（境界）", () => {
+    expect(shortenId("id-1", 8)).toBe("id-1");
+  });
+
+  it("桁数が id の長さと同じならそのまま返す（境界）", () => {
+    expect(shortenId("abcdefgh", 8)).toBe("abcdefgh");
+  });
+});
+
+describe("matchById の完全一致", () => {
+  it("id 全体を指定すると、その記録を返す", () => {
+    const target = entry(uuid("aaaaaaaa"));
+    const other = entry(uuid("bbbbbbbb"));
+
+    expect(matchById([other, target], target.id)).toEqual({ kind: "found", entry: target });
+  });
+
+  it("完全一致は接頭辞一致より優先する（他の id の接頭辞になっていても曖昧にしない）", () => {
+    // "id-1" は "id-10" の接頭辞。完全一致を優先しないと曖昧になる
+    const short = entry("id-1");
+    const long = entry("id-10");
+
+    expect(matchById([short, long], "id-1")).toEqual({ kind: "found", entry: short });
+  });
+
+  it("大文字小文字を区別しない", () => {
+    const target = entry(uuid("aaaaaaaa"));
+
+    expect(matchById([target], target.id.toUpperCase())).toEqual({ kind: "found", entry: target });
+  });
+
+  it("前後の空白は無視する", () => {
+    const target = entry(uuid("aaaaaaaa"));
+
+    expect(matchById([target], `  ${target.id}  `)).toEqual({ kind: "found", entry: target });
+  });
+});
+
+describe("matchById の接頭辞一致", () => {
+  it("先頭8桁で1件に決まれば、その記録を返す", () => {
+    const target = entry(uuid("aaaaaaaa"));
+    const other = entry(uuid("bbbbbbbb"));
+
+    expect(matchById([target, other], "aaaaaaaa")).toEqual({ kind: "found", entry: target });
+  });
+
+  it("1文字でも1件に決まれば返す", () => {
+    const target = entry(uuid("aaaaaaaa"));
+    const other = entry(uuid("bbbbbbbb"));
+
+    expect(matchById([target, other], "a")).toEqual({ kind: "found", entry: target });
+  });
+
+  it("該当が無ければ none を返す", () => {
+    expect(matchById([entry(uuid("aaaaaaaa"))], "zzzzzzzz")).toEqual({ kind: "none" });
+  });
+
+  it("記録が1件も無ければ none を返す（境界）", () => {
+    expect(matchById([], "aaaaaaaa")).toEqual({ kind: "none" });
+  });
+
+  it("空文字は none にする（全件に一致させない・境界）", () => {
+    expect(matchById([entry(uuid("aaaaaaaa"))], "")).toEqual({ kind: "none" });
+    expect(matchById([entry(uuid("aaaaaaaa"))], "   ")).toEqual({ kind: "none" });
+  });
+});
+
+describe("matchById の曖昧な指定（取り違えの防止）", () => {
+  it("複数に一致したら ambiguous を返し、候補をすべて渡す", () => {
+    const first = entry(uuid("aaaaaaaa"));
+    const second = entry(`aaaaaaaa${first.id.slice(8, 35)}f`);
+
+    const match = matchById([first, second], "aaaaaaaa");
+
+    expect(match.kind).toBe("ambiguous");
+    expect(match.kind === "ambiguous" ? match.candidates : []).toEqual([first, second]);
+  });
+
+  it("候補の順序は渡された順を保つ", () => {
+    const first = entry("aaaaaaaa1111");
+    const second = entry("aaaaaaaa2222");
+
+    const match = matchById([second, first], "aaaaaaaa");
+
+    expect(match.kind === "ambiguous" ? match.candidates.map((each) => each.id) : []).toEqual([
+      second.id,
+      first.id,
+    ]);
+  });
+
+  it("曖昧な接頭辞でも、1桁伸ばせば決まる", () => {
+    const first = entry("aaaaaaaa1111");
+    const second = entry("aaaaaaaa2222");
+
+    expect(matchById([first, second], "aaaaaaaa").kind).toBe("ambiguous");
+    expect(matchById([first, second], "aaaaaaaa1")).toEqual({ kind: "found", entry: first });
+  });
+});
+
+describe("shortIdLength と matchById が噛み合う（一覧に出た表記でそのまま引ける）", () => {
+  it("衝突する id があっても、一覧の桁数で切れば1件に決まる", () => {
+    const ids = ["aaaaaaaa1111", "aaaaaaaa2222", "bbbbbbbb3333"];
+    const entries = ids.map(entry);
+    const length = shortIdLength(ids);
+
+    for (const each of entries) {
+      expect(matchById(entries, shortenId(each.id, length))).toEqual({
+        kind: "found",
+        entry: each,
+      });
+    }
+  });
+});

--- a/tests/format/log.test.ts
+++ b/tests/format/log.test.ts
@@ -4,6 +4,9 @@ import type { LogRow } from "../../src/domain/log.js";
 import { displayWidth } from "../../src/format/columns.js";
 import { formatLogLines } from "../../src/format/log.js";
 
+/** このファイルは整形そのものを見るので、id を切らない桁数を渡す（短縮は #58 の別テスト）。 */
+const LONG_ENOUGH = 100;
+
 function local(day: number, hours: number, minutes = 0): Date {
   const date = new Date(2000, 0, 1);
   date.setFullYear(2026, 7, day);
@@ -32,20 +35,24 @@ function row(
 
 describe("formatLogLines", () => {
   it("該当0件のときは「該当なし」を1行出す（エラーにしない）", () => {
-    expect(formatLogLines([])).toEqual(["該当する記録はありません"]);
+    expect(formatLogLines([], LONG_ENOUGH)).toEqual(["該当する記録はありません"]);
   });
 
   it("各行に編集で使える ID が含まれている", () => {
-    const lines = formatLogLines([row("abc123", local(13, 9), local(13, 10), { note: "設計" })]);
+    const lines = formatLogLines(
+      [row("abc123", local(13, 9), local(13, 10), { note: "設計" })],
+      LONG_ENOUGH,
+    );
 
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("abc123");
   });
 
   it("行に日付・開始・終了・長さ・作業名・タグがすべて出る", () => {
-    const lines = formatLogLines([
-      row("abc123", local(13, 9), local(13, 10, 30), { tags: ["work"], note: "設計" }),
-    ]);
+    const lines = formatLogLines(
+      [row("abc123", local(13, 9), local(13, 10, 30), { tags: ["work"], note: "設計" })],
+      LONG_ENOUGH,
+    );
 
     const line = lines[0] ?? "";
 
@@ -58,30 +65,37 @@ describe("formatLogLines", () => {
   });
 
   it("複数のタグを並べる", () => {
-    const lines = formatLogLines([
-      row("a", local(13, 9), local(13, 10), { tags: ["work", "proj/loop-demo"] }),
-    ]);
+    const lines = formatLogLines(
+      [row("a", local(13, 9), local(13, 10), { tags: ["work", "proj/loop-demo"] })],
+      LONG_ENOUGH,
+    );
 
     expect(lines[0]).toContain("#work");
     expect(lines[0]).toContain("#proj/loop-demo");
   });
 
   it("実行中の記録は終了時刻の代わりに「実行中」と出す", () => {
-    const lines = formatLogLines([row("a", local(13, 11), undefined, { note: "レビュー" })]);
+    const lines = formatLogLines(
+      [row("a", local(13, 11), undefined, { note: "レビュー" })],
+      LONG_ENOUGH,
+    );
 
     expect(lines[0]).toContain("実行中");
     expect(lines[0]).toContain("11:00");
   });
 
   it("作業名が無くても行が壊れない（境界）", () => {
-    const lines = formatLogLines([row("a", local(13, 9), local(13, 10), { tags: ["work"] })]);
+    const lines = formatLogLines(
+      [row("a", local(13, 9), local(13, 10), { tags: ["work"] })],
+      LONG_ENOUGH,
+    );
 
     expect(lines[0]).toContain("#work");
     expect(lines[0]).not.toContain("undefined");
   });
 
   it("タグも作業名も無くても行が壊れない（境界）", () => {
-    const lines = formatLogLines([row("a", local(13, 9), local(13, 10))]);
+    const lines = formatLogLines([row("a", local(13, 9), local(13, 10))], LONG_ENOUGH);
 
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("a");
@@ -89,24 +103,27 @@ describe("formatLogLines", () => {
   });
 
   it("長さ 0 の記録も 0s として1行出す（境界）", () => {
-    const lines = formatLogLines([row("a", local(13, 9), local(13, 9))]);
+    const lines = formatLogLines([row("a", local(13, 9), local(13, 9))], LONG_ENOUGH);
 
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("0s");
   });
 
   it("1件につき1行だけ出す", () => {
-    const lines = formatLogLines([
-      row("a", local(13, 9), local(13, 10)),
-      row("b", local(13, 10), local(13, 11)),
-      row("c", local(13, 11), undefined),
-    ]);
+    const lines = formatLogLines(
+      [
+        row("a", local(13, 9), local(13, 10)),
+        row("b", local(13, 10), local(13, 11)),
+        row("c", local(13, 11), undefined),
+      ],
+      LONG_ENOUGH,
+    );
 
     expect(lines).toHaveLength(3);
   });
 
   it("日を跨ぐ記録は開始日と両端の時刻が読める", () => {
-    const lines = formatLogLines([row("a", local(12, 23), local(13, 1))]);
+    const lines = formatLogLines([row("a", local(12, 23), local(13, 1))], LONG_ENOUGH);
 
     expect(lines[0]).toContain("2026-08-12");
     expect(lines[0]).toContain("23:00");
@@ -115,10 +132,13 @@ describe("formatLogLines", () => {
   });
 
   it("ID の長さが違っても後続の列が揃う", () => {
-    const lines = formatLogLines([
-      row("short", local(13, 9), local(13, 10)),
-      row("very-long-id-1234", local(13, 10), local(13, 11)),
-    ]);
+    const lines = formatLogLines(
+      [
+        row("short", local(13, 9), local(13, 10)),
+        row("very-long-id-1234", local(13, 10), local(13, 11)),
+      ],
+      LONG_ENOUGH,
+    );
 
     const positions = lines.map((line) => line.indexOf("2026-08-13"));
 
@@ -126,10 +146,13 @@ describe("formatLogLines", () => {
   });
 
   it("全角の作業名が混ざっても長さの列が揃う", () => {
-    const lines = formatLogLines([
-      row("a", local(13, 9), local(13, 10), { note: "設計" }),
-      row("b", local(13, 10), local(13, 11), { note: "review" }),
-    ]);
+    const lines = formatLogLines(
+      [
+        row("a", local(13, 9), local(13, 10), { note: "設計" }),
+        row("b", local(13, 10), local(13, 11), { note: "review" }),
+      ],
+      LONG_ENOUGH,
+    );
 
     // 長さの列は作業名より前にあるので、作業名の幅に影響されない
     const positions = lines.map((line) => line.indexOf("1h"));
@@ -140,10 +163,13 @@ describe("formatLogLines", () => {
   // `実行中` は3文字だが端末では6桁を占める。桁が揃っているかは文字数ではなく
   // 表示幅で見る必要がある（`indexOf` の値は UTF-16 の位置なので、揃っていても一致しない）
   it("実行中と完了が混ざっても作業名の開始桁が揃う", () => {
-    const lines = formatLogLines([
-      row("a", local(13, 9), local(13, 10), { note: "設計" }),
-      row("b", local(13, 11), undefined, { note: "レビュー" }),
-    ]);
+    const lines = formatLogLines(
+      [
+        row("a", local(13, 9), local(13, 10), { note: "設計" }),
+        row("b", local(13, 11), undefined, { note: "レビュー" }),
+      ],
+      LONG_ENOUGH,
+    );
 
     const columns = [columnOf(lines[0] ?? "", "設計"), columnOf(lines[1] ?? "", "レビュー")];
 


### PR DESCRIPTION
## 概要

`log` の一覧で id を短く出し、`edit` / `rm` が**その表記のまま**引けるようにした。

- `src/domain/entry-id.ts` — 桁数の決定と引き当て（`shortIdLength` / `shortenId` / `matchById`）
- `src/commands/lookup.ts` — 引き当て結果を利用者向けエラーに翻訳（`resolveEntry`）
- `src/format/log.ts` / `src/commands/log.ts` — 一覧の id を短く出す
- `src/commands/edit.ts` / `src/commands/rm.ts` — 接頭辞で引き、出力も短縮 id にする

Closes #58

### 設計の理由

**採番は変えず、表示を短くして接頭辞で引く**（git の短縮 SHA と同じ）。Issue のスコープは
「表示だけ短縮＋前方一致」と「採番自体を短くする」の2案だったが、**後者は既に保存されている
UUID を持つ記録が読めなくなる余地を作る**（#58 の DoD にも「既存の UUID も参照・編集・削除
できること」がある）。この方針なら保存されている値には一切触れない。

**桁数は固定にしない。** 表示を短くする以上、その表記でそのまま引けなければ短縮しないより
悪い。先頭8桁を既定としつつ、**全記録の中で重複しない長さまで伸ばす**。

**`log` が期間で絞らず全件を読むのはこのため。** 一覧に出る分だけで桁数を決めると、期間の外の
記録と先頭が同じときに、出した文字列で引けなくなる。`listByRange` は**どの範囲を渡しても
ファイル全体を読む**（`jsonl-store.ts` の `readState`）ので、読み込みは増えない。
期間での絞り込みは `selectLogRows` が元から行っている。

**複数に一致したら1件を選ばない。** 取り違えて別の記録を編集・削除するより、候補を示して
打ち直してもらうほうがよい。候補は短縮 id で並べる（「もっと長く」とだけ言われても、
どこまで打てばよいか分からない）。

**完全一致を接頭辞一致より優先する。** 長さの違う id が混ざると短いほうが長いほうの接頭辞に
なりうる（`id-1` と `id-10`）。優先しないと、id 全体を正確に打った利用者に「曖昧です」と返す。

**`export` は短縮しない。** 機械が読む元データなので保存されている値をそのまま出す（PR #61 の方針）。

## 受け入れ条件

- [x] **一覧に出た ID の表記で、そのまま記録を参照できるテストがある**
      → `tests/commands/short-id.test.ts`「一覧に出た表記でそのまま参照できる（DoD）」3件
      （`log` → `edit` / `log` → `rm` / 衝突時も同じ）

      実行結果:
      ```
      $ tock log
      20389813  2026-08-14  03:00-03:30  30m  レビュー #work
      b3a33841  2026-08-14  01:00-02:00  1h   設計 #work

      $ tock edit 20389813 --note "定例レビュー"
      修正しました: 定例レビュー #work
      id: 20389813
      ```

- [x] **前方一致で解決する場合、候補が複数あるときに曖昧だと分かるエラーを返すテストがある（境界）**
      → `tests/commands/short-id.test.ts`「曖昧な指定を取り違えない（DoD）」5件、
      `tests/domain/entry-id.test.ts`「matchById の曖昧な指定（取り違えの防止）」3件

      実行結果（先頭8桁が同じ記録を2件用意した）:
      ```
      $ tock edit aaaaaaaa --note x
      id が複数の記録に一致します: aaaaaaaa（候補: aaaaaaaa-1 / aaaaaaaa-9）。もっと長く指定してください
      exit=1

      $ tock edit aaaaaaaa-1 --note "決まった"
      修正しました: 決まった #work
      id: aaaaaaaa-1
      ```
      **`rm` は確認を出す前に止まる**（消してよいか尋ねてから失敗させない）。

- [x] **該当する ID が無いときのエラーが利用者向け（終了コード 1）であるテストがある**
      → `tests/commands/short-id.test.ts`「該当しない id（DoD）」3件（`edit` / `rm` / 記録0件）

      ```
      $ tock edit zzzzzzzz --note x
      その id の記録がありません: zzzzzzzz
      exit=1
      ```
      （終了コードはパイプを挟まずに測っている）

- [x] **短縮した ID が衝突しうる件数でも、記録を取り違えないテストがある（境界）**
      → `tests/commands/short-id.test.ts`「先頭8桁が衝突する記録があれば、区別できる桁数まで
      伸ばす」「曖昧なときは記録を書き換えない」「曖昧なときは削除もしない」、
      `tests/domain/entry-id.test.ts`「shortIdLength と matchById が噛み合う」

      実行結果:
      ```
      $ tock log
      bbbbbbbb-2  2026-08-14  04:00-04:30  30m  レビュー #work
      aaaaaaaa-9  2026-08-14  03:00-03:30  30m  実装 #work
      aaaaaaaa-1  2026-08-14  01:00-02:00  1h   設計 #work
      ```
      衝突する2件があるため、**3件とも 10桁に伸びている**（8桁のままだと上2行が同じ表記になる）。

- [x] **採番を変える場合、既存の UUID を持つ記録も参照・編集・削除できるテストがある**
      → `tests/commands/short-id.test.ts`「既存の UUID もそのまま使える（DoD）」4件

      **採番は変えていない**ので、保存されている値は 36 桁のまま。
      ```
      $ tock export --format csv | cut -d, -f1
      id
      b3a33841-ac39-42a0-83fd-8fe546de0a67
      20389813-bc5f-42f6-ac13-f347d2d78b9a

      $ tock edit 20389813-bc5f-42f6-ac13-f347d2d78b9a --note "全体で指定"
      修正しました: 全体で指定 #work
      id: 20389813
      ```
      大文字で書かれた id、8桁より短い接頭辞（1文字でも1件に決まれば可）も受け付ける。

## mutation test

DoD の中心にある振る舞いを6箇所壊した。**すべてでテストが落ちた（穴なし）。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 曖昧でも先頭の1件を返す（取り違え） | 7件 |
| 桁数を伸ばさず常に8桁にする | 8件 |
| 完全一致の優先をやめる | 1件 |
| `log` が期間で絞った記録だけから桁数を決める | 1件 |
| 大文字小文字を区別する | 2件 |
| 空文字を全件に一致させる | 1件 |

元に戻して 1166 件すべて通ることを確認済み（39 files / 1166 tests。1122 → 1166 で +44件）。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | 記録0件での `shortIdLength` / `matchById` / `edit`、空文字と空白だけの指定（**全件に一致させない**） |
| 同時刻 | id の話なので該当なし。既存の一覧・編集のテストはそのまま通る |
| 日跨ぎ | 該当なし |
| 上限値・範囲外 | 1文字の接頭辞、id 全体（36桁）、桁数より短い id、**同じ id が2つある場合に伸ばし続けない** |
| **終端のないデータ** | **実行中の記録も同じ表記で引けることを確認**（下記） |

実行中エントリ（`end` を持たない）は id の扱いに影響しない。既存の
`tests/commands/edit.test.ts` /`rm.test.ts` の実行中エントリのテストは、**そのまま通っている**
（`id-1` のような短い id は8桁より短いので切られない）。

**片方が他方の接頭辞になる id**（`id-1` と `id-10`）は、テストで使っている形そのものなので
明示的に固定した。完全一致の優先が無いと `id-1` が曖昧になる。

## `log` / `format/log.ts` / `edit` / `rm` に触った理由

**直している性質が1つ（「id を短く見せて、その表記で引けるようにする」）なので1 PR にまとめた**
（`CLAUDE.md`「1 Issue = 1 PR の例外」）。分けると、途中の状態で「一覧は短いのに参照できない」
という、短縮しないより悪い状態が生まれる。

- `format/log.ts` — `formatLogLines(rows, idLength)` に桁数を渡す形にした。**既定値を持たせず
  必須にした**のは、呼び出し側が桁数を決める責任を持つことを型で示すため
- `commands/lookup.ts` — `findById` を `resolveEntry` に置き換えた。`edit` と `rm` が同じ規則で
  引くよう、この関数以外の経路を作らない。引き当ての規則自体は `domain/entry-id.ts` にあり、
  ここは `UserError` への翻訳だけを行う（domain は `UserError` を知らない）
- `tests/format/log.test.ts` — 桁数を渡すぶんだけ直した。**検証内容は変えていない**
  （id を切らない桁数を渡している。短縮の検証は `short-id.test.ts` に置いた）

## スコープに入れなかったもの

- **採番自体の短縮** — 上記のとおり、既存の記録が読めなくなる余地を作らないため
- **`export` の id 短縮** — 機械が読む元データ。PR #61 で決めた方針どおり
- **`status` / `switch` の出力に id を出す** — 元から出していない。出すかどうかは
  表示の設計の話で、この Issue の範囲外
- **`Store` に「id で引く」操作を足す** — #57 の担当範囲。`lookup.ts` の回避策は残したまま

## スタック

- base: `main`（スタックなし）
- 依存の E4-5（#16）・E4-6（#17）はどちらもマージ済み

## 依存の追加

なし。

## 検証

`npm run check` green（39 files / 1166 tests）。

- プリフライトの修正試行 **0回**（open PR なし）
- 実装フェーズの修正試行 **0回**

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_