### PR TITLE
[E4-10][P2] 出力を `head` や `less` で打ち切ると EPIPE でクラッシュする

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -344,6 +344,8 @@ if (invokedAsEntryPoint()) {
   // `EPIPE` 以外の書き込みエラーは内部エラーとして扱う。**`run` の戻り値で上書きしない**
   // ——出力が欠けたのに終了コード 0 を返すと、スクリプトから成功と見分けられない
   let writeFailed = false;
+  let writeReported = false;
+  let reportedCode: unknown;
   const reportWriteError = (error: unknown): void => {
     writeFailed = true;
 
@@ -351,6 +353,19 @@ if (invokedAsEntryPoint()) {
     // 下の代入が済んだあとに来ることがある（`> /dev/full` で実際にそうなった）。
     // 戻り値の代入だけに任せると、出力が欠けたのに終了コード 0 で終わる
     process.exitCode = EXIT_INTERNAL;
+
+    // **同じ原因を繰り返し報告しない。** 書き込みは行ごとなので、`> /dev/full` のように
+    // 以降も必ず失敗する相手だと、同じ `ENOSPC` が行数ぶん stderr に並ぶ（レビューで指摘）。
+    // 利用者に伝わるのは「書けなかった」ことと理由の1組で足りる。
+    //
+    // **`code` が変わったら改めて報告する。** 別の原因まで飲むと、最初の失敗のあとに
+    // 起きた本当の問題が見えなくなる
+    const code = isRecordObject(error) ? error["code"] : undefined;
+    if (writeReported && code === reportedCode) {
+      return;
+    }
+    writeReported = true;
+    reportedCode = code;
 
     try {
       process.stderr.write(`${messageOf(error)}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,85 @@ function writeAll(lines: readonly string[], write: (line: string) => void): void
   }
 }
 
+/**
+ * `code` を持つオブジェクトとして読めるか。
+ *
+ * Node の書き込みエラーは `Error` に `code` が乗った形で届くが、`error` イベントで
+ * 渡ってくる値の型は保証されていない。`Error` でない値でも落ちないようにする。
+ */
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** 書き込み先として必要な最小の形。テストから偽のストリームを渡せるようにする。 */
+export interface LineStream {
+  write(chunk: string): boolean;
+  on(event: "error", listener: (error: unknown) => void): unknown;
+}
+
+/**
+ * 読み手がパイプを閉じたことによる書き込みエラーか。
+ *
+ * `tock --help | head -3` のように読み手が先に終わると、書き込みは `EPIPE` で失敗する。
+ * これは**利用者の操作として正常**なので、他の書き込みエラーとは区別する。
+ */
+export function isBrokenPipe(error: unknown): boolean {
+  return isRecordObject(error) && error["code"] === "EPIPE";
+}
+
+/**
+ * ストリームへ1行ずつ書く関数を作る。**`EPIPE` は静かに飲む。**
+ *
+ * `| head` や `| less` で見て途中でやめる、`| grep -m1` で1件だけ拾う、といった使い方は
+ * CLI では普通の操作である。それでスタックトレースが出ると、利用者からはツールが
+ * 壊れているように見える（#49）。
+ *
+ * **`error` を購読することが本質。** Node は購読者のいない `error` イベントを
+ * 未処理として throw し、プロセスを異常終了させる。#49 の原因はこれで、
+ * 購読していれば、`EPIPE` かどうかを見て分ける余地が生まれる。
+ *
+ * **`EPIPE` 以外は飲まない。** ディスクが一杯（`ENOSPC`）のような本当の失敗を黙って
+ * 捨てると、出力が欠けたことに気づけない。呼び出し側へ渡して報告させる。
+ *
+ * **`EPIPE` のあとは書き込みを止める。** 閉じた先へ書き続けると同じ失敗を繰り返すだけで、
+ * 書けるようになることはない。`EPIPE` 以外では止めない——1行が書けなかったことと、
+ * 以降がすべて書けないことは別だから。
+ */
+export function createLineWriter(
+  stream: LineStream,
+  onWriteError: (error: unknown) => void,
+): (line: string) => void {
+  let broken = false;
+
+  // 非同期に届く経路。`write` が成功して返ったあとに `error` として通知される
+  stream.on("error", (error) => {
+    if (isBrokenPipe(error)) {
+      broken = true;
+      return;
+    }
+
+    onWriteError(error);
+  });
+
+  return (line: string): void => {
+    if (broken) {
+      return;
+    }
+
+    try {
+      // 同期的に投げる経路。閉じた直後の書き込みはここで失敗することがある
+      stream.write(`${line}\n`);
+    } catch (error) {
+      if (isBrokenPipe(error)) {
+        broken = true;
+        return;
+      }
+
+      onWriteError(error);
+    }
+  };
+}
+
 /** 例外から利用者に見せるメッセージを取り出す。Error でない値を投げられても落ちない。 */
 function messageOf(error: unknown): string {
   if (error instanceof Error) {
@@ -262,14 +341,34 @@ function invokedAsEntryPoint(): boolean {
 }
 
 if (invokedAsEntryPoint()) {
-  process.exitCode = await run(process.argv.slice(2), {
-    out: (line) => {
-      process.stdout.write(`${line}\n`);
-    },
-    err: (line) => {
-      process.stderr.write(`${line}\n`);
-    },
+  // `EPIPE` 以外の書き込みエラーは内部エラーとして扱う。**`run` の戻り値で上書きしない**
+  // ——出力が欠けたのに終了コード 0 を返すと、スクリプトから成功と見分けられない
+  let writeFailed = false;
+  const reportWriteError = (error: unknown): void => {
+    writeFailed = true;
+
+    // **ここで直接立てる。** 書き込みエラーは `error` イベントとして非同期に届くので、
+    // 下の代入が済んだあとに来ることがある（`> /dev/full` で実際にそうなった）。
+    // 戻り値の代入だけに任せると、出力が欠けたのに終了コード 0 で終わる
+    process.exitCode = EXIT_INTERNAL;
+
+    try {
+      process.stderr.write(`${messageOf(error)}\n`);
+    } catch {
+      // stderr 自体が書けないなら伝える先が無い。終了コードだけを残す
+    }
+  };
+
+  const code = await run(process.argv.slice(2), {
+    out: createLineWriter(process.stdout, reportWriteError),
+    err: createLineWriter(process.stderr, reportWriteError),
     version: readVersion,
     commands: buildCommands(),
   });
+
+  // `EPIPE` は終了コードを変えない。読み手が先に終わるのは正常な操作であり、
+  // パイプライン全体の終了コードは読み手のもの（`| head` なら head）になる
+  if (!writeFailed) {
+    process.exitCode = code;
+  }
 }

--- a/tests/cli-epipe.test.ts
+++ b/tests/cli-epipe.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { createLineWriter, isBrokenPipe } from "../src/cli.js";
+
+/**
+ * 出力先のパイプが閉じられたときの書き込み（#49）。
+ *
+ * `tock --help | head -3` のように読み手が先に終わると、`stdout` の `error` イベントが
+ * 誰にも購読されておらず、Node がスタックトレースを出して異常終了していた。
+ *
+ * **偽のストリームで検証する。** 本物のパイプを閉じる経路（`tests/e2e/cli.test.ts`）は
+ * 読み手が先に終わるかどうかがタイミング次第で、`EPIPE` が起きない実行もある。
+ * それだけだと「起きなかったから通った」のか「飲めたから通った」のか区別できないので、
+ * ここで **必ず `EPIPE` を起こして**振る舞いを固定する。
+ */
+
+interface Fake {
+  /** 書き込まれた文字列。 */
+  readonly written: string[];
+  /** 非同期に届く `error` イベントを模す。 */
+  readonly emitError: (error: unknown) => void;
+  /** `error` の購読者の数。購読していること自体を検証する。 */
+  readonly listeners: () => number;
+  readonly stream: {
+    write: (chunk: string) => boolean;
+    on: (event: "error", listener: (error: unknown) => void) => unknown;
+  };
+}
+
+/**
+ * 偽のストリーム。
+ *
+ * `throwOnWrite` を渡すと、その回数目の `write` で同期的に例外を投げる
+ * （`EPIPE` は `error` イベントとして届くこともあれば、`write` が直接投げることもある）。
+ */
+function fakeStream(options: { throwOnWrite?: { call: number; error: unknown } } = {}): Fake {
+  const written: string[] = [];
+  const listeners: ((error: unknown) => void)[] = [];
+  let calls = 0;
+
+  return {
+    written,
+    listeners: () => listeners.length,
+    emitError: (error) => {
+      for (const listener of listeners) {
+        listener(error);
+      }
+    },
+    stream: {
+      write: (chunk) => {
+        calls += 1;
+        if (options.throwOnWrite !== undefined && options.throwOnWrite.call === calls) {
+          throw options.throwOnWrite.error;
+        }
+        written.push(chunk);
+
+        return true;
+      },
+      on: (_event, listener) => {
+        listeners.push(listener);
+
+        return undefined;
+      },
+    },
+  };
+}
+
+/** 読み手がパイプを閉じたときに Node が渡してくる形。 */
+function epipe(): Error & { code: string } {
+  return Object.assign(new Error("write EPIPE"), { code: "EPIPE", errno: -32, syscall: "write" });
+}
+
+/** 書き込み先が本当に壊れている場合（飲んではいけない）。 */
+function diskFull(): Error & { code: string } {
+  return Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
+}
+
+describe("EPIPE の判定", () => {
+  it("code が EPIPE なら true", () => {
+    expect(isBrokenPipe(epipe())).toBe(true);
+  });
+
+  it("他の書き込みエラーは false（飲まない）", () => {
+    expect(isBrokenPipe(diskFull())).toBe(false);
+  });
+
+  it("code を持たない Error は false（境界）", () => {
+    expect(isBrokenPipe(new Error("何か"))).toBe(false);
+  });
+
+  it("Error でない値でも落ちない（境界）", () => {
+    expect(isBrokenPipe("EPIPE")).toBe(false);
+    expect(isBrokenPipe(undefined)).toBe(false);
+    expect(isBrokenPipe(null)).toBe(false);
+  });
+});
+
+describe("パイプが閉じられても異常終了しない（DoD）", () => {
+  it("error イベントを購読する（未処理の error で落ちないことの構造的な保証）", () => {
+    const fake = fakeStream();
+
+    createLineWriter(fake.stream, () => undefined);
+
+    // 購読者がいなければ Node は未処理の error イベントとして throw する。
+    // #49 の原因はまさにこれで、購読の有無が直る／直らないの分かれ目になる
+    expect(fake.listeners()).toBe(1);
+  });
+
+  it("EPIPE が届いても例外にならず、報告もしない（静かに終わる）", () => {
+    const fake = fakeStream();
+    const reported: unknown[] = [];
+    const write = createLineWriter(fake.stream, (error) => reported.push(error));
+
+    write("1行目");
+    expect(() => fake.emitError(epipe())).not.toThrow();
+
+    expect(reported).toEqual([]);
+  });
+
+  it("EPIPE のあとは書き込みを止める", () => {
+    const fake = fakeStream();
+    const write = createLineWriter(fake.stream, () => undefined);
+
+    write("1行目");
+    fake.emitError(epipe());
+    write("2行目");
+    write("3行目");
+
+    // 閉じた先へ書き続けると、同じ error が何度も起きる
+    expect(fake.written).toEqual(["1行目\n"]);
+  });
+
+  it("write が同期的に EPIPE を投げても飲む（境界）", () => {
+    const fake = fakeStream({ throwOnWrite: { call: 2, error: epipe() } });
+    const reported: unknown[] = [];
+    const write = createLineWriter(fake.stream, (error) => reported.push(error));
+
+    write("1行目");
+    expect(() => write("2行目")).not.toThrow();
+    write("3行目");
+
+    expect(fake.written).toEqual(["1行目\n"]);
+    expect(reported).toEqual([]);
+  });
+
+  it("1行も書いていない状態で EPIPE が届いても落ちない（境界）", () => {
+    const fake = fakeStream();
+    const write = createLineWriter(fake.stream, () => undefined);
+
+    expect(() => fake.emitError(epipe())).not.toThrow();
+
+    write("あとから書く");
+    expect(fake.written).toEqual([]);
+  });
+});
+
+describe("EPIPE 以外の書き込みエラーは報告する（DoD）", () => {
+  it("error イベントで届いたものを報告する", () => {
+    const fake = fakeStream();
+    const reported: unknown[] = [];
+    const write = createLineWriter(fake.stream, (error) => reported.push(error));
+
+    write("1行目");
+    fake.emitError(diskFull());
+
+    expect(reported).toHaveLength(1);
+    expect((reported[0] as Error).message).toContain("no space left on device");
+  });
+
+  it("write が同期的に投げたものを報告する", () => {
+    const fake = fakeStream({ throwOnWrite: { call: 1, error: diskFull() } });
+    const reported: unknown[] = [];
+    const write = createLineWriter(fake.stream, (error) => reported.push(error));
+
+    write("1行目");
+
+    expect(reported).toHaveLength(1);
+  });
+
+  it("EPIPE 以外では書き込みを止めない（1行の失敗で残りを捨てない）", () => {
+    const fake = fakeStream();
+    const write = createLineWriter(fake.stream, () => undefined);
+
+    write("1行目");
+    fake.emitError(diskFull());
+    write("2行目");
+
+    expect(fake.written).toEqual(["1行目\n", "2行目\n"]);
+  });
+});
+
+describe("パイプが閉じられない通常の書き込み（回帰）", () => {
+  it("渡された行をすべて書き、改行を付ける", () => {
+    const fake = fakeStream();
+    const write = createLineWriter(fake.stream, () => undefined);
+
+    write("1行目");
+    write("2行目");
+
+    expect(fake.written).toEqual(["1行目\n", "2行目\n"]);
+  });
+
+  it("空文字の行も1行として書く（境界）", () => {
+    const fake = fakeStream();
+    const write = createLineWriter(fake.stream, () => undefined);
+
+    write("");
+
+    expect(fake.written).toEqual(["\n"]);
+  });
+
+  it("報告関数は呼ばれない", () => {
+    const fake = fakeStream();
+    let called = 0;
+    const write = createLineWriter(fake.stream, () => {
+      called += 1;
+    });
+
+    write("1行目");
+
+    expect(called).toBe(0);
+  });
+});

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -133,6 +133,9 @@ async function exists(path: string): Promise<boolean> {
  */
 const built = await exists(CLI);
 
+/** `/dev/full` があるか（Linux のみ）。`EPIPE` 以外の書き込みエラーを起こすのに使う。 */
+const hasDevFull = await exists("/dev/full");
+
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "tock-e2e-data-"));
   home = await mkdtemp(join(tmpdir(), "tock-e2e-home-"));
@@ -343,6 +346,130 @@ describe("npm run check と CI に含まれている（DoD）", () => {
 
     expect(workflow).toContain("npm run check");
   });
+});
+
+/**
+ * 出力を途中で打ち切られたときの振る舞い（#49）。
+ *
+ * **本物のパイプを閉じる経路をここで通す。** `tests/cli-epipe.test.ts` は偽のストリームで
+ * `EPIPE` を必ず起こして振る舞いを固定しているが、「実際に `| head -3` して出るか」は
+ * 本物の子プロセスでしか確かめられない。
+ *
+ * `sh -c` を使うのは、**読み手が先に終わる**状況を作るため。`node` の終了コードは
+ * パイプラインの外からは見えない（`| head` の終了コードになる）ので、`echo $?` で
+ * stderr に混ぜて観測する。**stderr はパイプに混ぜない**——混ぜると `head` に切られて
+ * エラー自体が見えなくなる（#49 の備考に書かれている落とし穴）。
+ */
+describe.skipIf(!built)("出力を head で打ち切っても壊れない（DoD）", () => {
+  /** `node <CLI> <args> | head -<lines>` を走らせ、node 自身の終了コードを stderr で観測する。 */
+  function piped(args: readonly string[], lines: number) {
+    const inner = ["node", CLI, ...args].map((part) => `'${part}'`).join(" ");
+
+    return execute(
+      "sh",
+      ["-c", `{ ${inner}; echo "node exit: $?" >&2; } | head -${String(lines)}`],
+      { PATH: process.env["PATH"], TOCK_DIR: dir, HOME: home },
+    );
+  }
+
+  it(
+    "スタックトレースを出さない",
+    async () => {
+      const result = await piped(["--help"], 3);
+
+      // 修正前はここに Error: write EPIPE と Node のスタックが出ていた
+      expect(result.stderr).not.toContain("EPIPE");
+      expect(result.stderr).not.toContain("Unhandled");
+      expect(result.stderr).not.toContain("node:internal");
+      expect(result.stderr).not.toContain("Node.js v");
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "異常終了しない（uncaughtException で落ちない）",
+    async () => {
+      const result = await piped(["--help"], 3);
+
+      // 未処理の error イベントで落ちると node は 1 で終わる
+      expect(result.stderr).toContain("node exit: 0");
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "打ち切られるまでの行は出ている（黙って何も出さない直し方をしていない）",
+    async () => {
+      const result = await piped(["--help"], 3);
+
+      expect(result.stdout).toContain("使い方: tock");
+      expect(result.stdout.trimEnd().split("\n")).toHaveLength(3);
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "出力が短くパイプが閉じられないケースは従来どおり（回帰）",
+    async () => {
+      // 3行に収まるので head は読み切る。EPIPE は起きない
+      const result = await piped(["status"], 3);
+
+      expect(result.stderr).toContain("node exit: 0");
+      expect(result.stdout).toContain("実行中の作業はありません");
+    },
+    RUN_TIMEOUT_MS,
+  );
+});
+
+/**
+ * `EPIPE` 以外の書き込みエラー（#49）。
+ *
+ * **`/dev/full` へ書くと必ず `ENOSPC` になる。** 「`EPIPE` だけを飲み、他は飲まない」の
+ * 後半は、本物の書き込みエラーを起こさないと確かめられない。Linux 以外には
+ * `/dev/full` が無いので、無ければ飛ばす（CI は ubuntu なので飛ばされない）。
+ */
+describe.skipIf(!built || !hasDevFull)("EPIPE 以外の書き込みエラーは飲まない（DoD）", () => {
+  function toDevFull(args: readonly string[]) {
+    const inner = ["node", CLI, ...args].map((part) => `'${part}'`).join(" ");
+
+    return execute("sh", ["-c", `${inner} > /dev/full; echo "node exit: $?" >&2`], {
+      PATH: process.env["PATH"],
+      TOCK_DIR: dir,
+      HOME: home,
+    });
+  }
+
+  it(
+    "書き込みエラーを stderr に報告する",
+    async () => {
+      const result = await toDevFull(["--help"]);
+
+      expect(result.stderr).toContain("ENOSPC");
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "終了コードで失敗を伝える（出力が欠けたのに 0 で終わらない）",
+    async () => {
+      const result = await toDevFull(["--help"]);
+
+      // 書き込みエラーは非同期に届くので、戻り値の代入だけに任せると 0 になる
+      expect(result.stderr).toContain("node exit: 2");
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "スタックトレースは出さない（報告はするが、内部の詳細は見せない）",
+    async () => {
+      const result = await toDevFull(["--help"]);
+
+      expect(result.stderr).not.toContain("node:internal");
+      expect(result.stderr).not.toContain("Unhandled");
+    },
+    RUN_TIMEOUT_MS,
+  );
 });
 
 /**

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -360,7 +360,17 @@ describe("npm run check と CI に含まれている（DoD）", () => {
  * stderr に混ぜて観測する。**stderr はパイプに混ぜない**——混ぜると `head` に切られて
  * エラー自体が見えなくなる（#49 の備考に書かれている落とし穴）。
  */
-describe.skipIf(!built)("出力を head で打ち切っても壊れない（DoD）", () => {
+/**
+ * **ここは本物の経路のスモークで、`EPIPE` を必ず起こす検証は
+ * `tests/cli-epipe.test.ts`（偽ストリーム）が持つ。**
+ *
+ * `--help` の出力はパイプバッファに収まるので、「書き切ったあとに読み手が閉じる」経路に
+ * なることがあり、その場合 `EPIPE` は起きない。つまりここが green でも
+ * 「起きなかったから通った」なのか「飲めたから通った」なのかは区別できない（レビューで指摘）。
+ * 振る舞いの固定は偽ストリーム側に置き、ここでは**利用者と同じ起動でスタックトレースが
+ * 出ないこと**だけを見る。
+ */
+describe.skipIf(!built)("出力を head で打ち切っても壊れない（DoD・スモーク）", () => {
   /** `node <CLI> <args> | head -<lines>` を走らせ、node 自身の終了コードを stderr で観測する。 */
   function piped(args: readonly string[], lines: number) {
     const inner = ["node", CLI, ...args].map((part) => `'${part}'`).join(" ");
@@ -445,6 +455,18 @@ describe.skipIf(!built || !hasDevFull)("EPIPE 以外の書き込みエラーは�
       const result = await toDevFull(["--help"]);
 
       expect(result.stderr).toContain("ENOSPC");
+    },
+    RUN_TIMEOUT_MS,
+  );
+
+  it(
+    "同じ原因は1回だけ報告する（行数ぶん並べない）",
+    async () => {
+      // `--help` は20行ほど書くので、1行ごとに報告すると同じ ENOSPC がその数だけ並ぶ
+      const result = await toDevFull(["--help"]);
+
+      const reported = result.stderr.split("\n").filter((line) => line.includes("ENOSPC"));
+      expect(reported).toHaveLength(1);
     },
     RUN_TIMEOUT_MS,
   );


### PR DESCRIPTION
## 概要

`stdout` / `stderr` の書き込みを `createLineWriter` に通し、**`EPIPE` だけを静かに飲む**ようにした。
`EPIPE` 以外（`ENOSPC` など）は飲まずに報告し、終了コード 2 で伝える。

Closes #49

### 原因

`src/cli.ts` の起動部が `process.stdout.write` を直接呼び、`error` イベントを購読していなかった。
**Node は購読者のいない `error` イベントを未処理として throw する**ので、読み手が先に終わると
プロセスが異常終了していた。購読していれば `EPIPE` かどうかを見て分ける余地が生まれる、
というのがこの修正の要点。

### 設計の理由

**`EPIPE` のあとは書き込みを止める。** 閉じた先へ書き続けても同じ失敗を繰り返すだけで、
書けるようになることはない。一方 **`EPIPE` 以外では止めない**——1行が書けなかったことと、
以降がすべて書けないことは別だから（`ENOSPC` は空きができれば書ける）。

**`EPIPE` では終了コードを変えない。** 読み手が先に終わるのは正常な操作で、パイプライン全体の
終了コードは読み手のもの（`| head` なら `head`）になる。ここで非 0 を返しても観測されないうえ、
`tock log | head -1` が失敗扱いになるのは実態と合わない。

**`EPIPE` 以外は終了コード 2（内部エラー）。** 出力が欠けたのに 0 で終わると、スクリプトから
成功と区別できない。

## 受け入れ条件

- [x] **出力の途中でパイプが閉じられたとき、stderr にスタックトレースが出ないテストがある**
      → `tests/e2e/cli.test.ts`「スタックトレースを出さない」（本物の `| head -3`）と
      `tests/cli-epipe.test.ts`「EPIPE が届いても例外にならず、報告もしない（静かに終わる）」

      **修正前**（Issue の再現手順そのまま）:

      ```
      $ node dist/cli.js --help 2>err.txt | head -3
      使い方: tock <command> [args]

      コマンド:
      $ cat err.txt
      node:events:497
            throw er; // Unhandled 'error' event
            ^

      Error: write EPIPE
          at afterWriteDispatched (node:internal/stream_base_commons:159:15)
          ...
          at out (file:///home/user/loop-demo/dist/cli.js:200:28)
          at writeAll (file:///home/user/loop-demo/dist/cli.js:61:9)
          at run (file:///home/user/loop-demo/dist/cli.js:87:9)
      Emitted 'error' event on Socket instance at:
          ...
        errno: -32,
        code: 'EPIPE',
        syscall: 'write'
      }

      Node.js v22.22.2
      ```

      **修正後**（stderr が空）:

      ```
      $ node dist/cli.js --help 2>err2.txt | head -3
      使い方: tock <command> [args]

      コマンド:
      $ cat err2.txt
      $ echo "[stderr ここまで]"
      [stderr ここまで]
      ```

      `| grep -m1` でも同じ（1件拾って打ち切る使い方）:

      ```
      $ node dist/cli.js --help 2>err3.txt | grep -m1 "コマンド"
      コマンド:
      $ cat err3.txt
      $ echo "[stderr ここまで]"
      [stderr ここまで]
      ```

- [x] **そのとき異常終了しない（プロセスが `uncaughtException` で落ちない）テストがある**
      → `tests/e2e/cli.test.ts`「異常終了しない（uncaughtException で落ちない）」

      **`node` 自身の終了コードを観測している。** パイプラインの外からは `| head` の
      終了コードしか見えないので、`echo $?` を stderr に混ぜて取り出した
      （stderr をパイプに混ぜないのは Issue の備考どおり）。

      ```
      ### 修正前
      $ sh -c '{ node dist/cli.js --help; echo "node exit: $?" >&2; } | head -3' 2>&1 >/dev/null
      （スタックトレース）
      Node.js v22.22.2
      node exit: 1        ← uncaughtException で落ちている

      ### 修正後
      $ sh -c '{ node dist/cli.js --help; echo "node exit: $?" >&2; } | head -3' 2>&1 >/dev/null
      node exit: 0
      ```

- [x] **`EPIPE` 以外の書き込みエラーは従来どおり報告されることを確認するテストがある**
      → `tests/cli-epipe.test.ts`「error イベントで届いたものを報告する」「write が同期的に
      投げたものを報告する」「EPIPE 以外では書き込みを止めない（1行の失敗で残りを捨てない）」、
      および `tests/e2e/cli.test.ts` の「EPIPE 以外の書き込みエラーは飲まない（DoD）」3件。

      **本物の書き込みエラーで確かめた。** `/dev/full` へ書くと必ず `ENOSPC` になる
      （Linux のみ。無い環境では飛ばす）。

      ```
      $ sh -c 'node dist/cli.js --help > /dev/full; echo "node exit: $?"' 2>&1
      ENOSPC: no space left on device, write
      node exit: 2
      ```

- [x] **出力が短くパイプが閉じられないケースが従来どおり動くテストがある（回帰防止）**
      → `tests/e2e/cli.test.ts`「出力が短くパイプが閉じられないケースは従来どおり（回帰）」
      （3行に収まるので `head` が読み切り、`EPIPE` が起きない）と
      「打ち切られるまでの行は出ている（黙って何も出さない直し方をしていない）」、
      `tests/cli-epipe.test.ts`「パイプが閉じられない通常の書き込み（回帰）」3件。

      既存の E2E 通しシナリオ（`start` → `status` → `stop` → `today` → `export`）もそのまま通る。

## 実装中に見つけた自分の誤り

**最初の実装は `ENOSPC` を報告はするが、終了コードが 0 のままだった。**
`npm run check` は green で、偽のストリームによる単体テストも通っていた。
`/dev/full` に実際に書いてみて気づいた。

```
### 直す前（reportWriteError の外で終了コードを決めていた）
$ sh -c 'node dist/cli.js --help > /dev/full; echo "node exit: $?"' 2>&1
ENOSPC: no space left on device, write
node exit: 0        ← 出力が欠けたのに成功として終わっている
```

原因は、**書き込みエラーが `error` イベントとして非同期に届く**こと。
`process.exitCode = writeFailed ? EXIT_INTERNAL : code` は `run` が返った直後に走るので、
そのあとに届いたエラーを取りこぼす。`reportWriteError` の中で `process.exitCode` を直接
立てる形に変え、上の出力（`node exit: 2`）になった。

**偽のストリームだけでは見つけられなかった。** 単体テストは「報告関数が呼ばれるか」までしか
見ておらず、`process.exitCode` に反映されるかは実プロセスの話なので、`/dev/full` の
E2E を足して固定した（変異5がこれを見張っている）。

## mutation test

| 壊した内容 | 落ちたテスト |
| --- | --- |
| `error` の購読をやめる（#49 の原因そのもの） | 7件 |
| すべての書き込みエラーを飲む（`isBrokenPipe` を常に true） | 8件 |
| `EPIPE` のあとも書き込みを続ける（`broken` を立てない） | 2件 |
| 同期的に投げられた `EPIPE` を飲まず再 throw する | 2件 |
| 書き込みエラーで終了コードを立てない（非同期の取りこぼし） | 1件 |

戻して 1323件すべて通ることを確認済み（45 files / 1323 tests）。

**変異のたびに `rm -rf dist && npm run build` してから実行している。** E2E はビルド済みの
`dist` を起動するので、古い `dist` が残っていると変異が反映されず件数を誤読する
（過去に #40 / #42 で踏んでいる）。

## 境界値の確認（`CLAUDE.md` のチェックリスト）

| 境界 | 対応 |
| --- | --- |
| 0件・空 | **1行も書いていない状態で `EPIPE` が届いても落ちない**／空文字の行も1行として書く |
| 同時刻 | 該当なし（時刻を扱わない） |
| 日跨ぎ | 該当なし |
| 上限値・範囲外 | `code` を持たない `Error`、`Error` でない値（文字列・`undefined`・`null`）を `isBrokenPipe` に渡しても落ちない |
| 終端のないデータ | 該当なし（記録を扱わない）。ただし**書き込みの「終端」が読み手側で決まる**のがこの Issue の性質で、`EPIPE` の前・後・同期／非同期の4通りを揃えた |

**偽のストリームと本物のパイプの両方で確かめている。** 本物の `| head` は読み手が先に
終わるかがタイミング次第で、`EPIPE` が起きない実行もありうる。それだけだと
「起きなかったから通った」のか「飲めたから通った」のか区別できないので、偽のストリームで
**必ず `EPIPE` を起こす**テストを土台にした。

## ブランチ名について（規約の食い違い）

定期実行の指示は `feat/<issue番号>-<短い説明>` を指定していたが、**`CLAUDE.md` は不具合修正に
`fix/` を定めている**（この Issue のラベルも `bug`）。SKILL.md 3-2 が「`CLAUDE.md` の規約に従う」と
定めているため `fix/49-epipe-silent-exit` にした。食い違い自体を報告する規定（SKILL.md 冒頭）に
従ってここに記す。

## スコープに入れなかったもの

- **`process.stdout` のバッファリング方式の変更** — 今回は `error` を購読して分けるだけ。
  書き込み方式そのものは触っていない
- **`SIGPIPE` の扱い** — Node は `SIGPIPE` を無視して `EPIPE` に変換するため、シグナル側の
  処理は不要（変換された `EPIPE` を扱えば足りる）
- **README への追記** — PR #76（#26）が README を追加中で、そちらは「今できないこと」に
  EPIPE を挙げていない。この修正で挙げる必要も無くなるため、両者に矛盾は生じない

## スタック

- base: `main`（依存の E4-1（#12）はマージ済み）
- 他の open PR は #76（README）のみ。**触るファイルは重ならない**
  （#76 は `README.md` と `tests/docs/`、こちらは `src/cli.ts` と `tests/cli-epipe.test.ts` /
  `tests/e2e/cli.test.ts`）

## 依存の追加

なし。

## 検証

`npm run check` green（45 files / **1323 tests**。1301 → 1323 で +22件）。
実装フェーズの修正試行 **0回**（`check` も CI も落ちていない。上記の終了コードの誤りは
`check` の失敗ではなく、CLI を実際に叩いて見つけたもの）。レビュー対応フェーズ 0/2。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_