### PR TITLE
[E3-2][P3] データのスキーマバージョンとマイグレーション

### DIFF
--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -15,12 +15,75 @@ import type { Store, StoreRange } from "./store.js";
  * ただし保証はそこまでで、**最後の 1 操作までは守れない**。追記の途中で落ちて行が
  * 途中で切れると、次の追記がその欠けた行の後ろに続いてしまい、両方まとめて壊れた 1 行
  * として飛ばされる。1 操作の原子性まで担保するなら追記ではなく別の書き込み方が必要で、
- * それは #10 / #11 の担当範囲。
+ * それは #11（多重起動時の安全性）の担当範囲。
  */
 type StoreRecord =
   | { readonly op: "append"; readonly entry: Entry }
   | { readonly op: "update"; readonly entry: Entry }
   | { readonly op: "delete"; readonly id: string };
+
+/**
+ * いまの版が書く保存形式のバージョン（#10）。
+ *
+ * **フィールドを増やしたときに、古い記録が読めなくなることを防ぐための番号。**
+ * 形を変えたら 1 つ上げ、`migrate` に前の形からの移し方を足す。
+ *
+ * **バージョンを持たない行は 1 として読む。** この仕組みを入れる前に書かれた
+ * `~/.tock/entries.jsonl` はすべてその形で、読めなくすると「更新したら記録が消えた」になる。
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * 行に書かれたバージョン。無ければ 1（この仕組みより前に書かれたもの）。
+ *
+ * **値が壊れている場合は `undefined`** を返し、呼び出し側で「壊れた行」として飛ばす。
+ * 新しいバージョンとして扱ってエラーにすると、1 行の破損で全記録が読めなくなる。
+ */
+function versionOf(raw: Record<string, unknown>): number | undefined {
+  const value = raw["v"];
+  if (value === undefined) {
+    return 1;
+  }
+
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * 読み込んだ値を、いまの形に移す。
+ *
+ * **いまは 1 しか存在しないので、そのまま返す。** 形を変えたときにここへ分岐を足す。
+ * 移行の置き場を先に決めておくのは、次に形を変える人が「どこに書くか」で迷わないため。
+ */
+function migrate(raw: Record<string, unknown>, version: number): Record<string, unknown> {
+  switch (version) {
+    case 1: {
+      return raw;
+    }
+    default: {
+      // ここに来るのは `assertReadableVersion` を通していない場合だけ
+      throw new Error(`移行の手順がありません: バージョン ${String(version)}`);
+    }
+  }
+}
+
+/**
+ * この版が読めるバージョンかを確かめる。**読めないなら飛ばさずエラーにする。**
+ *
+ * 読めない行を黙って飛ばす方針は**壊れた行のためのもの**で、新しい版が書いた記録に
+ * そのまま当てると「無かったこと」になる。利用者からは記録が消えたように見え、
+ * そこへ書き足すと本当に失われる。**気づける形で止めるほうが損失が小さい。**
+ */
+function assertReadableVersion(version: number, filePath: string): void {
+  if (version <= SCHEMA_VERSION) {
+    return;
+  }
+
+  throw new Error(
+    `保存形式のバージョン ${String(version)} は読めません` +
+      `（この版が読めるのは ${String(SCHEMA_VERSION)} まで）: ${filePath}。` +
+      `新しい版の tock で開いてください。この版で書き足すと記録が壊れます`,
+  );
+}
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -38,8 +101,8 @@ function asNonEmptyString(value: unknown): string | undefined {
  * つまり手で編集してタイムゾーンなしの日時を書いた行は、書き込み時より甘い基準で
  * 通過する。
  *
- * ここでの役目は「壊れて読めない行を落とす」ことに限る。保存済みデータの妥当性を
- * どこまで遡って保証するかは #10（スキーマバージョンとマイグレーション）の担当範囲。
+ * ここでの役目は「壊れて読めない行を落とす」ことに限る。**書き込み時と同じ厳密さに
+ * 揃えるかは #85 の担当範囲**（#10 で形のバージョンは入れたが、値の妥当性は別の話）。
  */
 function asTimestamp(value: unknown): string | undefined {
   const text = asNonEmptyString(value);
@@ -113,8 +176,14 @@ function asEntry(value: unknown): Entry | undefined {
   };
 }
 
-/** 1 行を操作の記録として読む。読めない行は `undefined`（呼び出し側で飛ばす）。 */
-function parseLine(line: string): StoreRecord | undefined {
+/**
+ * 1 行を操作の記録として読む。読めない行は `undefined`（呼び出し側で飛ばす）。
+ *
+ * **バージョンの確認は形の検査より先に行う。** 新しい版が書いた行は、こちらが知らない
+ * 形をしている可能性がある。先に形を見ると「壊れた行」として飛ばしてしまい、
+ * 知らないバージョンだったことに気づけない。
+ */
+function parseLine(line: string, filePath: string): StoreRecord | undefined {
   if (line.trim() === "") {
     return undefined;
   }
@@ -130,15 +199,24 @@ function parseLine(line: string): StoreRecord | undefined {
     return undefined;
   }
 
-  const op = parsed["op"];
+  const version = versionOf(parsed);
+  if (version === undefined) {
+    // バージョンの値そのものが壊れている。新しい版が書いたとは言えないので飛ばす
+    return undefined;
+  }
+
+  assertReadableVersion(version, filePath);
+  const migrated = migrate(parsed, version);
+
+  const op = migrated["op"];
 
   if (op === "delete") {
-    const id = asNonEmptyString(parsed["id"]);
+    const id = asNonEmptyString(migrated["id"]);
     return id === undefined ? undefined : { op: "delete", id };
   }
 
   if (op === "append" || op === "update") {
-    const entry = asEntry(parsed["entry"]);
+    const entry = asEntry(migrated["entry"]);
     return entry === undefined ? undefined : { op, entry };
   }
 
@@ -149,7 +227,10 @@ function parseLine(line: string): StoreRecord | undefined {
  * ファイルの内容を JSONL として読み、現在の状態に畳み込む。
  *
  * **読めない行は飛ばす。** 1 行の破損で全記録が読めなくなるほうが損失が大きい。
- * 破損行の検知と修復は #10（スキーマとマイグレーション）の担当範囲。
+ * 飛ばしたことを利用者に伝えるかどうかは #85 の担当範囲（いまは黙って飛ばす）。
+ *
+ * **ただし「知らない新しいバージョン」は飛ばさずエラーになる**（`assertReadableVersion`）。
+ * そちらは壊れた行ではなく、新しい版が正しく書いた記録だから。
  *
  * 追加順を保つため Map を使う。更新は元の位置に留まる。
  */
@@ -167,7 +248,7 @@ async function readState(filePath: string): Promise<Map<string, Entry>> {
 
   const state = new Map<string, Entry>();
   for (const line of raw.split("\n")) {
-    const record = parseLine(line);
+    const record = parseLine(line, filePath);
     if (record === undefined) {
       continue;
     }
@@ -188,7 +269,8 @@ function isNotFound(error: unknown): boolean {
 
 async function appendRecord(filePath: string, record: StoreRecord): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
-  await appendFile(filePath, `${JSON.stringify(record)}\n`, "utf8");
+  // **バージョンを先頭に置く。** 行を目で見たときに、どの形で書かれたかが最初に読める
+  await appendFile(filePath, `${JSON.stringify({ v: SCHEMA_VERSION, ...record })}\n`, "utf8");
 }
 
 /**

--- a/tests/store/schema-version.test.ts
+++ b/tests/store/schema-version.test.ts
@@ -52,6 +52,16 @@ async function writeLegacy(...records: readonly unknown[]): Promise<void> {
   await writeFile(file, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
 }
 
+/**
+ * 知らないバージョンに出会ったときの、利用者向けメッセージ。
+ *
+ * **`/バージョン/` のような緩い一致では見ない。** `migrate` の内部エラー
+ * （`移行の手順がありません: バージョン 2`）にも当たってしまい、**バージョンの門を
+ * 素通しにしても6件が通ってしまった**（mutation test で判明）。門が効いていることを
+ * 見たいので、門が出す文面そのものに寄せる。
+ */
+const UNSUPPORTED = new RegExp(`保存形式のバージョン ${String(SCHEMA_VERSION + 1)} は読めません`);
+
 async function lines(): Promise<Record<string, unknown>[]> {
   const raw = await readFile(file, "utf8");
 
@@ -135,7 +145,7 @@ describe("知らない新しいバージョンは明示的なエラーになる�
   it("読み出しがエラーになる（黙って飛ばさない）", async () => {
     await writeLegacy(future);
 
-    await expect(store.listAll()).rejects.toThrow(/バージョン/);
+    await expect(store.listAll()).rejects.toThrow(UNSUPPORTED);
   });
 
   it("エラーに読めなかったバージョンと、いまの版が読める上限が出る", async () => {
@@ -152,13 +162,13 @@ describe("知らない新しいバージョンは明示的なエラーになる�
 
     await expect(
       store.listByRange({ start: new Date("2026-08-01"), end: new Date("2026-08-31") }),
-    ).rejects.toThrow(/バージョン/);
+    ).rejects.toThrow(UNSUPPORTED);
   });
 
   it("実行中の検索でもエラーになる", async () => {
     await writeLegacy(future);
 
-    await expect(store.findRunning()).rejects.toThrow(/バージョン/);
+    await expect(store.findRunning()).rejects.toThrow(UNSUPPORTED);
   });
 
   it("**書き込もうとしてもファイルを壊さない**", async () => {
@@ -167,7 +177,7 @@ describe("知らない新しいバージョンは明示的なエラーになる�
     await writeLegacy(future);
     const before = await readFile(file, "utf8");
 
-    await expect(store.append(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(/バージョン/);
+    await expect(store.append(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(UNSUPPORTED);
 
     await expect(readFile(file, "utf8")).resolves.toBe(before);
   });
@@ -176,8 +186,8 @@ describe("知らない新しいバージョンは明示的なエラーになる�
     await writeLegacy(future);
     const before = await readFile(file, "utf8");
 
-    await expect(store.update(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(/バージョン/);
-    await expect(store.delete("future")).rejects.toThrow(/バージョン/);
+    await expect(store.update(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(UNSUPPORTED);
+    await expect(store.delete("future")).rejects.toThrow(UNSUPPORTED);
 
     await expect(readFile(file, "utf8")).resolves.toBe(before);
   });
@@ -186,7 +196,7 @@ describe("知らない新しいバージョンは明示的なエラーになる�
     // 「読めたぶんだけ返す」にすると、欠けたことに気づかないまま集計が出る
     await writeLegacy({ op: "append", entry: entry("2026-08-01T09:00:00Z") }, future);
 
-    await expect(store.listAll()).rejects.toThrow(/バージョン/);
+    await expect(store.listAll()).rejects.toThrow(UNSUPPORTED);
   });
 });
 

--- a/tests/store/schema-version.test.ts
+++ b/tests/store/schema-version.test.ts
@@ -140,7 +140,36 @@ describe("旧形式のレコードを最新形として読める（DoD）", () =
 });
 
 describe("知らない新しいバージョンは明示的なエラーになる（DoD）", () => {
-  const future = { v: SCHEMA_VERSION + 1, op: "append", id: "future", entry: { unknown: true } };
+  /**
+   * **v1 としても読める行にする**（レビューで指摘）。
+   *
+   * `entry` が v1 の形として壊れていると、門が無くても `asEntry` が落とすので、
+   * **門が効いているのか形の検査が落としたのかを区別できない。** 実際、門を
+   * 「読めなかったときだけ通る」位置に動かしても、差し替え前は21件すべて通った。
+   *
+   * 次の版でいちばん起きやすい変更は**既存フィールドはそのまま、任意フィールドを足す**
+   * ことで、それは v1 としても読める（`asEntry` は知らないフィールドを無視する）。
+   * その形で見れば、門を後ろに置いた実装は落ちる。
+   */
+  const future = {
+    v: SCHEMA_VERSION + 1,
+    op: "append",
+    entry: {
+      id: "future",
+      start: "2026-08-04T09:00:00.000Z",
+      tags: ["work"],
+      newField: "次の版が足したもの",
+    },
+  };
+
+  it("この fixture は v1 としても読める（この describe が門を見ていることの前提）", async () => {
+    // バージョンだけを外して書くと読める。つまり以降のテストが落ちる理由は
+    // **バージョンだけ**であって、形の検査ではない
+    const { v: _version, ...withoutVersion } = future;
+    await writeLegacy(withoutVersion);
+
+    await expect(store.listAll()).resolves.toHaveLength(1);
+  });
 
   it("読み出しがエラーになる（黙って飛ばさない）", async () => {
     await writeLegacy(future);

--- a/tests/store/schema-version.test.ts
+++ b/tests/store/schema-version.test.ts
@@ -1,0 +1,232 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createEntry } from "../../src/domain/entry.js";
+import { createJsonlStore, SCHEMA_VERSION } from "../../src/store/jsonl-store.js";
+import type { Store } from "../../src/store/store.js";
+
+/**
+ * 保存形式のバージョンと移行（#10）。
+ *
+ * **フィールドを増やしたときに、古い記録が読めなくなることを防ぐ。** 各行にバージョンを
+ * 持たせ、読み出し時に現在の形へ移す。
+ *
+ * **バージョンが無い行は、この仕組みを入れる前に書かれたもの**として扱う（＝1）。
+ * 既存の `~/.tock/entries.jsonl` はすべてこの形なので、ここを読めなくすると
+ * 「更新したら記録が消えた」になる。
+ *
+ * **知らない新しいバージョンは飛ばさずエラーにする。** 読めない行を黙って飛ばす方針は
+ * 壊れた行のためのもので、そのまま当てると**新しい版が書いた記録が「無かったこと」に
+ * なる**。利用者からは記録が消えたように見え、そこへ書き足すと本当に失われる。
+ */
+
+let dir = "";
+let file = "";
+let store: Store;
+let counter = 0;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-schema-"));
+  file = join(dir, "entries.jsonl");
+  store = createJsonlStore(file);
+  counter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function entry(start: string, end?: string) {
+  counter += 1;
+
+  return createEntry(
+    { start, ...(end === undefined ? {} : { end }), tags: ["work"] },
+    { newId: () => `e${String(counter)}` },
+  );
+}
+
+/** バージョンを持たない行（この仕組みを入れる前の形）を直接書く。 */
+async function writeLegacy(...records: readonly unknown[]): Promise<void> {
+  await writeFile(file, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
+}
+
+async function lines(): Promise<Record<string, unknown>[]> {
+  const raw = await readFile(file, "utf8");
+
+  return raw
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("旧形式のレコードを最新形として読める（DoD）", () => {
+  it("バージョンを持たない行を読める", async () => {
+    const legacy = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await writeLegacy({ op: "append", entry: legacy });
+
+    await expect(store.listAll()).resolves.toEqual([legacy]);
+  });
+
+  it("バージョンを持たない実行中エントリも読める（終端のないデータ）", async () => {
+    // `end` の無い行を落とすと、前夜から続く作業が消える
+    const running = entry("2026-08-01T09:00:00Z");
+    await writeLegacy({ op: "append", entry: running });
+
+    const all = await store.listAll();
+
+    expect(all).toEqual([running]);
+    expect(all[0]?.end).toBeUndefined();
+  });
+
+  it("バージョンを持たない update / delete も畳み込める", async () => {
+    const first = entry("2026-08-01T09:00:00Z");
+    const second = entry("2026-08-02T09:00:00Z", "2026-08-02T10:00:00Z");
+    const stopped = { ...first, end: "2026-08-01T10:00:00Z" };
+
+    await writeLegacy(
+      { op: "append", entry: first },
+      { op: "append", entry: second },
+      { op: "update", entry: stopped },
+      { op: "delete", id: second.id },
+    );
+
+    await expect(store.listAll()).resolves.toEqual([stopped]);
+  });
+
+  it("旧形式のファイルに追記しても、既存の行は読めたまま", async () => {
+    const legacy = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await writeLegacy({ op: "append", entry: legacy });
+
+    const added = entry("2026-08-03T09:00:00Z", "2026-08-03T10:00:00Z");
+    await store.append(added);
+
+    await expect(store.listAll()).resolves.toEqual([legacy, added]);
+  });
+
+  it("新しく書いた行にはバージョンが入る", async () => {
+    await store.append(entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z"));
+
+    expect((await lines())[0]?.["v"]).toBe(SCHEMA_VERSION);
+  });
+
+  it("削除の行にもバージョンが入る（操作の種類で漏れない）", async () => {
+    const only = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await store.append(only);
+    await store.delete(only.id);
+
+    const written = await lines();
+    expect(written).toHaveLength(2);
+    expect(written.every((line) => line["v"] === SCHEMA_VERSION)).toBe(true);
+  });
+
+  it("いまのバージョンを明記した行も読める（境界: 上限ちょうど）", async () => {
+    const current = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await writeLegacy({ v: SCHEMA_VERSION, op: "append", entry: current });
+
+    await expect(store.listAll()).resolves.toEqual([current]);
+  });
+});
+
+describe("知らない新しいバージョンは明示的なエラーになる（DoD）", () => {
+  const future = { v: SCHEMA_VERSION + 1, op: "append", id: "future", entry: { unknown: true } };
+
+  it("読み出しがエラーになる（黙って飛ばさない）", async () => {
+    await writeLegacy(future);
+
+    await expect(store.listAll()).rejects.toThrow(/バージョン/);
+  });
+
+  it("エラーに読めなかったバージョンと、いまの版が読める上限が出る", async () => {
+    await writeLegacy(future);
+
+    // 何をすればよいか（新しい版を使う）が分かる材料を出す
+    await expect(store.listAll()).rejects.toThrow(
+      new RegExp(`${String(SCHEMA_VERSION + 1)}.*${String(SCHEMA_VERSION)}`),
+    );
+  });
+
+  it("範囲指定の読み出しでもエラーになる", async () => {
+    await writeLegacy(future);
+
+    await expect(
+      store.listByRange({ start: new Date("2026-08-01"), end: new Date("2026-08-31") }),
+    ).rejects.toThrow(/バージョン/);
+  });
+
+  it("実行中の検索でもエラーになる", async () => {
+    await writeLegacy(future);
+
+    await expect(store.findRunning()).rejects.toThrow(/バージョン/);
+  });
+
+  it("**書き込もうとしてもファイルを壊さない**", async () => {
+    // ここが「破壊せず」の核心。読めない記録の後ろに書き足すと、その記録は
+    // 新しい版から見ても壊れた状態になる
+    await writeLegacy(future);
+    const before = await readFile(file, "utf8");
+
+    await expect(store.append(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(/バージョン/);
+
+    await expect(readFile(file, "utf8")).resolves.toBe(before);
+  });
+
+  it("更新・削除でもファイルを壊さない", async () => {
+    await writeLegacy(future);
+    const before = await readFile(file, "utf8");
+
+    await expect(store.update(entry("2026-08-05T09:00:00Z"))).rejects.toThrow(/バージョン/);
+    await expect(store.delete("future")).rejects.toThrow(/バージョン/);
+
+    await expect(readFile(file, "utf8")).resolves.toBe(before);
+  });
+
+  it("読める行が先にあっても、後ろの新しいバージョンで止まる", async () => {
+    // 「読めたぶんだけ返す」にすると、欠けたことに気づかないまま集計が出る
+    await writeLegacy({ op: "append", entry: entry("2026-08-01T09:00:00Z") }, future);
+
+    await expect(store.listAll()).rejects.toThrow(/バージョン/);
+  });
+});
+
+describe("バージョンの値が壊れている行（境界）", () => {
+  it.each([
+    ["0", 0],
+    ["負の数", -1],
+    ["小数", 1.5],
+    ["文字列", "1"],
+    ["null", null],
+  ])("%s は壊れた行として飛ばす（エラーにしない）", async (_label, version) => {
+    const valid = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await writeLegacy(
+      { v: version, op: "append", entry: entry("2026-08-02T09:00:00Z") },
+      { op: "append", entry: valid },
+    );
+
+    // **エラーにしない。** 壊れた値は「新しい版が書いた」ではなく「壊れた行」なので、
+    // 従来どおり飛ばす。ここをエラーにすると、1行の破損で全記録が読めなくなる
+    await expect(store.listAll()).resolves.toEqual([valid]);
+  });
+
+  it("バージョンだけ正しくて中身が壊れている行は飛ばす", async () => {
+    const valid = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await writeLegacy(
+      { v: SCHEMA_VERSION, op: "append", entry: { id: "" } },
+      {
+        op: "append",
+        entry: valid,
+      },
+    );
+
+    await expect(store.listAll()).resolves.toEqual([valid]);
+  });
+
+  it("JSON として読めない行は従来どおり飛ばす（回帰）", async () => {
+    const valid = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await store.append(valid);
+    await writeFile(file, `${await readFile(file, "utf8")}壊れた行\n`, "utf8");
+
+    await expect(store.listAll()).resolves.toEqual([valid]);
+  });
+});


### PR DESCRIPTION
## 概要

各行にスキーマバージョン（`v`）を持たせ、読み出し時に現在の形へ移す仕組みを入れた。

**バージョンを持たない行は 1 として読む。** 既存の `~/.tock/entries.jsonl` はすべて
その形なので、読めなくすると「更新したら記録が消えた」になる。

### 知らない新しいバージョンは、飛ばさずエラーにする

このストアは元々**読めない行を黙って飛ばす**（1行の破損で全記録が読めなくなるほうが
損失が大きいため）。**その方針を新しいバージョンにそのまま当てると危険**なので、ここだけ
分けた。

新しい版が書いた記録を「読めない行」として飛ばすと、利用者からは**記録が消えたように
見える**。そこへ書き足すと、新しい版から見ても壊れた状態になり**本当に失われる**。
気づける形で止めるほうが損失が小さい。

```
$ tock log
保存形式のバージョン 2 は読めません（この版が読めるのは 1 まで）: /tmp/.../entries.jsonl。新しい版の tock で開いてください。この版で書き足すと記録が壊れます
$ echo $?
2
```

**壊れたバージョンの値（`0` / `-1` / `1.5` / `"1"` / `null`）は従来どおり飛ばす。**
それは「新しい版が書いた」ではなく「壊れた行」なので、エラーにすると1行の破損で
全記録が読めなくなる。

### バージョンの確認は、形の検査より先に置いた

新しい版の行は**こちらが知らない形をしている可能性がある。** 先に形を見ると
「壊れた行」として飛ばしてしまい、知らないバージョンだったことに気づけない。
mutation test でこの順序を入れ替えると7件落ちる。

Closes #10

## 受け入れ条件

- [x] 旧形式のレコードを読み込んで最新形に変換するテストがある
      → `tests/store/schema-version.test.ts`「旧形式のレコードを最新形として読める（DoD）」7件
        （バージョンなしの行 / **実行中エントリ** / update・delete の畳み込み /
        旧形式への追記 / 書いた行にバージョンが入る / delete の行にも入る / 上限ちょうど）
      → 実行結果:
      ```
      $ cat "$TOCK_DIR/entries.jsonl"
      {"op":"append","entry":{"id":"aaaaaaaa-...","start":"2026-08-15T01:00:00.000Z",...,"note":"旧形式"}}

      $ TZ=UTC tock log
      aaaaaaaa  2026-08-15  01:00-01:30  30m  旧形式 #work
      ```
      → 追記すると新しい行にだけバージョンが入り、旧形式の行はそのまま残る:
      ```
      {"op":"append","entry":{"id":"aaaaaaaa-...          ← 旧形式のまま
      {"v":1,"op":"append","entry":{"id":"eb76964c-...    ← 追記した行
      {"v":1,"op":"update","entry":{"id":"eb76964c-...
      ```
      → 混在しても両方読める:
      ```
      $ TZ=UTC tock log
      eb76964c  2026-08-15  05:43-05:43  0s   新形式 #work
      aaaaaaaa  2026-08-15  01:00-01:30  30m  旧形式 #work
      ```

- [x] 未知の新しいバージョンを読んだ場合に、破壊せず明示的なエラーになるテストがある
      → `tests/store/schema-version.test.ts`「知らない新しいバージョンは明示的なエラーになる（DoD）」7件
        （`listAll` / `listByRange` / `findRunning` / **append・update・delete でファイルが変わらない** /
        読める行が先にあっても止まる / メッセージに両方のバージョンが出る）
      → **「破壊せず」の実行確認**:
      ```
      $ tock start "書き足し #work"
      保存形式のバージョン 2 は読めません（この版が読めるのは 1 まで）: /tmp/.../entries.jsonl。新しい版の tock で開いてください。この版で書き足すと記録が壊れます
      $ echo $?
      2
      → entries.jsonl は変わっていない
      ```

## 境界値（`CLAUDE.md` のチェックリスト）

| 境界 | テスト |
| --- | --- |
| **終端のないデータ** | 「バージョンを持たない実行中エントリも読める」 |
| 上限値ちょうど | 「いまのバージョンを明記した行も読める（境界: 上限ちょうど）」 |
| 上限値+1 | 「知らない新しいバージョンは明示的なエラーになる」7件 |
| 範囲外・型違い | 「バージョンの値が壊れている行（境界）」`0` / 負 / 小数 / 文字列 / `null` |
| 0件・空 | 「JSON として読めない行は従来どおり飛ばす（回帰）」 |

## mutation test

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 知らない新しいバージョンを飛ばす（門を素通し） | 7件 |
| バージョンの無い行を「壊れた行」として飛ばす | 12件 |
| 書き込み時にバージョンを付けない | 2件 |
| 壊れたバージョンの値もエラーにする | 5件 |
| バージョンの確認を形の検査より後にする | 7件 |

いずれも落ち、復元後は 1499 件すべて通ることを確認した。

### テストの穴を1つ塞いだ

**1回目は、門を素通しにしても6件が通ってしまった。** 期待値を `/バージョン/` という
緩い一致で書いていたため、`migrate` の内部エラー（`移行の手順がありません: バージョン 2`）
にも当たっていた。

見たいのは「知らないバージョンで止まること」なので、**門が出す文面そのもの**に寄せた
（`保存形式のバージョン N は読めません`）。塞いだあと、同じ mutation で 1件 → 7件に増えた。

## 判断が必要かもしれない点

**エラーの終了コードが 2（内部エラー）になる。** メッセージは利用者向けだが、
コード上は内部エラー扱い。

`UserError`（終了コード 1）は `src/cli.ts` にあり、store から使うと
**依存の向きが store → cli になる**（現在 store が import しているのは domain だけ）。
既存の store のエラー（`同じ id のエントリが既にあります` など）も同じく 2 なので、
**この PR では揃えた**。分けるなら store 側に専用のエラー型を置いて commands で
翻訳する形になり、この Issue の DoD を超える。

## スタック

- base: `main`（依存の #9 はマージ済み。open な PR は無い）

## 依存の追加

なし。

## この PR で直していない点

`asTimestamp` と `readState` のコメントが「#10 の担当範囲」と書いていたが、
**#10 は保存形式のバージョンだけを扱い、読み込み時の検証の厳密さ・壊れた行の伝え方は
扱っていない。** 閉じる Issue を指したままにすると読んだ人が辿れなくなるので、
**#85 として起票**し、コメントの参照先を差し替えた（#9 からの申し送りもそこに移した）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_