### PR TITLE
[E3-3][P3] 多重起動時の安全性（ファイルロック）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { type CommandUsage, formatCommandHelp } from "./format/help.js";
 import { randomId } from "./id.js";
 import { createJsonConfigStore, loadEffectiveConfig } from "./store/config-store.js";
 import { createJsonlStore } from "./store/jsonl-store.js";
+import { LockTimeoutError } from "./store/lock.js";
 import { resolveConfigPath, resolveStorePath } from "./store/store.js";
 import { readVersion } from "./version.js";
 
@@ -256,7 +257,12 @@ export async function run(argv: readonly string[], deps: CliDeps): Promise<numbe
     return EXIT_OK;
   } catch (error) {
     deps.err(messageOf(error));
-    return error instanceof UserError ? EXIT_USAGE : EXIT_INTERNAL;
+
+    // ロック待ちのタイムアウト（#11）も利用者起因として扱う。tock の不具合ではなく、
+    // 別の端末で動いている・異常終了でロックが残っている、という利用者が直せる状態
+    return error instanceof UserError || error instanceof LockTimeoutError
+      ? EXIT_USAGE
+      : EXIT_INTERNAL;
   }
 }
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -62,35 +62,44 @@ export function createEditCommand(deps: CommandDeps): Command {
         );
       }
 
-      const entries = await deps.store.listAll();
-      const target = resolveEntry(entries, id);
+      // **読み出しから書き込みまでを1つの操作にする（#11）。** 別々にすると、重なりの
+      // 検査に使った一覧が古くなり、他のプロセスが書いた記録と重なる編集を通してしまう
+      const { edited, shown } = await deps.store.transaction(async () => {
+        const entries = await deps.store.listAll();
+        const target = resolveEntry(entries, id);
 
-      const now = deps.now();
-      const changes: EntryChanges = {
-        ...(startValue === undefined
-          ? {}
-          : { start: resolveClockTimeOn(startValue, startedAt(target), now, "--start") }),
-        ...(endValue === undefined
-          ? {}
-          : { end: resolveClockTimeOn(endValue, endBaseDate(target, now), now, "--end") }),
-        ...(tagsValue === undefined ? {} : { tags: parseTagList(tagsValue) }),
-        ...(noteValue === undefined ? {} : { note: noteValue }),
-      };
+        const now = deps.now();
+        const changes: EntryChanges = {
+          ...(startValue === undefined
+            ? {}
+            : { start: resolveClockTimeOn(startValue, startedAt(target), now, "--start") }),
+          ...(endValue === undefined
+            ? {}
+            : { end: resolveClockTimeOn(endValue, endBaseDate(target, now), now, "--end") }),
+          ...(tagsValue === undefined ? {} : { tags: parseTagList(tagsValue) }),
+          ...(noteValue === undefined ? {} : { note: noteValue }),
+        };
 
-      const edited = translate(() => applyEdit(target, changes));
+        const candidate = translate(() => applyEdit(target, changes));
 
-      const conflict = findOverlapping(edited, entries);
-      if (conflict !== undefined) {
-        throw new UserError(
-          `編集後の時間が別の記録と重なります: ${describe(conflict)}（id: ${shortenId(conflict.id, shortIdLength(entries.map((entry) => entry.id)))}）`,
-        );
-      }
+        const conflict = findOverlapping(candidate, entries);
+        if (conflict !== undefined) {
+          throw new UserError(
+            `編集後の時間が別の記録と重なります: ${describe(conflict)}（id: ${shortenId(conflict.id, shortIdLength(entries.map((entry) => entry.id)))}）`,
+          );
+        }
 
-      await deps.store.update(edited);
+        await deps.store.update(candidate);
+
+        return {
+          edited: candidate,
+          shown: shortenId(candidate.id, shortIdLength(entries.map((entry) => entry.id))),
+        };
+      });
 
       io.out(`修正しました: ${describe(edited)}`);
       // 打った文字列ではなく、引き当てた記録の短縮 id を見せる（`log` の一覧と同じ表記）
-      io.out(`id: ${shortenId(edited.id, shortIdLength(entries.map((entry) => entry.id)))}`);
+      io.out(`id: ${shown}`);
     },
   };
 }

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -59,7 +59,18 @@ export function createRmCommand(deps: CommandDeps, confirm: Confirm): Command {
         return;
       }
 
-      await deps.store.delete(target.id);
+      // **確認はロックの外で待つ（#11）。** 人の返事を待つ間ロックを握ると、その間
+      // 他のプロセスの打刻がすべてタイムアウトする。代わりに、答えを得てから
+      // **もう一度引き当て直して**削除する——待っている間に消えた記録を、
+      // 見えなくなった後から消しにいかないようにするため
+      await deps.store.transaction(async () => {
+        const current = await deps.store.listAll();
+        if (!current.some((entry) => entry.id === target.id)) {
+          throw new UserError(`確認している間に、この記録は無くなりました（id: ${shown}）`);
+        }
+
+        await deps.store.delete(target.id);
+      });
 
       io.out(`削除しました: ${describe(target)}`);
       io.out(`id: ${shown}`);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -30,19 +30,25 @@ export function createStartCommand(deps: CommandDeps): Command {
       rejectUnknownArgs(rest, { command: "start", usage: USAGE });
       const { tags, note } = parseDescription(rest.join(" "));
 
-      const running = await deps.store.findRunning();
-      if (running !== undefined) {
-        throw new UserError(
-          `すでに実行中の作業があります（開始: ${running.start}）。先に tock stop してください`,
+      // **判断と書き込みを1つの操作にする（#11）。** 別々にすると、2つのプロセスが
+      // 同時に「実行中は無い」と読んで、実行中エントリが2つできる（実測で再現する）
+      const entry = await deps.store.transaction(async () => {
+        const running = await deps.store.findRunning();
+        if (running !== undefined) {
+          throw new UserError(
+            `すでに実行中の作業があります（開始: ${running.start}）。先に tock stop してください`,
+          );
+        }
+
+        const created = createEntry(
+          { start: at, tags, ...(note === undefined ? {} : { note }) },
+          { newId: deps.newId },
         );
-      }
 
-      const entry = createEntry(
-        { start: at, tags, ...(note === undefined ? {} : { note }) },
-        { newId: deps.newId },
-      );
+        await deps.store.append(created);
 
-      await deps.store.append(entry);
+        return created;
+      });
 
       const label = note ?? "（名前なし）";
       const tagText = tags.length === 0 ? "" : ` [${tags.map((tag) => `#${tag}`).join(" ")}]`;

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -33,29 +33,35 @@ export function createStopCommand(deps: CommandDeps): Command {
       const { at, rest: remaining } = resolveAt(rest, deps.now());
       rejectUnknownArgs(remaining, { command: "stop", usage: USAGE });
 
-      const running = await deps.store.findRunning();
-      if (running === undefined) {
-        throw new UserError("実行中の作業がありません。tock start で開始してください");
-      }
+      // **判断と書き込みを1つの操作にする（#11）。** 別々にすると、2つのプロセスが
+      // 同じ実行中エントリを見て、両方が停止を書き込む
+      const stopped = await deps.store.transaction(async () => {
+        const running = await deps.store.findRunning();
+        if (running === undefined) {
+          throw new UserError("実行中の作業がありません。tock start で開始してください");
+        }
 
-      // createEntry は end < start を弾く。その失敗は打ち間違いなので UserError に translate し、
-      // 保存はしない（実行中のまま残るので、正しい時刻で再実行できる）
-      let stopped;
-      try {
-        stopped = createEntry(
-          {
-            start: running.start,
-            end: at,
-            tags: running.tags,
-            ...resolveNote(running.note, note),
-          },
-          { newId: () => running.id },
-        );
-      } catch (error) {
-        throw new UserError(error instanceof Error ? error.message : String(error));
-      }
+        // createEntry は end < start を弾く。その失敗は打ち間違いなので UserError に翻訳し、
+        // 保存はしない（実行中のまま残るので、正しい時刻で再実行できる）
+        let candidate;
+        try {
+          candidate = createEntry(
+            {
+              start: running.start,
+              end: at,
+              tags: running.tags,
+              ...resolveNote(running.note, note),
+            },
+            { newId: () => running.id },
+          );
+        } catch (error) {
+          throw new UserError(error instanceof Error ? error.message : String(error));
+        }
 
-      await deps.store.update(stopped);
+        await deps.store.update(candidate);
+
+        return candidate;
+      });
 
       io.out(`停止しました: ${formatDuration(durationMs(stopped))}`);
       io.out(`終了時刻: ${stopped.end ?? ""}`);

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -34,18 +34,25 @@ export function createSwitchCommand(deps: CommandDeps): Command {
       rejectUnknownArgs(rest, { command: "switch", usage: USAGE });
       const { tags, note } = parseDescription(rest.join(" "));
 
-      const running = await deps.store.findRunning();
-
-      // **書き込む前に、失敗しうる組み立てをすべて済ませる。**
-      // 途中で弾かれると「前を止めただけで新規開始されない」中途半端な状態が残るため、
-      // 検証は保存の前に寄せる
       const next = createEntry(
         { start: at, tags, ...(note === undefined ? {} : { note }) },
         { newId: deps.newId },
       );
-      const stopped = running === undefined ? undefined : stopAt(running, at);
 
-      await save(deps, running, stopped, next);
+      // **判断と2つの書き込みを1つの操作にする（#11）。** 別々にすると、停止と開始の間に
+      // 他のプロセスが割り込み、実行中エントリが2つできる
+      const stopped = await deps.store.transaction(async () => {
+        const running = await deps.store.findRunning();
+
+        // **書き込む前に、失敗しうる組み立てをすべて済ませる。**
+        // 途中で弾かれると「前を止めただけで新規開始されない」中途半端な状態が残るため、
+        // 検証は保存の前に寄せる
+        const closing = running === undefined ? undefined : stopAt(running, at);
+
+        await save(deps, running, closing, next);
+
+        return closing;
+      });
 
       if (stopped !== undefined) {
         io.out(`停止しました: ${formatDuration(durationMs(stopped))}`);
@@ -59,15 +66,16 @@ export function createSwitchCommand(deps: CommandDeps): Command {
 /**
  * 確定と追記を行う。追記に失敗したら、確定を巻き戻す。
  *
- * ストアに複数の書き込みをまとめる手段が無いため（追記のみの JSONL）、片方だけ成功した
- * 状態がありえる。順序と巻き戻しでそれを詰める。
+ * **呼び出し側が `transaction` で囲むので、他のプロセスから途中の状態は見えない**（#11）。
+ * ただし追記のみの JSONL なので、**この間に落ちれば片方だけ書かれた状態がファイルに残る。**
+ * 順序と巻き戻しでそれを詰める。
  *
  * - 確定を先にするのは、追記を先にすると失敗時に**実行中が2件**残るため。
  *   どちらを止めるべきか決められない状態になり、0件より不都合が大きい
  * - 追記が落ちた場合は元の実行中エントリを書き戻し、切り替えを試す前の状態に戻す
  *
- * 巻き戻し自体が失敗する可能性は残る。書き込みを1回にまとめる話は #11（ファイルロック）や
- * #40（ストアの整理）の範囲なので、ここでは扱わない。
+ * 巻き戻し自体が失敗する可能性は残る。**2つの追記を1行にまとめて、落ちても中間状態を
+ * 作らないようにする話は、この Issue の範囲外**（#11 で入れたのは排他であって原子性ではない）。
  */
 async function save(
   deps: CommandDeps,
@@ -98,7 +106,7 @@ async function save(
  *
  * この状態は DoD が避けたい形（前の作業は停止済み・新しい作業は無し）そのままなので、
  * **今どうなっているかと、どう戻すか**もメッセージに入れる。書き込みを1回にまとめて
- * この状態自体を作らない話は #11（ファイルロック）や #40（ストアの整理）の範囲。
+ * この状態自体を作らない話は、排他（#11）とは別で、まだ扱っていない。
  */
 async function rollback(deps: CommandDeps, running: Entry, cause: unknown): Promise<void> {
   try {

--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 
 import type { Entry } from "../domain/entry.js";
 import { overlapsPeriod } from "../domain/period.js";
+import { DEFAULT_LOCK_OPTIONS, type LockOptions, withLock } from "./lock.js";
 import type { Store, StoreRange } from "./store.js";
 
 /**
@@ -279,35 +280,56 @@ async function appendRecord(filePath: string, record: StoreRecord): Promise<void
  * 保存先は引数で受け取る。既定の場所を組み立てるのは `resolveStorePath` の役目で、
  * テストは一時ディレクトリを指したパスを渡せる。
  *
- * 同時実行への保護は入れていない（#11 の担当範囲）。
+ * **書き込みは排他する（#11）。** 「読んでから書く」の間に他のプロセスが割り込むと、
+ * 実行中エントリが2つできて `stop` できなくなる。**読み出しはロックを取らない**——
+ * 追記は行単位で守られているので、読み手は壊れた状態を見ない。
  */
-export function createJsonlStore(filePath: string): Store {
+export function createJsonlStore(
+  filePath: string,
+  lock: LockOptions = DEFAULT_LOCK_OPTIONS,
+): Store {
+  const lockPath = `${filePath}.lock`;
+
+  /**
+   * 読んでから書くまでを、まとめて排他する（#11）。
+   *
+   * **読みと書きを別々にロックしても意味がない。** 壊れるのは「実行中は無い」と読んでから
+   * 書くまでの間で、そこに他のプロセスが割り込むと実行中エントリが2つできる。
+   */
+  const exclusively = async (write: (state: Map<string, Entry>) => Promise<void>): Promise<void> =>
+    withLock(lockPath, lock, async () => {
+      await write(await readState(filePath));
+    });
+
   return {
     async append(entry: Entry): Promise<void> {
-      const state = await readState(filePath);
-      if (state.has(entry.id)) {
-        throw new Error(`同じ id のエントリが既にあります: ${entry.id}`);
-      }
+      await exclusively(async (state) => {
+        if (state.has(entry.id)) {
+          throw new Error(`同じ id のエントリが既にあります: ${entry.id}`);
+        }
 
-      await appendRecord(filePath, { op: "append", entry });
+        await appendRecord(filePath, { op: "append", entry });
+      });
     },
 
     async update(entry: Entry): Promise<void> {
-      const state = await readState(filePath);
-      if (!state.has(entry.id)) {
-        throw new Error(`更新対象のエントリが見つかりません: ${entry.id}`);
-      }
+      await exclusively(async (state) => {
+        if (!state.has(entry.id)) {
+          throw new Error(`更新対象のエントリが見つかりません: ${entry.id}`);
+        }
 
-      await appendRecord(filePath, { op: "update", entry });
+        await appendRecord(filePath, { op: "update", entry });
+      });
     },
 
     async delete(id: string): Promise<void> {
-      const state = await readState(filePath);
-      if (!state.has(id)) {
-        throw new Error(`削除対象のエントリが見つかりません: ${id}`);
-      }
+      await exclusively(async (state) => {
+        if (!state.has(id)) {
+          throw new Error(`削除対象のエントリが見つかりません: ${id}`);
+        }
 
-      await appendRecord(filePath, { op: "delete", id });
+        await appendRecord(filePath, { op: "delete", id });
+      });
     },
 
     async listAll(): Promise<Entry[]> {

--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
@@ -291,19 +292,37 @@ export function createJsonlStore(
   const lockPath = `${filePath}.lock`;
 
   /**
-   * 読んでから書くまでを、まとめて排他する（#11）。
+   * いま自分がロックを握っているか。
    *
-   * **読みと書きを別々にロックしても意味がない。** 壊れるのは「実行中は無い」と読んでから
-   * 書くまでの間で、そこに他のプロセスが割り込むと実行中エントリが2つできる。
+   * **入れ子を検出するために非同期の文脈で持つ。** 単なる真偽値だと、同じプロセスの
+   * 別の呼び出し（並行して走る `transaction`）まで「握っている」と誤判定し、
+   * 排他をすり抜ける。`AsyncLocalStorage` なら `run` で作った文脈の中だけで見える。
    */
-  const exclusively = async (write: (state: Map<string, Entry>) => Promise<void>): Promise<void> =>
-    withLock(lockPath, lock, async () => {
+  const holding = new AsyncLocalStorage<true>();
+
+  /**
+   * ロックの中で処理を走らせる。**既に握っていれば取り直さない。**
+   *
+   * 取り直すと、自分が握っているロックを自分で待つことになって進めなくなる。
+   */
+  const exclusively = <T>(action: () => Promise<T>): Promise<T> =>
+    holding.getStore() === true
+      ? action()
+      : withLock(lockPath, lock, () => holding.run(true, action));
+
+  /** 読み出してから書くまでを1つにする。個々の書き込み操作が使う。 */
+  const writing = async (write: (state: Map<string, Entry>) => Promise<void>): Promise<void> =>
+    exclusively(async () => {
       await write(await readState(filePath));
     });
 
   return {
+    async transaction<T>(action: () => Promise<T>): Promise<T> {
+      return exclusively(action);
+    },
+
     async append(entry: Entry): Promise<void> {
-      await exclusively(async (state) => {
+      await writing(async (state) => {
         if (state.has(entry.id)) {
           throw new Error(`同じ id のエントリが既にあります: ${entry.id}`);
         }
@@ -313,7 +332,7 @@ export function createJsonlStore(
     },
 
     async update(entry: Entry): Promise<void> {
-      await exclusively(async (state) => {
+      await writing(async (state) => {
         if (!state.has(entry.id)) {
           throw new Error(`更新対象のエントリが見つかりません: ${entry.id}`);
         }
@@ -323,7 +342,7 @@ export function createJsonlStore(
     },
 
     async delete(id: string): Promise<void> {
-      await exclusively(async (state) => {
+      await writing(async (state) => {
         if (!state.has(id)) {
           throw new Error(`削除対象のエントリが見つかりません: ${id}`);
         }

--- a/src/store/lock.ts
+++ b/src/store/lock.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 
@@ -17,10 +18,16 @@ import { dirname } from "node:path";
  * 1つしか成功しないので、勝った側だけが処理に入れる。
  */
 
-/** ロックファイルに書く中身。取得した時刻を後から読めるようにする。 */
+/**
+ * ロックファイルに書く中身。取得した時刻と、**誰が取ったか**を後から読めるようにする。
+ *
+ * `token` は取得のたびに作り直す。**`pid` では足りない**——同じプロセスの別の取得
+ * （前の取得が古いとみなされて回収され、握り直した場合）を区別できない。
+ */
 interface LockFile {
   readonly pid: number;
   readonly at: number;
+  readonly token: string;
 }
 
 export interface LockOptions {
@@ -75,6 +82,28 @@ function isAlreadyExists(error: unknown): boolean {
   );
 }
 
+/** いま置かれているロックファイルの中身。読めなければ `undefined`。 */
+async function readLock(lockPath: string): Promise<{ at?: number; token?: string } | undefined> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(lockPath, "utf8"));
+  } catch {
+    // 無い・読めない・JSON でない
+    return undefined;
+  }
+
+  if (typeof raw !== "object" || raw === null) {
+    return undefined;
+  }
+
+  const { at, token } = raw as { at?: unknown; token?: unknown };
+
+  return {
+    ...(typeof at === "number" && Number.isFinite(at) ? { at } : {}),
+    ...(typeof token === "string" ? { token } : {}),
+  };
+}
+
 /**
  * ロックが取得された時刻。
  *
@@ -83,16 +112,9 @@ function isAlreadyExists(error: unknown): boolean {
  * 別の手がかりへ落とす。それも読めなければ「非常に古い」として扱う。
  */
 async function acquiredAt(lockPath: string): Promise<number> {
-  try {
-    const raw: unknown = JSON.parse(await readFile(lockPath, "utf8"));
-    if (typeof raw === "object" && raw !== null) {
-      const at = (raw as { at?: unknown }).at;
-      if (typeof at === "number" && Number.isFinite(at)) {
-        return at;
-      }
-    }
-  } catch {
-    // 読めない・JSON でない・`at` が無い。次の手がかりへ
+  const at = (await readLock(lockPath))?.at;
+  if (at !== undefined) {
+    return at;
   }
 
   try {
@@ -103,26 +125,62 @@ async function acquiredAt(lockPath: string): Promise<number> {
   }
 }
 
-/** ロックを1回だけ取りにいく。取れたら `true`。 */
-async function tryAcquire(lockPath: string, options: LockOptions): Promise<boolean> {
-  const content: LockFile = { pid: process.pid, at: options.now() };
+/**
+ * ロックを1回だけ取りにいく。取れたら、その取得を表す token を返す。
+ *
+ * **`wx` で作ったあと書き込みに失敗したら、自分で消してから投げる。** この時点では
+ * `withLock` の `finally` はまだ始まっておらず、ここで消さないと**空のロックファイルが
+ * 残ったまま例外が外へ出る。** そうなると `staleMs` が経つか手で消すまで、以降の
+ * 書き込みがすべてタイムアウトする。
+ */
+async function tryAcquire(lockPath: string, options: LockOptions): Promise<string | undefined> {
+  const content: LockFile = { pid: process.pid, at: options.now(), token: randomUUID() };
 
+  let handle;
   try {
-    const handle = await open(lockPath, "wx");
-    try {
-      await handle.writeFile(JSON.stringify(content), "utf8");
-    } finally {
-      await handle.close();
-    }
-
-    return true;
+    handle = await open(lockPath, "wx");
   } catch (error) {
     if (!isAlreadyExists(error)) {
       throw error;
     }
 
-    return false;
+    return undefined;
   }
+
+  try {
+    try {
+      await handle.writeFile(JSON.stringify(content), "utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    await rm(lockPath, { force: true });
+    throw error;
+  }
+
+  return content.token;
+}
+
+/**
+ * **自分が取ったロックだけを解放する。**
+ *
+ * 無条件に消してはいけない。自分の処理が `staleMs` を超えて長引くと、待っていた側が
+ * 「異常終了で残った」とみなして取り除き、自分のロックとして握り直す。そこでこちらが
+ * 無条件に消すと、**動いている相手のロックを奪う**ことになり、3つ目のプロセスが
+ * 並行して書き込めてしまう（実測で再現する）。
+ *
+ * 取得時に書いた token が残っているときだけ消す。**読んでから消すまでの隙間は残る**が、
+ * 無条件に消すのに比べれば窓は桁違いに小さい。
+ *
+ * **中身が読めなくなっていた場合も消さない。** 自分のものだと確かめられない以上、
+ * 残すほうが安全で、残っても `staleMs` の経過で回収される。
+ */
+async function release(lockPath: string, token: string): Promise<void> {
+  if ((await readLock(lockPath))?.token !== token) {
+    return;
+  }
+
+  await rm(lockPath, { force: true });
 }
 
 /**
@@ -140,9 +198,25 @@ export async function withLock<T>(
 ): Promise<T> {
   await mkdir(dirname(lockPath), { recursive: true });
 
+  const token = await acquire(lockPath, options);
+
+  try {
+    return await action();
+  } finally {
+    await release(lockPath, token);
+  }
+}
+
+/** 取れるまで待つ。待ち時間を使い切ったら `LockTimeoutError`。 */
+async function acquire(lockPath: string, options: LockOptions): Promise<string> {
   const startedAt = options.now();
 
-  while (!(await tryAcquire(lockPath, options))) {
+  for (;;) {
+    const token = await tryAcquire(lockPath, options);
+    if (token !== undefined) {
+      return token;
+    }
+
     // 異常終了で残ったロックなら取り除いて、次の試行で取りにいく
     if (options.now() - (await acquiredAt(lockPath)) > options.staleMs) {
       await rm(lockPath, { force: true });
@@ -157,11 +231,5 @@ export async function withLock<T>(
     }
 
     await options.wait(options.retryMs);
-  }
-
-  try {
-    return await action();
-  } finally {
-    await rm(lockPath, { force: true });
   }
 }

--- a/src/store/lock.ts
+++ b/src/store/lock.ts
@@ -1,0 +1,149 @@
+import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/**
+ * 書き込みの排他（#11）。
+ *
+ * **守るのは「読んでから書く」の間。** 追記そのものは `O_APPEND` が行単位で守るので、
+ * 別プロセスから同時に追記しても行は混ざらない。壊れるのは `start` のような
+ * **状態を読んで判断してから書く**操作で、2つのプロセスが同時に「実行中は無い」と
+ * 読むと、実行中エントリが2つできて `stop` できなくなる（実測で再現する）。
+ *
+ * **読み出しはロックを取らない。** 追記が行単位で守られている以上、読み手は
+ * 「ある時点までの行」を見るだけで壊れた状態にはならない。読みでも待たせると、
+ * 集計するたびに書き込みと競合して遅くなる。
+ *
+ * 仕組みは**ロックファイルの排他作成**（`wx`）に頼る。同じパスへの `open` は
+ * 1つしか成功しないので、勝った側だけが処理に入れる。
+ */
+
+/** ロックファイルに書く中身。取得した時刻を後から読めるようにする。 */
+interface LockFile {
+  readonly pid: number;
+  readonly at: number;
+}
+
+export interface LockOptions {
+  /** 現在時刻（ミリ秒）。テストで固定できるよう注入する。 */
+  readonly now: () => number;
+  /** 指定ミリ秒待つ。テストでは即座に返して時計だけ進める。 */
+  readonly wait: (ms: number) => Promise<void>;
+  /** 取得できないまま待つ上限。超えたら諦めてエラーにする。 */
+  readonly timeoutMs: number;
+  /** これより古いロックは、異常終了で残ったものとみなして取り除く。 */
+  readonly staleMs: number;
+  /** 取得を試す間隔。 */
+  readonly retryMs: number;
+}
+
+/**
+ * 既定の設定。
+ *
+ * **打刻は待たされると使われなくなる**ので、上限は短くする。一方で短すぎると、
+ * 正常な書き込みが競合しただけで落ちる。`staleMs` は `timeoutMs` より長くしないと、
+ * **待っている最中に相手のロックを「古い」とみなして奪う。**
+ */
+export const DEFAULT_LOCK_OPTIONS: LockOptions = {
+  now: () => Date.now(),
+  wait: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+  timeoutMs: 5_000,
+  staleMs: 30_000,
+  retryMs: 50,
+};
+
+function isAlreadyExists(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && (error as { code?: unknown }).code === "EEXIST"
+  );
+}
+
+/**
+ * ロックが取得された時刻。
+ *
+ * **中身が読めない場合はファイルの更新時刻に頼る。** 書き込みの途中で落ちると、空や
+ * 壊れた中身が残りうる。判定できないまま永久に書けなくなるほうが困るので、
+ * 別の手がかりへ落とす。それも読めなければ「非常に古い」として扱う。
+ */
+async function acquiredAt(lockPath: string): Promise<number> {
+  try {
+    const raw: unknown = JSON.parse(await readFile(lockPath, "utf8"));
+    if (typeof raw === "object" && raw !== null) {
+      const at = (raw as { at?: unknown }).at;
+      if (typeof at === "number" && Number.isFinite(at)) {
+        return at;
+      }
+    }
+  } catch {
+    // 読めない・JSON でない・`at` が無い。次の手がかりへ
+  }
+
+  try {
+    return (await stat(lockPath)).mtimeMs;
+  } catch {
+    // ファイルごと消えていた。取得を試せばよいので、古いものとして扱う
+    return Number.NEGATIVE_INFINITY;
+  }
+}
+
+/** ロックを1回だけ取りにいく。取れたら `true`。 */
+async function tryAcquire(lockPath: string, options: LockOptions): Promise<boolean> {
+  const content: LockFile = { pid: process.pid, at: options.now() };
+
+  try {
+    const handle = await open(lockPath, "wx");
+    try {
+      await handle.writeFile(JSON.stringify(content), "utf8");
+    } finally {
+      await handle.close();
+    }
+
+    return true;
+  } catch (error) {
+    if (!isAlreadyExists(error)) {
+      throw error;
+    }
+
+    return false;
+  }
+}
+
+/**
+ * ロックを取ってから処理を実行し、**必ず解放する。**
+ *
+ * 解放を漏らすと、1回の失敗で以降ずっと書き込めなくなる。処理が投げても解放する。
+ *
+ * **取れなかった相手のロックは消さない。** 待てなかったからと消すと排他の意味が無くなる。
+ * 消すのは「古すぎる（＝異常終了で残った）」と判断できたときだけ。
+ */
+export async function withLock<T>(
+  lockPath: string,
+  options: LockOptions,
+  action: () => Promise<T>,
+): Promise<T> {
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  const startedAt = options.now();
+
+  while (!(await tryAcquire(lockPath, options))) {
+    // 異常終了で残ったロックなら取り除いて、次の試行で取りにいく
+    if (options.now() - (await acquiredAt(lockPath)) > options.staleMs) {
+      await rm(lockPath, { force: true });
+      continue;
+    }
+
+    if (options.now() - startedAt >= options.timeoutMs) {
+      throw new Error(
+        `他の tock が書き込み中のため、${String(options.timeoutMs)}ms 待っても始められませんでした: ` +
+          `${lockPath}。実行中の tock が無ければ、このファイルを消してください`,
+      );
+    }
+
+    await options.wait(options.retryMs);
+  }
+
+  try {
+    return await action();
+  } finally {
+    await rm(lockPath, { force: true });
+  }
+}

--- a/src/store/lock.ts
+++ b/src/store/lock.ts
@@ -51,6 +51,24 @@ export const DEFAULT_LOCK_OPTIONS: LockOptions = {
   retryMs: 50,
 };
 
+/**
+ * 待ってもロックが取れなかった。
+ *
+ * **利用者に見せて意味のあるエラー**（別の端末で tock が動いている、あるいは異常終了で
+ * ロックが残っている）なので、想定外の例外と区別できる型にする。区別できないと
+ * 「tock の不具合」を表す終了コード 2 で終わり、スクリプトから見て内部エラーと同じになる。
+ *
+ * **`UserError` を使わないのは、依存が循環するため。** `UserError` は `cli.ts` にあり、
+ * その `cli.ts` は `store/jsonl-store.ts` を import している（`src/cli.ts` の import 節）。
+ * 逆向きに参照させず、`cli.ts` 側でこの型を見て終了コードを決める。
+ */
+export class LockTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LockTimeoutError";
+  }
+}
+
 function isAlreadyExists(error: unknown): boolean {
   return (
     typeof error === "object" && error !== null && (error as { code?: unknown }).code === "EEXIST"
@@ -132,7 +150,7 @@ export async function withLock<T>(
     }
 
     if (options.now() - startedAt >= options.timeoutMs) {
-      throw new Error(
+      throw new LockTimeoutError(
         `他の tock が書き込み中のため、${String(options.timeoutMs)}ms 待っても始められませんでした: ` +
           `${lockPath}。実行中の tock が無ければ、このファイルを消してください`,
       );

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -25,6 +25,24 @@ export type StoreRange = Period;
  * 指した実装を渡せる）。
  */
 export interface Store {
+  /**
+   * 読み出しから書き込みまでを、1つの操作としてまとめる（#11）。
+   *
+   * **書き込みだけを排他しても足りない。** 壊れるのは「実行中は無い」と読んでから
+   * 書くまでの間で、そこに他のプロセスが割り込むと実行中エントリが2つでき、
+   * `stop` できなくなる（実測で再現する）。判断に使った読み出しも、この中に入れる。
+   *
+   * ```ts
+   * await store.transaction(async () => {
+   *   if ((await store.findRunning()) !== undefined) throw new UserError("既に実行中です");
+   *   await store.append(entry);
+   * });
+   * ```
+   *
+   * **入れ子にしてよい。** 中で呼ぶ `append` などは、外側の排他をそのまま使う。
+   */
+  transaction<T>(action: () => Promise<T>): Promise<T>;
+
   /** 新しいエントリを追加する。同じ id が既にあれば失敗する。 */
   append(entry: Entry): Promise<void>;
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { type Command, EXIT_INTERNAL, EXIT_OK, EXIT_USAGE, run, UserError } from "../src/cli.js";
+import { LockTimeoutError } from "../src/store/lock.js";
 
 /** stdout / stderr を別々に集める。混ざっていないことを検証できる。 */
 function collector(): {
@@ -339,6 +340,22 @@ describe("終了コード", () => {
 
     expect(code).toBe(EXIT_INTERNAL);
     expect(err.length).toBeGreaterThan(0);
+  });
+
+  it("ロック待ちのタイムアウトは 1 を返す（#11）", async () => {
+    // 「別の端末で tock が動いている」は利用者が直せる状態であって、tock の不具合ではない。
+    // 2 を返すとスクリプトからは想定外の例外と見分けが付かない
+    const { err, io } = collector();
+    const commands = [
+      command("start", "作業を開始する", () => {
+        throw new LockTimeoutError("他の tock が書き込み中のため、5000ms 待っても…");
+      }),
+    ];
+
+    const code = await run(["start"], deps(io, commands));
+
+    expect(code).toBe(EXIT_USAGE);
+    expect(err.join("\n")).toContain("他の tock が書き込み中");
   });
 
   it("終了コードの値が仕様どおりである", () => {

--- a/tests/commands/export.test.ts
+++ b/tests/commands/export.test.ts
@@ -134,6 +134,7 @@ describe("export の引数", () => {
 
   it("引数の検査は store を読む前に行う（記録が壊れていても打ち間違いを先に返す）", async () => {
     const broken: Store = {
+      transaction: <T>(action: () => Promise<T>) => action(),
       append: () => Promise.reject(new Error("読めません")),
       update: () => Promise.reject(new Error("読めません")),
       delete: () => Promise.reject(new Error("読めません")),

--- a/tests/commands/rm.test.ts
+++ b/tests/commands/rm.test.ts
@@ -289,3 +289,58 @@ describe("rm と実行中エントリ（終端がない）", () => {
     expect(asked[0]).toContain("作業中");
   });
 });
+
+describe("確認を待つ間の排他（#11）", () => {
+  it("**返事を待っている間はロックを握らない**", async () => {
+    // 人の返事を待つ間ロックを握ると、その間に打刻した他の端末がすべてタイムアウトする。
+    // 確認の最中に別の書き込みが通ることで、握っていないことを見る
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+    let wroteDuringConfirm = false;
+
+    const confirmMeanwhile: Confirm = async () => {
+      await createStartCommand(deps(local(13, 17))).run(["割り込み"], io);
+      wroteDuringConfirm = true;
+
+      return true;
+    };
+
+    await createRmCommand(deps(NOW), confirmMeanwhile).run([id], io);
+
+    expect(wroteDuringConfirm).toBe(true);
+    expect((await store.listByRange(allTime)).some((entry) => entry.id === id)).toBe(false);
+  });
+
+  it("待っている間に記録が消えていたら、消しにいかず伝える", async () => {
+    // ロックの外で待つ以上、返事が返る頃には対象が無くなっていることがある。
+    // 引き当て直さないと「削除対象が見つかりません」という内部向けの文面が出る
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    const confirmAfterDelete: Confirm = async () => {
+      await store.delete(id);
+
+      return true;
+    };
+
+    await expect(createRmCommand(deps(NOW), confirmAfterDelete).run([id], io)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  it("消えていた場合のエラーに、消そうとした id が出る", async () => {
+    const id = await record(local(13, 9), local(13, 10), "設計 #work");
+
+    const confirmAfterDelete: Confirm = async () => {
+      await store.delete(id);
+
+      return true;
+    };
+
+    const error = await Promise.resolve(
+      createRmCommand(deps(NOW), confirmAfterDelete).run([id], io),
+    )
+      .then(() => undefined)
+      .catch((caught: unknown) => caught);
+
+    expect((error as Error).message).toContain("無くなりました");
+  });
+});

--- a/tests/commands/start.test.ts
+++ b/tests/commands/start.test.ts
@@ -286,3 +286,44 @@ describe("start の未知のオプション", () => {
     expect((await store.listByRange(allTime))[0]?.note).toBe("-5分の中断あり");
   });
 });
+
+describe("同時に打刻しても実行中は1つ（#11）", () => {
+  it("**並行して start しても、実行中エントリは1件しかできない**", async () => {
+    // 「実行中を調べる」と「追記する」を別々にしていると、両方が「実行中は無い」と
+    // 読んで2件できる。そうなると `stop` しても片方が残り、手詰まりになる
+    const results = await Promise.allSettled([
+      createStartCommand(deps()).run(["ひとつめ"], io),
+      createStartCommand(deps()).run(["ふたつめ"], io),
+      createStartCommand(deps()).run(["みっつめ"], io),
+    ]);
+
+    const running = (await store.listByRange(allTime)).filter((entry) => entry.end === undefined);
+    expect(running).toHaveLength(1);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+  });
+
+  it("弾かれたほうは、実行中がある旨の利用者向けエラーになる", async () => {
+    const results = await Promise.allSettled([
+      createStartCommand(deps()).run(["ひとつめ"], io),
+      createStartCommand(deps()).run(["ふたつめ"], io),
+    ]);
+
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(rejected).toHaveLength(1);
+    for (const { reason } of rejected) {
+      expect(reason).toBeInstanceOf(UserError);
+      expect((reason as Error).message).toContain("すでに実行中の作業があります");
+    }
+  });
+
+  it("並行 start のあとに stop すると、実行中が無くなる（手詰まりにならない）", async () => {
+    await Promise.allSettled([
+      createStartCommand(deps()).run(["ひとつめ"], io),
+      createStartCommand(deps()).run(["ふたつめ"], io),
+    ]);
+
+    await createStopCommand(deps(localTime(11, 0))).run([], io);
+
+    expect(await store.findRunning()).toBeUndefined();
+  });
+});

--- a/tests/commands/switch.test.ts
+++ b/tests/commands/switch.test.ts
@@ -64,6 +64,7 @@ const allTime = {
 /** 追記だけが必ず失敗するストア。書き込みが途中で落ちた状況を作る。 */
 function storeWithFailingAppend(base: Store): Store {
   return {
+    transaction: <T>(action: () => Promise<T>) => action(),
     append: () => Promise.reject(new Error("書き込みに失敗しました")),
     update: (entry) => base.update(entry),
     delete: (id) => base.delete(id),
@@ -82,6 +83,7 @@ function storeWithFailingAppend(base: Store): Store {
  */
 function storeWithFailingAppendAndRollback(base: Store): Store {
   return {
+    transaction: <T>(action: () => Promise<T>) => action(),
     append: () => Promise.reject(new Error("追記が失敗しました")),
     update: (entry) =>
       entry.end === undefined
@@ -103,6 +105,7 @@ function storeWithFailingAppendAndRollback(base: Store): Store {
  */
 function storeWithFailingUpdate(base: Store): Store {
   return {
+    transaction: <T>(action: () => Promise<T>) => action(),
     append: (entry) => base.append(entry),
     update: () => Promise.reject(new Error("確定の書き込みに失敗しました")),
     delete: (id) => base.delete(id),

--- a/tests/store/concurrent-write.test.ts
+++ b/tests/store/concurrent-write.test.ts
@@ -1,0 +1,277 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createEntry } from "../../src/domain/entry.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { DEFAULT_LOCK_OPTIONS, type LockOptions } from "../../src/store/lock.js";
+import type { Store } from "../../src/store/store.js";
+
+/**
+ * 多重起動しても壊れない（#11）。
+ *
+ * `lock.test.ts` がロックそのものを見るのに対し、ここは**ストア越しに使ったときに
+ * 何が守られるか**を見る。
+ *
+ * **本当の欠陥は「読んでから書く」の間にある。** 追記そのものは `O_APPEND` が行単位で
+ * 守るので、同時に書いても行は混ざらないし消えない。壊れるのは `start` のように
+ * **状態を読んで判断してから書く**操作で、2つの実行が同時に「実行中は無い」と読むと、
+ * 実行中エントリが2つできて `stop` できなくなる。だから `transaction` で読みから
+ * 書きまでを1つにまとめる。
+ */
+
+let dir = "";
+let file = "";
+let store: Store;
+let counter = 0;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-concurrent-"));
+  file = join(dir, "entries.jsonl");
+  store = createJsonlStore(file);
+  counter = 0;
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function entry(start: string, end?: string) {
+  counter += 1;
+
+  return createEntry(
+    { start, ...(end === undefined ? {} : { end }), tags: ["work"] },
+    { newId: () => `e${String(counter)}` },
+  );
+}
+
+/** 他のプロセスがロックを握っている状態を、ロックファイルを置いて作る。 */
+async function heldByOther(): Promise<void> {
+  await writeFile(`${file}.lock`, JSON.stringify({ pid: 99_999, at: Date.now() }), "utf8");
+}
+
+describe("並行書き込みでレコードが欠落しない（DoD）", () => {
+  it("同時に追記しても、すべての記録が残る", async () => {
+    const entries = Array.from({ length: 20 }, (_unused, index) =>
+      entry(`2026-08-01T${String(index).padStart(2, "0")}:00:00Z`),
+    );
+
+    await Promise.all(entries.map((added) => store.append(added)));
+
+    const all = await store.listAll();
+    expect(all.map((found) => found.id).toSorted()).toEqual(
+      entries.map((added) => added.id).toSorted(),
+    );
+  });
+
+  it("同時に追記と削除をしても、結果が読める形のまま", async () => {
+    // 追記と削除が混ざると、畳み込みの結果が壊れうる。行が壊れていないことを直接見る
+    const kept = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    const removed = entry("2026-08-02T09:00:00Z", "2026-08-02T10:00:00Z");
+    await store.append(removed);
+
+    await Promise.all([store.append(kept), store.delete(removed.id)]);
+
+    const raw = await readFile(file, "utf8");
+    const lines = raw.split("\n").filter((line) => line.trim() !== "");
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(() => JSON.parse(line) as unknown).not.toThrow();
+    }
+    await expect(store.listAll()).resolves.toEqual([kept]);
+  });
+
+  it("**同時に「実行中を調べてから開始」しても、実行中は1つだけになる**", async () => {
+    // ここが #11 の核心。ロックが無いと、両方が「実行中は無い」と読んで2つ開始し、
+    // `stop` できない状態になる（実測で再現した）
+    const started: string[] = [];
+    const rejected: string[] = [];
+
+    const start = async (id: string, at: string): Promise<void> => {
+      await store.transaction(async () => {
+        if ((await store.findRunning()) !== undefined) {
+          rejected.push(id);
+
+          return;
+        }
+
+        await store.append(createEntry({ start: at, tags: ["work"] }, { newId: () => id }));
+        started.push(id);
+      });
+    };
+
+    await Promise.all([
+      start("a", "2026-08-01T09:00:00Z"),
+      start("b", "2026-08-01T09:00:01Z"),
+      start("c", "2026-08-01T09:00:02Z"),
+    ]);
+
+    expect(started).toHaveLength(1);
+    expect(rejected).toHaveLength(2);
+    const running = (await store.listAll()).filter((found) => found.end === undefined);
+    expect(running).toHaveLength(1);
+  });
+
+  it("並行する transaction が重なって走らない", async () => {
+    let inside = 0;
+    let maxInside = 0;
+
+    const task = () =>
+      store.transaction(async () => {
+        inside += 1;
+        maxInside = Math.max(maxInside, inside);
+        await store.listAll();
+        inside -= 1;
+      });
+
+    await Promise.all([task(), task(), task(), task()]);
+
+    expect(maxInside).toBe(1);
+  });
+
+  it("**読み出しはロックを待たない**", async () => {
+    // 集計のたびに書き込みと競合して待たされると、使い物にならない。
+    // 追記は行単位で守られているので、読み手は壊れた状態を見ない
+    const only = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await store.append(only);
+    await heldByOther();
+
+    await expect(store.listAll()).resolves.toEqual([only]);
+    await expect(
+      store.listByRange({ start: new Date("2026-08-01"), end: new Date("2026-08-02") }),
+    ).resolves.toEqual([only]);
+    await expect(store.findRunning()).resolves.toBeUndefined();
+  });
+});
+
+describe("transaction の入れ子（同じロックを使い回す）", () => {
+  it("中で append を呼んでも進む", async () => {
+    // 取り直すと自分の握ったロックを自分で待つことになり、タイムアウトまで止まる
+    const added = entry("2026-08-01T09:00:00Z");
+
+    await store.transaction(async () => {
+      await store.findRunning();
+      await store.append(added);
+    });
+
+    await expect(store.listAll()).resolves.toEqual([added]);
+  });
+
+  it("三重に入れ子にしても進む（境界）", async () => {
+    const added = entry("2026-08-01T09:00:00Z");
+
+    await store.transaction(async () => {
+      await store.transaction(async () => {
+        await store.transaction(async () => {
+          await store.append(added);
+        });
+      });
+    });
+
+    await expect(store.listAll()).resolves.toEqual([added]);
+  });
+
+  it("処理の戻り値をそのまま返す", async () => {
+    await expect(store.transaction(() => Promise.resolve(42))).resolves.toBe(42);
+  });
+
+  it("**失敗してもロックを解放する**", async () => {
+    // 漏らすと、1回の失敗で以降ずっと書き込めなくなる
+    await expect(store.transaction(() => Promise.reject(new Error("失敗")))).rejects.toThrow(
+      "失敗",
+    );
+
+    await expect(stat(`${file}.lock`)).rejects.toThrow();
+    await expect(store.append(entry("2026-08-01T09:00:00Z"))).resolves.toBeUndefined();
+  });
+
+  it("入れ子の中で失敗しても、外側がロックを解放する", async () => {
+    await expect(
+      store.transaction(() => store.transaction(() => Promise.reject(new Error("内側の失敗")))),
+    ).rejects.toThrow("内側の失敗");
+
+    await expect(stat(`${file}.lock`)).rejects.toThrow();
+  });
+
+  it("終わったあとにロックファイルが残らない", async () => {
+    await store.append(entry("2026-08-01T09:00:00Z"));
+
+    await expect(stat(`${file}.lock`)).rejects.toThrow();
+  });
+});
+
+describe("ロック待ちのタイムアウト（DoD）", () => {
+  /** すぐ諦めるストア。実時間を待たずにタイムアウトを見る。 */
+  function impatient(): Store {
+    const options: LockOptions = { ...DEFAULT_LOCK_OPTIONS, timeoutMs: 0, staleMs: 30_000 };
+
+    return createJsonlStore(file, options);
+  }
+
+  it("追記が分かりやすいエラーで失敗する", async () => {
+    await heldByOther();
+
+    await expect(impatient().append(entry("2026-08-01T09:00:00Z"))).rejects.toThrow(
+      /他の tock が書き込み中/,
+    );
+  });
+
+  it("エラーに、待った時間とロックファイルの場所が出る", async () => {
+    await heldByOther();
+
+    const error = await impatient()
+      .append(entry("2026-08-01T09:00:00Z"))
+      .catch((caught: unknown) => caught);
+
+    expect((error as Error).message).toContain(`${file}.lock`);
+    expect((error as Error).message).toContain("0ms");
+  });
+
+  it("**取れなかったときは書き込まない**", async () => {
+    // 取れないのに書いてしまうなら、ロックを取る意味が無い
+    const before = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await store.append(before);
+    await heldByOther();
+    const raw = await readFile(file, "utf8");
+
+    await expect(impatient().append(entry("2026-08-02T09:00:00Z"))).rejects.toThrow();
+
+    await expect(readFile(file, "utf8")).resolves.toBe(raw);
+  });
+
+  it("transaction の中身が実行されない", async () => {
+    await heldByOther();
+    let ran = false;
+
+    await expect(
+      impatient().transaction(() => {
+        ran = true;
+
+        return Promise.resolve();
+      }),
+    ).rejects.toThrow(/他の tock が書き込み中/);
+
+    expect(ran).toBe(false);
+  });
+
+  it("**他のプロセスのロックを壊さない**", async () => {
+    await heldByOther();
+    const held = await readFile(`${file}.lock`, "utf8");
+
+    await expect(impatient().append(entry("2026-08-01T09:00:00Z"))).rejects.toThrow();
+
+    await expect(readFile(`${file}.lock`, "utf8")).resolves.toBe(held);
+  });
+
+  it("更新と削除も同じように待って諦める", async () => {
+    const existing = entry("2026-08-01T09:00:00Z", "2026-08-01T10:00:00Z");
+    await store.append(existing);
+    await heldByOther();
+
+    await expect(impatient().update({ ...existing, note: "直した" })).rejects.toThrow(
+      /他の tock が書き込み中/,
+    );
+    await expect(impatient().delete(existing.id)).rejects.toThrow(/他の tock が書き込み中/);
+  });
+});

--- a/tests/store/lock-write-failure.test.ts
+++ b/tests/store/lock-write-failure.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `wx` でロックファイルを作ったあと、本文の書き込みに失敗した場合（レビュー指摘）。
+ *
+ * **作った側が消さないと、空のロックファイルが残ったまま例外が外へ出る。** その時点では
+ * `withLock` の `finally` はまだ始まっていないので、そちらでは拾えない。残ると
+ * `staleMs` が経つか手で消すまで、以降の書き込みがすべてタイムアウトする。
+ *
+ * **この失敗は実ファイルでは起こしにくい**（ディスク満杯など）ので、`open` が返す
+ * ハンドルの書き込みだけを失敗させる。**ファイル自体は本物を作る**——テストで見たいのは
+ * 「作ったファイルが消えるか」なので、そこは実体が要る。
+ *
+ * モックはこのファイル単位で効くため、他のロックのテストと混ぜず独立させている。
+ */
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+
+  return {
+    ...actual,
+    default: actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const handle = await actual.open(...args);
+
+      return Object.assign(handle, {
+        writeFile: () => Promise.reject(new Error("ディスクが満杯です")),
+      });
+    },
+  };
+});
+
+const { DEFAULT_LOCK_OPTIONS, withLock } = await import("../../src/store/lock.js");
+
+let dir = "";
+let lockPath = "";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-lock-write-"));
+  lockPath = join(dir, "entries.jsonl.lock");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("ロックファイルの書き込みに失敗したとき", () => {
+  it("**作ったロックファイルを残さない**", async () => {
+    await expect(withLock(lockPath, DEFAULT_LOCK_OPTIONS, () => Promise.resolve())).rejects.toThrow(
+      "ディスクが満杯です",
+    );
+
+    await expect(stat(lockPath)).rejects.toThrow();
+  });
+
+  it("処理は実行されない", async () => {
+    let ran = false;
+
+    await expect(
+      withLock(lockPath, DEFAULT_LOCK_OPTIONS, () => {
+        ran = true;
+
+        return Promise.resolve();
+      }),
+    ).rejects.toThrow();
+
+    expect(ran).toBe(false);
+  });
+
+  it("失敗の理由がそのまま伝わる（握りつぶさない）", async () => {
+    // ここで EEXIST 扱いにして「取れなかった」に丸めると、待ち続けたあげく
+    // タイムアウトのエラーになり、本当の原因（書き込めない）が消える
+    const error = await withLock(lockPath, DEFAULT_LOCK_OPTIONS, () => Promise.resolve()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect((error as Error).name).not.toBe("LockTimeoutError");
+    expect((error as Error).message).toBe("ディスクが満杯です");
+  });
+});

--- a/tests/store/lock.test.ts
+++ b/tests/store/lock.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_LOCK_OPTIONS, type LockOptions, withLock } from "../../src/store/lock.js";
+import {
+  DEFAULT_LOCK_OPTIONS,
+  LockTimeoutError,
+  type LockOptions,
+  withLock,
+} from "../../src/store/lock.js";
 
 /**
  * 書き込みの排他（#11）。
@@ -149,6 +154,17 @@ describe("待っても取れなければタイムアウトする（DoD）", () =
 
     await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow(
       /他の tock が書き込み中/,
+    );
+  });
+
+  it("**想定外の例外と区別できる型で失敗する**", async () => {
+    // 区別できないと、CLI は「tock の不具合」を表す終了コード 2 で終わる。
+    // 別の端末が動いているのは利用者が直せる状態なので、そこと同じ扱いにしない
+    const { options } = controllable({ timeoutMs: 100, staleMs: 10_000 });
+    await held();
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toBeInstanceOf(
+      LockTimeoutError,
     );
   });
 

--- a/tests/store/lock.test.ts
+++ b/tests/store/lock.test.ts
@@ -308,6 +308,63 @@ describe("異常終了で残った古いロック（DoD のスコープ）", () 
   });
 });
 
+describe("解放するのは自分が取ったロックだけ（レビュー指摘）", () => {
+  it("**取り直された相手のロックを、解放時に消さない**", async () => {
+    // 自分の処理が `staleMs` を超えて長引くと、待っていた側が「異常終了で残った」と
+    // みなして取り除き、握り直す。そこで無条件に消すと**動いている相手のロックを奪う**。
+    // 実測では、そのあと3つ目のプロセスが並行して入れてしまった
+    const { options } = controllable({ timeoutMs: 100, staleMs: 1_000 });
+    const other = JSON.stringify({ pid: 99_999, at: 0, token: "他のプロセスの取得" });
+
+    await withLock(lockPath, options, async () => {
+      // 待っていた側が回収して握り直した状況
+      await writeFile(lockPath, other, "utf8");
+    });
+
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(other);
+  });
+
+  it("奪われたあとでも、相手が解放すれば取得できる（手詰まりにならない）", async () => {
+    const { options } = controllable({ timeoutMs: 100, staleMs: 1_000 });
+
+    await withLock(lockPath, options, async () => {
+      await writeFile(lockPath, JSON.stringify({ pid: 99_999, at: 0, token: "別" }), "utf8");
+    });
+    await rm(lockPath, { force: true });
+
+    await expect(withLock(lockPath, options, () => Promise.resolve("取れた"))).resolves.toBe(
+      "取れた",
+    );
+  });
+
+  it("中身が読めなくなっていたら消さない（境界）", async () => {
+    // 自分のものだと確かめられない以上、残すほうが安全。残っても `staleMs` で回収される
+    const { options } = controllable({ timeoutMs: 100, staleMs: 1_000 });
+
+    await withLock(lockPath, options, async () => {
+      await writeFile(lockPath, "壊れています", "utf8");
+    });
+
+    await expect(readFile(lockPath, "utf8")).resolves.toBe("壊れています");
+  });
+
+  it("取得のたびに違う token を書く（同じプロセスでも取り違えない）", async () => {
+    // `pid` だけだと、同じプロセスの前の取得と区別が付かない
+    const { options } = controllable();
+    const tokens: unknown[] = [];
+
+    for (const attempt of [1, 2, 3]) {
+      void attempt;
+      await withLock(lockPath, options, async () => {
+        tokens.push((JSON.parse(await readFile(lockPath, "utf8")) as { token: unknown }).token);
+      });
+    }
+
+    expect(new Set(tokens).size).toBe(3);
+    expect(tokens.every((token) => typeof token === "string" && token !== "")).toBe(true);
+  });
+});
+
 describe("既定の設定", () => {
   it("タイムアウトと古さの期限が、待てる長さになっている", () => {
     // 打刻は待たされると使われなくなる。一方で短すぎると、正常な書き込みが競合で落ちる

--- a/tests/store/lock.test.ts
+++ b/tests/store/lock.test.ts
@@ -1,0 +1,306 @@
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_LOCK_OPTIONS, type LockOptions, withLock } from "../../src/store/lock.js";
+
+/**
+ * 書き込みの排他（#11）。
+ *
+ * **守りたいのは「読んでから書く」の間。** 追記そのものは `O_APPEND` が行単位で守るので、
+ * 行が混ざったり消えたりはしない（実測済み。30プロセスから同時に追記しても30行）。
+ * 壊れるのは `start` のような**状態を読んで判断してから書く**操作で、2つのプロセスが
+ * 同時に「実行中は無い」と読むと、実行中エントリが2つできて `stop` できなくなる。
+ *
+ * **時刻と待機は注入する。** タイムアウトと古いロックの判定を、実時間を待たずに
+ * 検証できるようにするため（`CLAUDE.md`「環境に依存する値は注入可能にする」）。
+ */
+
+let dir = "";
+let lockPath = "";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-lock-"));
+  lockPath = join(dir, "entries.jsonl.lock");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** 時刻を手で進められるロック設定。待機した時間だけ時計も進む。 */
+function controllable(overrides: Partial<LockOptions> = {}) {
+  let current = 0;
+  const waited: number[] = [];
+
+  const options: LockOptions = {
+    ...DEFAULT_LOCK_OPTIONS,
+    now: () => current,
+    wait: (ms: number) => {
+      waited.push(ms);
+      current += ms;
+
+      return Promise.resolve();
+    },
+    ...overrides,
+  };
+
+  return { options, waited, advance: (ms: number) => (current += ms) };
+}
+
+describe("ロックの取得と解放", () => {
+  it("処理の間だけロックファイルがある", async () => {
+    const { options } = controllable();
+    let duringExists = false;
+
+    await withLock(lockPath, options, async () => {
+      duringExists = await stat(lockPath).then(
+        () => true,
+        () => false,
+      );
+    });
+
+    expect(duringExists).toBe(true);
+    await expect(stat(lockPath)).rejects.toThrow();
+  });
+
+  it("処理の戻り値をそのまま返す", async () => {
+    const { options } = controllable();
+
+    await expect(withLock(lockPath, options, () => Promise.resolve(42))).resolves.toBe(42);
+  });
+
+  it("**処理が失敗してもロックを解放する**", async () => {
+    // ここを漏らすと、1回の失敗で以降ずっと書き込めなくなる
+    const { options } = controllable();
+
+    await expect(
+      withLock(lockPath, options, () => Promise.reject(new Error("失敗"))),
+    ).rejects.toThrow("失敗");
+
+    await expect(stat(lockPath)).rejects.toThrow();
+  });
+
+  it("解放したあとは、もう一度取得できる", async () => {
+    const { options } = controllable();
+
+    await withLock(lockPath, options, () => Promise.resolve());
+
+    await expect(withLock(lockPath, options, () => Promise.resolve("2回目"))).resolves.toBe(
+      "2回目",
+    );
+  });
+
+  it("ロックファイルの親ディレクトリが無ければ作る（境界）", async () => {
+    const { options } = controllable();
+    const nested = join(dir, "a", "b", "entries.jsonl.lock");
+
+    await expect(withLock(nested, options, () => Promise.resolve("ok"))).resolves.toBe("ok");
+  });
+});
+
+describe("並行して呼んでも、同時には1つしか通らない（DoD）", () => {
+  it("重なって実行されない", async () => {
+    const { options } = controllable();
+    let inside = 0;
+    let maxInside = 0;
+
+    const task = () =>
+      withLock(lockPath, options, async () => {
+        inside += 1;
+        maxInside = Math.max(maxInside, inside);
+        await Promise.resolve();
+        inside -= 1;
+      });
+
+    await Promise.all([task(), task(), task(), task(), task()]);
+
+    expect(maxInside).toBe(1);
+  });
+
+  it("並行して呼んでも全部が実行される（取りこぼさない）", async () => {
+    const { options } = controllable();
+    const done: number[] = [];
+
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((n) =>
+        withLock(lockPath, options, () => {
+          done.push(n);
+
+          return Promise.resolve();
+        }),
+      ),
+    );
+
+    expect(done.toSorted()).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("待っても取れなければタイムアウトする（DoD）", () => {
+  /** 他のプロセスが握っている状態を、ロックファイルを置いて作る。 */
+  async function held(atMs = 0): Promise<void> {
+    await writeFile(lockPath, JSON.stringify({ pid: 99_999, at: atMs }), "utf8");
+  }
+
+  it("分かりやすいエラーで失敗する", async () => {
+    const { options } = controllable({ timeoutMs: 100, staleMs: 10_000 });
+    await held();
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow(
+      /他の tock が書き込み中/,
+    );
+  });
+
+  it("エラーに、待った時間とロックファイルの場所が出る", async () => {
+    // 何が起きているか・どこを見ればよいかが分からないと、利用者は手詰まりになる
+    const { options } = controllable({ timeoutMs: 100, staleMs: 10_000 });
+    await held();
+
+    const error = await withLock(lockPath, options, () => Promise.resolve()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect((error as Error).message).toContain(lockPath);
+    expect((error as Error).message).toContain("100");
+  });
+
+  it("**他のプロセスのロックを壊さない**", async () => {
+    // 待てなかったからと消してしまうと、排他の意味が無くなる
+    const { options } = controllable({ timeoutMs: 100, staleMs: 10_000 });
+    await held();
+    const before = await readFile(lockPath, "utf8");
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow();
+
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(before);
+  });
+
+  it("処理は実行されない", async () => {
+    const { options } = controllable({ timeoutMs: 100, staleMs: 10_000 });
+    await held();
+    let ran = false;
+
+    await expect(
+      withLock(lockPath, options, () => {
+        ran = true;
+
+        return Promise.resolve();
+      }),
+    ).rejects.toThrow();
+
+    expect(ran).toBe(false);
+  });
+
+  it("タイムアウトが 0 なら待たずに失敗する（境界）", async () => {
+    const { options, waited } = controllable({ timeoutMs: 0, staleMs: 10_000 });
+    await held();
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow();
+    expect(waited).toEqual([]);
+  });
+
+  it("待っている間に解放されれば取得できる", async () => {
+    const { options } = controllable({ timeoutMs: 1_000, staleMs: 10_000 });
+    await held();
+
+    // 1回目の待機の直後に解放される状況を作る
+    const releasing = withLock(
+      lockPath,
+      {
+        ...options,
+        wait: async (ms) => {
+          await rm(lockPath, { force: true });
+          void ms;
+        },
+      },
+      () => Promise.resolve("取れた"),
+    );
+
+    await expect(releasing).resolves.toBe("取れた");
+  });
+});
+
+describe("異常終了で残った古いロック（DoD のスコープ）", () => {
+  /** 指定した時刻に取得されたロックを置く。 */
+  async function heldAt(atMs: number): Promise<void> {
+    await writeFile(lockPath, JSON.stringify({ pid: 99_999, at: atMs }), "utf8");
+  }
+
+  it("古すぎるロックは取り除いて取得する", async () => {
+    // 異常終了でロックが残ったまま二度と書き込めなくなるのを避ける
+    const { options } = controllable({ timeoutMs: 100, staleMs: 1_000 });
+    await heldAt(-5_000);
+
+    await expect(withLock(lockPath, options, () => Promise.resolve("取れた"))).resolves.toBe(
+      "取れた",
+    );
+  });
+
+  it("期限ちょうどのロックはまだ古くない（境界）", async () => {
+    // 「以上」と「超過」を取り違えると、生きているロックを奪う
+    const { options } = controllable({ timeoutMs: 0, staleMs: 1_000 });
+    await heldAt(-1_000);
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow(
+      /他の tock が書き込み中/,
+    );
+  });
+
+  it("期限を1ミリ秒でも超えたら古い（境界）", async () => {
+    const { options } = controllable({ timeoutMs: 0, staleMs: 1_000 });
+    await heldAt(-1_001);
+
+    await expect(withLock(lockPath, options, () => Promise.resolve("取れた"))).resolves.toBe(
+      "取れた",
+    );
+  });
+
+  it("中身が読めないロックファイルは、更新時刻で古さを判断する（境界）", async () => {
+    // 書き込みの途中で落ちると、空や壊れた中身が残りうる。
+    // **判定できないまま永久に書けなくなるほうが困る**ので、ファイルの更新時刻に落とす。
+    //
+    // **ここだけ実時計を使う。** 更新時刻は実ファイルの属性なので、注入した時計と
+    // 混ぜると比較が成立しない（最初この取り違えでテストが落ちた）
+    const old = new Date(Date.now() - 60_000);
+    await writeFile(lockPath, "壊れています", "utf8");
+    await utimes(lockPath, old, old);
+
+    const options: LockOptions = { ...DEFAULT_LOCK_OPTIONS, timeoutMs: 0, staleMs: 1_000 };
+
+    await expect(withLock(lockPath, options, () => Promise.resolve("取れた"))).resolves.toBe(
+      "取れた",
+    );
+  });
+
+  it("中身が読めなくても、更新時刻が新しければ待つ（境界）", async () => {
+    // 「読めない＝古い」にすると、書き込み中のロックを奪ってしまう
+    await writeFile(lockPath, "壊れています", "utf8");
+
+    const options: LockOptions = { ...DEFAULT_LOCK_OPTIONS, timeoutMs: 0, staleMs: 30_000 };
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow(
+      /他の tock が書き込み中/,
+    );
+  });
+
+  it("取り除いたあとに握り直され、それが新しければ待つ（境界）", async () => {
+    const { options } = controllable({ timeoutMs: 0, staleMs: 1_000 });
+    await heldAt(0);
+
+    await expect(withLock(lockPath, options, () => Promise.resolve())).rejects.toThrow();
+  });
+});
+
+describe("既定の設定", () => {
+  it("タイムアウトと古さの期限が、待てる長さになっている", () => {
+    // 打刻は待たされると使われなくなる。一方で短すぎると、正常な書き込みが競合で落ちる
+    expect(DEFAULT_LOCK_OPTIONS.timeoutMs).toBeGreaterThan(0);
+    expect(DEFAULT_LOCK_OPTIONS.timeoutMs).toBeLessThanOrEqual(10_000);
+  });
+
+  it("古さの期限はタイムアウトより長い", () => {
+    // 逆だと、待っている最中に相手のロックを古いとみなして奪う
+    expect(DEFAULT_LOCK_OPTIONS.staleMs).toBeGreaterThan(DEFAULT_LOCK_OPTIONS.timeoutMs);
+  });
+});


### PR DESCRIPTION
## 概要

複数の端末から同時に操作しても壊れないようにする。

**実測してから方針を決めた。** 最初に「レコードが欠落する」を疑ったが、30プロセスから同時に追記しても30行そのまま残る。追記は `O_APPEND` が行単位で守るので、行が混ざることも消えることもない。

**実際に壊れるのは「読んでから書く」の間だった。** `start` は「実行中は無い」と読んでから追記する。2プロセスが同時に読むと両方が「無い」と判断し、実行中エントリが2件できる。こうなると `stop` しても片方が残り、手詰まりになる。**修正前の実装で10回中2回再現した**（下記）。

このため、書き込み1回ずつを排他するだけでは足りない。`Store` に `transaction` を足し、**判断に使った読み出しごと**1つの操作にまとめた。

```ts
const entry = await deps.store.transaction(async () => {
  const running = await deps.store.findRunning();
  if (running !== undefined) throw new UserError("すでに実行中の作業があります…");
  await deps.store.append(created);
  return created;
});
```

設計上の判断が5つある。

| 判断 | 理由 |
| --- | --- |
| 入れ子を許す | 中で呼ぶ `append` が同じロックを取り直すと、**自分の握ったロックを自分で待つ**ことになって進めなくなる |
| 握っているかを `AsyncLocalStorage` で持つ | 単なる真偽値だと、同じプロセスで**並行して走る別の `transaction`** まで「握っている」と誤判定し、排他をすり抜ける |
| **読み出しはロックを取らない** | 追記が行単位で守られている以上、読み手は壊れた状態を見ない。読みでも待たせると集計のたびに書き込みと競合する |
| **`rm` の確認はロックの外で待つ** | 人の返事を待つ間ロックを握ると、その間の打刻がすべてタイムアウトする。代わりに返事を得てから引き当て直す |
| **解放するのは自分が取ったロックだけ**（レビュー指摘） | 無条件に消すと、stale 回収で握り直した相手のロックを奪う。取得時に書いた token が残っているときだけ消す |

**ロック待ちのタイムアウトは終了コード 1 にした。** 「別の端末で tock が動いている」は利用者が直せる状態であって、tock の不具合（終了コード 2）ではない。`store/` から `cli.ts` の `UserError` は参照できない（`cli.ts` が `store/jsonl-store.ts` を import しており、逆向きにすると循環する）ので、`LockTimeoutError` を `store/lock.ts` に置き、`cli.ts` 側で終了コードを決めている。

Closes #11

## 受け入れ条件

- [x] 並行書き込みでレコードが欠落しないテストがある

  → `tests/store/concurrent-write.test.ts`「同時に追記しても、すべての記録が残る」（20件を同時に `append`）、「同時に追記と削除をしても、結果が読める形のまま」、および `tests/commands/start.test.ts`「**並行して start しても、実行中エントリは1件しかできない**」

  CLI でも確認した。12件の記録を作り、12プロセスから同時に `edit` する。

  ```
  $ for id in $ids; do node dist/cli.js edit "$id" --note "直した$i" & done; wait
  記録の件数: 11
  「直した」が入った件数: 11
  壊れた行: 0
  ```

  （記録が11件なのは、生成に使った `--at` の1つが不正で `start` が弾かれたため。11件すべてが同時編集を受けて残っている）

- [x] ロック待ちがタイムアウトした場合に、分かりやすいエラーで終了するテストがある

  → `tests/store/lock.test.ts`「分かりやすいエラーで失敗する」「エラーに、待った時間とロックファイルの場所が出る」「**想定外の例外と区別できる型で失敗する**」、`tests/store/concurrent-write.test.ts`「追記が分かりやすいエラーで失敗する」ほか、`tests/cli.test.ts`「ロック待ちのタイムアウトは 1 を返す（#11）」

  ```
  $ node dist/cli.js start "先客"
  $ echo '{"pid":99999,"at":'"$(date +%s000)"'}' > "$TOCK_DIR/entries.jsonl.lock"
  $ node dist/cli.js stop
  他の tock が書き込み中のため、5000ms 待っても始められませんでした: /tmp/tmp.kUvk2EUsRu/entries.jsonl.lock。実行中の tock が無ければ、このファイルを消してください
  $ echo $?
  1
  ```

  **待てなかった相手のロックは消さない**（`tests/store/lock.test.ts`「**他のプロセスのロックを壊さない**」）。消すのは「古すぎる（＝異常終了で残った）」と判断できたときだけ。

### スコープの3点目（異常終了で残った古いロックの扱い）

DoD には無いが Issue のスコープに挙がっているので実装した。ロックファイルに取得時刻を書き、`staleMs`（既定 30 秒）を超えたものは取り除いて取得する。中身が読めない場合はファイルの更新時刻に落とす——書き込みの途中で落ちると空や壊れた中身が残りうるので、**判定できないまま永久に書けなくなるほうが困る。**

境界は `tests/store/lock.test.ts` の「期限ちょうどのロックはまだ古くない」「期限を1ミリ秒でも超えたら古い」「中身が読めないロックファイルは、更新時刻で古さを判断する」「中身が読めなくても、更新時刻が新しければ待つ」で押さえた。

## 修正前後の実測

2プロセスから同時に `start` を10回。

```
=== 修正前（main）: 2プロセス同時 start を10回 ===
run1  実行中 1 件
run2  実行中 1 件
run3  実行中 1 件
run4  実行中 2 件      ← stop できない
run5  実行中 1 件
run6  実行中 1 件
run7  実行中 1 件
run8  実行中 2 件      ← stop できない
run9  実行中 1 件
run10 実行中 1 件
→ 実行中が2件になった回数: 2 / 10
```

```
=== 修正後: 2プロセス同時 start を10回 ===
run1  実行中 1 件
（中略。run2〜run10 もすべて 1 件）
→ 実行中が2件になった回数: 0 / 10
```

10プロセスに増やしても実行中は1件で、残りは利用者向けエラーで終わる。

```
$ for i in $(seq 1 10); do node dist/cli.js start "作業$i" & done; wait
行数: 1
$ node dist/cli.js status
実行中: 作業5
経過: 0s
開始: 2026-08-15T07:10:38.167Z
$ echo $?
0
$ ls -a "$TOCK_DIR"
.  ..  entries.jsonl        ← ロックファイルは残らない
```

## レビューで直したこと（`b51cffb`）

**指摘は2件とも本物で、片方は排他そのものが崩れる欠陥だった。**

### [Major] 解放が所有権を見ていなかった

自分の処理が `staleMs` を超えて長引くと、待っていた側がそのロックを「異常終了で残った」とみなして回収し、握り直す。そこで**無条件に消すと、動いている相手のロックを奪う。**

再現の条件を1つ調整した。最初の再現では C が `staleMs` を超えて握っている B のロックを回収してしまい、**「解放の不備で奪った」のか「stale 回収で奪った」のかが区別できなかった。** B が握る時間を `staleMs` 未満（`staleMs: 300` に対し 250ms）にして切り分けた。

```
=== 修正前（143dd75） ===
A の解放後、B のロックファイルは: **消えた**
  そのとき B は: 処理中
C は B と同時に入れたか: **入れた（排他が壊れている）**

=== 修正後（b51cffb） ===
A の解放後、B のロックファイルは: 残っている
  そのとき B は: 処理中
C は B と同時に入れたか: 入れなかった
```

取得のたびに `randomUUID()` の token を書き、解放時にそれが残っているときだけ消すようにした。**`pid` では足りない**——同じプロセスが回収されて握り直した場合を区別できない。

**限界:** 読んでから消すまでの隙間は残る。無条件に消すのに比べれば窓は桁違いに小さいという判断で、原子的にやるには `renameat2` 相当か、ロック自体をディレクトリにする（`mkdir` の原子性を使う）などが要る。

### [Minor] `wx` で作ったあと書き込みに失敗すると、作りかけが残る

その時点では `withLock` の `finally` がまだ始まっていないので拾えない。`tryAcquire` の中で消してから投げるようにした。あわせて `open` の失敗とそれ以降の失敗を別の `try` に分け、**書き込みの失敗が `EEXIST` 判定に掛かって「取れなかった」に丸められる**余地も無くした。

**実ファイルでは再現できなかった。** `wx` で作れて直後の書き込みだけが失敗する状況を、テスト環境で安定して作る手段が見つからない（`/dev/full` へのシンボリックリンクも `O_CREAT|O_EXCL` が `EEXIST` を返すため使えない）。`tests/store/lock-write-failure.test.ts` を独立させ、`open` が返すハンドルの `writeFile` だけを失敗させている。**ファイル自体は本物を作る**——見たいのは「作ったファイルが消えるか」なので、そこは実体が要る。

## mutation test

| 壊した内容 | 落ちたテスト |
| --- | --- |
| `start.ts` の `transaction` を外し、`findRunning` と `append` を別々にする | 3件 |
| `exclusively` がロックを取らず、そのまま実行する | 11件 |
| `exclusively` が入れ子でもロックを取り直す（再入を検出しない） | 11件 |
| `withLock` の解放を `finally` から外し、失敗時に漏らす | 3件 |
| `rm.ts` の「確認後の引き当て直し」を外し、そのまま削除する | 2件 |
| `cli.ts` の終了コード判定から `LockTimeoutError` を外す | 1件 |
| `release` を無条件 `rm` に戻す（レビュー分） | 2件 |
| `tryAcquire` の書き込み失敗時の `rm` を外す（レビュー分） | 1件 |

落ちなかった箇所は無い。壊した実装はすべて元に戻し、`npm run check` が全件（1553件）通ることを確認した。

**限界:** これが答えるのは「書いてあるコードをテストが見張っているか」だけで、方針そのものの正しさには答えない。とくに**追記2回の原子性は入っていない**（下記）。

## この PR で扱っていないこと

**排他は入れたが、原子性は入っていない。** `switch` は「前を停止する追記」と「次を開始する追記」の2行を書く。他のプロセスから途中の状態は見えなくなったが、**その2行の間でプロセスが落ちれば片方だけ書かれた状態がファイルに残る。** いまは巻き戻しで詰めているが、巻き戻し自体が失敗する可能性は残る。

これを閉じるには2つの操作を1行にまとめる必要があり、保存形式の設計になる。#11 のスコープ（ロックの取得と解放・タイムアウト・古いロック）を超えるので、**#88 として起票した。** `switch.ts` のコメントは、この点を #11 の担当だと書いていたので事実に合わせて直した。

## スタック

- base: `main`（依存の #9 はマージ済み。open な PR は他に無い）
