### PR TITLE
[E1-12][P3] package-lock.json の engines が package.json と食い違っている

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vitest": "4.1.10"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/tests/package-engines.test.ts
+++ b/tests/package-engines.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `package.json` と `package-lock.json` の `engines` が食い違っていないこと（#83）。
+ *
+ * **`npm ci` は通るので CI では気づけない。** 食い違ったまま `npm install` を走らせると
+ * npm が差を埋めるため、**依存を1つ足しただけの PR に無関係な行が混ざる。**
+ *
+ * **`npm` を実行して確かめない。** `npm install --package-lock-only` を走らせて
+ * 差分の有無を見るやり方は、ネットワークと npm の版に結果が左右される。ここで固定したい
+ * のは「2つのファイルの宣言が一致していること」なので、両方を読んで突き合わせる。
+ * これが一致していれば、npm が埋める差はもう無い。
+ *
+ * **見るのはルート項目（`packages[""]`）だけ。** lockfile には依存パッケージ自身の
+ * `engines` も並ぶが、それらは各パッケージの宣言であってこちらが決めるものではない
+ * （`tests/docs/license.test.ts` が `license` を同じ理由でルート項目だけに絞っている）。
+ */
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+type Engines = Record<string, string>;
+
+function readJson(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(ROOT, name), "utf8")) as Record<string, unknown>;
+}
+
+/** lockfile のルート項目（このリポジトリ自身の宣言）。 */
+function lockRoot(): Record<string, unknown> {
+  const packages = readJson("package-lock.json")["packages"] as Record<
+    string,
+    Record<string, unknown>
+  >;
+
+  return packages[""] ?? {};
+}
+
+function enginesOf(source: Record<string, unknown>): Engines | undefined {
+  const engines = source["engines"];
+
+  return typeof engines === "object" && engines !== null && !Array.isArray(engines)
+    ? (engines as Engines)
+    : undefined;
+}
+
+describe("engines の宣言が2つのファイルで一致している（DoD）", () => {
+  it("**ルート項目の `engines` が丸ごと一致する**", () => {
+    // `node` だけを見ると、あとで `npm` などを足したときに同じ食い違いが再発する
+    expect(enginesOf(lockRoot())).toEqual(enginesOf(readJson("package.json")));
+  });
+
+  it("`engines.node` が一致する", () => {
+    expect(enginesOf(lockRoot())?.["node"]).toBe(enginesOf(readJson("package.json"))?.["node"]);
+  });
+});
+
+describe("検査が空振りで通らない（境界）", () => {
+  /**
+   * **両方に `engines` が無ければ、この検査は「一致」と言えてしまう。**
+   * `undefined === undefined` は通るので、宣言そのものが消えたときに気づけない。
+   * だから「一致していること」とは別に「書いてあること」を確かめる。
+   */
+  it("`package.json` に `engines.node` が書いてある", () => {
+    expect(enginesOf(readJson("package.json"))?.["node"]).toBeTypeOf("string");
+  });
+
+  it("lockfile のルート項目に `engines.node` が書いてある", () => {
+    expect(enginesOf(lockRoot())?.["node"]).toBeTypeOf("string");
+  });
+
+  it("空の `engines` を一致とみなさない（境界: 空）", () => {
+    // 上の2件が見ている「書いてあること」を、比較関数の側からも押さえる
+    expect(enginesOf({ engines: {} })?.["node"]).toBeUndefined();
+  });
+
+  it("`engines` が無い場合は `undefined` を返す（境界: 0件）", () => {
+    expect(enginesOf({})).toBeUndefined();
+  });
+
+  it("`engines` がオブジェクトでなければ読まない（境界: 型違い）", () => {
+    expect(enginesOf({ engines: ">=22" })).toBeUndefined();
+    expect(enginesOf({ engines: [">=22"] })).toBeUndefined();
+    expect(enginesOf({ engines: null })).toBeUndefined();
+  });
+});
+
+describe("見るのはルート項目だけ（境界）", () => {
+  it("lockfile のルート項目が引けている（空のオブジェクトで素通ししない）", () => {
+    // `lockRoot` が `?? {}` で空を返していると、上の検査が「両方 undefined」で通る
+    expect(Object.keys(lockRoot()).length).toBeGreaterThan(0);
+    expect(lockRoot()["name"]).toBe(readJson("package.json")["name"]);
+  });
+
+  it("**依存パッケージの `engines` は突き合わせない**", () => {
+    // 依存側は各パッケージ自身の宣言で、こちらの `package.json` と一致するはずがない。
+    // 一律に比べると直しようのない検査になる（Issue のスコープ外）
+    const packages = readJson("package-lock.json")["packages"] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const dependencies = Object.entries(packages).filter(([path]) => path !== "");
+    const declared = dependencies
+      .map(([, entry]) => enginesOf(entry)?.["node"])
+      .filter((node): node is string => node !== undefined);
+
+    // 依存側にも `engines.node` はあり、こちらの宣言と違う値が含まれている。
+    // 「全部一致」を求めていたら通らない状態であることを示す
+    expect(declared).not.toHaveLength(0);
+    expect(declared.some((node) => node !== enginesOf(readJson("package.json"))?.["node"])).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## 概要

`package-lock.json` のルート項目の `engines.node` を `package.json` に合わせた（`>=22` → `>=22.12.0`）。Issue のとおり `npm install --package-lock-only --ignore-scripts` を走らせただけで、**差分は1行**。依存のバージョンは1つも動いていない。

```diff
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12.0"
       }
```

あわせて、次に食い違ったときに `npm run check` で落ちるよう検査を足した。

Closes #83

### 検査の作り方について

**`npm` を実行して差分の有無を見る形にしていない。** Issue の「`npm` の実行までは要らない」に沿ったもので、理由は結果がネットワークと npm の版に左右されるため。固定したいのは「2つのファイルの宣言が一致していること」で、これが一致していれば npm が埋める差はもう無い。

**見るのはルート項目（`packages[""]`）だけ。** 依存パッケージ側の `engines` は各パッケージ自身の宣言で、こちらの `package.json` と一致するはずがない。`tests/docs/license.test.ts` が `license` を同じ理由でルート項目に絞っているので、その形に揃えた。

## 受け入れ条件

- [x] `package-lock.json` のルート項目の `engines.node` が `package.json` と一致している
      → 実行結果:
      ```console
      $ node -p "require('./package.json').engines.node"
      >=22.12.0
      $ node -p "require('./package-lock.json').packages[''].engines.node"
      >=22.12.0
      ```
      → 走らせ直しても差分が増えないことも確認しました（`npm install --package-lock-only --ignore-scripts` を2回実行しても、`git diff --stat` は `1 file changed, 1 insertion(+), 1 deletion(-)` のまま）

- [x] `npm install --package-lock-only` を走らせても差分が出ないことを確認したテストがある
      （2つのファイルを読んで突き合わせる形でよい。`npm` の実行までは要らない）
      → `tests/package-engines.test.ts`（9件）。中心は「**ルート項目の `engines` が丸ごと一致する**」と「`engines.node` が一致する」の2件で、残る7件は下記の境界

- [x] `npm ci` が通る
      → 実行結果:
      ```console
      $ npm ci
      added 20 packages, and audited 21 packages in 1s
      20 packages are looking for funding
        run `npm fund` for details
      found 0 vulnerabilities
      $ echo $?
      0
      ```
      → CI でも `npm ci` を通っています

### 固定した境界（Issue の指定）

| 境界 | テスト |
| --- | --- |
| **ルート項目（`packages[""]`）だけを見る** | 「**依存パッケージの `engines` は突き合わせない**」— 依存側にも `engines.node` があり、こちらの宣言と違う値が含まれていることを明示している（「全部一致」を求めていたら通らない状態） |
| **`engines` が両方に無い場合に、検査が空振りで通らない** | 「`package.json` に `engines.node` が書いてある」「lockfile のルート項目に `engines.node` が書いてある」の2件。`undefined === undefined` は通ってしまうので、一致とは別に「書いてあること」を確かめる |
| 空の `engines` | 「空の `engines` を一致とみなさない（境界: 空）」 |
| `engines` が無い | 「`engines` が無い場合は `undefined` を返す（境界: 0件）」 |
| `engines` が型違い | 「`engines` がオブジェクトでなければ読まない」（文字列 / 配列 / `null`） |
| ルート項目が引けていない | 「lockfile のルート項目が引けている（空のオブジェクトで素通ししない）」— `?? {}` が空を返していると上の検査が「両方 undefined」で通る |

## mutation test

**`src/` を変更していないため、`CLAUDE.md` の定める mutation test は未実施です**（壊せる実装が無い）。

代わりに、**テストが空振りしていないことを検査対象のデータ側で確かめました。** 実装を壊す代わりに `package.json` / `package-lock.json` を「もっともらしく間違った形」に書き換え、落ちることを確認しています。

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 修正前の状態（lockfile だけ `>=22` に戻す） | 2件 |
| **両方から `engines` を消す**（空振りの検出） | 2件 |
| `package.json` にだけ `engines.npm` を足す（`node` だけ見る検査では気づけない形） | 1件 |

3つめは「丸ごと一致」の検査だけが落ち、「`node` が一致」は通ります。両方を持っている理由がこれで、片方だけだと後から `engines` にキーが増えたときに同じ食い違いが再発します。

すべて元に戻し、`npm run check` が全件通ることを確認しました（**62 files / 1711 tests**、+9件）。

**限界:** これが答えるのは「宣言の食い違いをテストが見張っているか」だけで、`>=22.12.0` という値そのものが妥当かには答えません。値の見直しは Issue のスコープ外です。

## スタック

- base: `main`
- 他の open PR（#92 / #93 / #94）とファイルは重なりません（`package-lock.json` と新規テスト1件のみ）

## 依存の追加

なし。依存のバージョンも変わっていません（差分は `engines` の1行だけ）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_