### PR TITLE
[E3-6][P3] 読み込み時の検証が書き込み時より緩く、壊れた行の扱いも決まっていない

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -335,9 +335,18 @@ async function confirmOnStdin(question: string): Promise<boolean> {
  * 保存先の決定と現在時刻・採番の取得はここでだけ行う。`run` と各コマンドは注入された
  * ものしか使わないので、テストは一時ディレクトリと固定した時刻で完全に再現できる。
  */
-function buildRuntime(): Pick<CliDeps, "commands" | "noticesBeforeRun"> {
+function buildRuntime(err: (line: string) => void): Pick<CliDeps, "commands" | "noticesBeforeRun"> {
+  const storePath = resolveStorePath(process.env, homedir());
   const deps = {
-    store: createJsonlStore(resolveStorePath(process.env, homedir())),
+    // **読めない行を飛ばしたら stderr に件数を出す（#85・案2）。** 黙って飛ばすと、
+    // 手で編集して壊した記録が消えたことに気づけない。行そのものは消していないので、
+    // そのことも文言に残す（設定ファイルの「消しません」と同じ扱い）
+    store: createJsonlStore(storePath, undefined, (count, filePath) => {
+      err(
+        `記録のファイルに読めない行が ${String(count)} 行あり、飛ばしました: ${filePath}。` +
+          `行そのものは消していません`,
+      );
+    }),
     now: () => new Date(),
     newId: randomId,
   };
@@ -464,11 +473,12 @@ if (invokedAsEntryPoint()) {
     }
   };
 
+  const errWriter = createLineWriter(process.stderr, reportWriteError);
   const code = await run(process.argv.slice(2), {
     out: createLineWriter(process.stdout, reportWriteError),
-    err: createLineWriter(process.stderr, reportWriteError),
+    err: errWriter,
     version: readVersion,
-    ...buildRuntime(),
+    ...buildRuntime(errWriter),
   });
 
   // `EPIPE` は終了コードを変えない。読み手が先に終わるのは正常な操作であり、

--- a/src/domain/entry.ts
+++ b/src/domain/entry.ts
@@ -71,6 +71,21 @@ function isRealCalendarDate(iso: string): boolean {
   );
 }
 
+/**
+ * 保存されている日時の文字列が、書き込み時（`createEntry`）と同じ基準で妥当か（#85）。
+ *
+ * **規則はここに1つだけ置き、store が読み込み時に呼ぶ。** 以前は store 側が
+ * `Date.parse` だけで判定しており、`tock start --at` なら弾かれる値（タイムゾーンなし・
+ * 実在しない日・範囲外の時刻）が手で編集したファイルからは通っていた。判定を
+ * 複製せず同じ部品（`ISO_8601_WITH_ZONE` / `isRealCalendarDate`）を使うので、
+ * 片方だけ直して食い違うことがない。
+ */
+export function isStoredTimestamp(value: string): boolean {
+  return (
+    ISO_8601_WITH_ZONE.test(value) && !Number.isNaN(Date.parse(value)) && isRealCalendarDate(value)
+  );
+}
+
 /** Date または ISO 8601 文字列を、UTC 正規形の ISO 8601 文字列に揃える。 */
 function toIsoString(value: Date | string, label: string): string {
   if (value instanceof Date) {

--- a/src/store/jsonl-store.ts
+++ b/src/store/jsonl-store.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import type { Entry } from "../domain/entry.js";
+import { type Entry, isStoredTimestamp } from "../domain/entry.js";
 import { overlapsPeriod } from "../domain/period.js";
 import { DEFAULT_LOCK_OPTIONS, type LockOptions, withLock } from "./lock.js";
 import type { Store, StoreRange } from "./store.js";
@@ -96,19 +96,18 @@ function asNonEmptyString(value: unknown): string | undefined {
 }
 
 /**
- * 日時として読めるかを確かめる。
+ * 日時として読めるかを確かめる。**基準は書き込み時（`createEntry`）と同じ**（#85）。
  *
- * **`createEntry` より基準は緩い。** あちらはタイムゾーン付き ISO 8601 であることと、
- * 暦としてその日が実在することまで見るが、ここは `Date.parse` が通るかだけを見る。
- * つまり手で編集してタイムゾーンなしの日時を書いた行は、書き込み時より甘い基準で
- * 通過する。
+ * 以前は `Date.parse` が通るかだけを見ており、`tock start --at` なら弾かれる値
+ * （タイムゾーンなし・実在しない日・`T24:00:00`）が手で編集したファイルからは
+ * 通っていた。規則そのものは `domain/entry.ts` の `isStoredTimestamp` に1つだけ置き、
+ * ここは呼ぶだけにする——判定を複製すると片方だけ直したときに食い違う。
  *
- * ここでの役目は「壊れて読めない行を落とす」ことに限る。**書き込み時と同じ厳密さに
- * 揃えるかは #85 の担当範囲**（#10 で形のバージョンは入れたが、値の妥当性は別の話）。
+ * 値は正規化せずそのまま返す。読み込みは記録を書き換えない。
  */
 function asTimestamp(value: unknown): string | undefined {
   const text = asNonEmptyString(value);
-  if (text === undefined || Number.isNaN(Date.parse(text))) {
+  if (text === undefined || !isStoredTimestamp(text)) {
     return undefined;
   }
 
@@ -228,30 +227,43 @@ function parseLine(line: string, filePath: string): StoreRecord | undefined {
 /**
  * ファイルの内容を JSONL として読み、現在の状態に畳み込む。
  *
- * **読めない行は飛ばす。** 1 行の破損で全記録が読めなくなるほうが損失が大きい。
- * 飛ばしたことを利用者に伝えるかどうかは #85 の担当範囲（いまは黙って飛ばす）。
+ * **読めない行は飛ばすが、飛ばした行数を数えて返す（#85・案2）。** 1 行の破損で
+ * 全記録が読めなくなるほうが損失は大きい。しかし黙って飛ばすと、手で編集して壊した
+ * 記録が消えたことに利用者が気づけない。件数の通知は呼び出し側（`onSkippedLines`）が
+ * 受け持つ。
+ *
+ * **空行は「壊れた行」に数えない。** 末尾の改行で必ず1つ空要素ができるため、
+ * 数えると壊れていないファイルでも誤報になる。
  *
  * **ただし「知らない新しいバージョン」は飛ばさずエラーになる**（`assertReadableVersion`）。
  * そちらは壊れた行ではなく、新しい版が正しく書いた記録だから。
  *
  * 追加順を保つため Map を使う。更新は元の位置に留まる。
  */
-async function readState(filePath: string): Promise<Map<string, Entry>> {
+async function readState(
+  filePath: string,
+): Promise<{ state: Map<string, Entry>; skippedLines: number }> {
   let raw: string;
   try {
     raw = await readFile(filePath, "utf8");
   } catch (error) {
     if (isNotFound(error)) {
       // ファイルが無い状態は「まだ記録がない」と同じ。読み出しでは作らない
-      return new Map();
+      return { state: new Map(), skippedLines: 0 };
     }
     throw error;
   }
 
+  let skippedLines = 0;
   const state = new Map<string, Entry>();
   for (const line of raw.split("\n")) {
+    if (line.trim() === "") {
+      continue;
+    }
+
     const record = parseLine(line, filePath);
     if (record === undefined) {
+      skippedLines += 1;
       continue;
     }
 
@@ -262,7 +274,7 @@ async function readState(filePath: string): Promise<Map<string, Entry>> {
     }
   }
 
-  return state;
+  return { state, skippedLines };
 }
 
 function isNotFound(error: unknown): boolean {
@@ -285,11 +297,40 @@ async function appendRecord(filePath: string, record: StoreRecord): Promise<void
  * 実行中エントリが2つできて `stop` できなくなる。**読み出しはロックを取らない**——
  * 追記は行単位で守られているので、読み手は壊れた状態を見ない。
  */
+/**
+ * 読めない行を飛ばしたときの通知。`(飛ばした行数, ファイルのパス)` を受け取る。
+ *
+ * 出力先はここで決めない（stderr へ書くのは CLI の縁の責務）。省略すれば従来どおり
+ * 黙って飛ばす——テストの多くは壊れたファイルを扱わないので、必須にしない。
+ */
+export type OnSkippedLines = (count: number, filePath: string) => void;
+
 export function createJsonlStore(
   filePath: string,
   lock: LockOptions = DEFAULT_LOCK_OPTIONS,
+  onSkippedLines?: OnSkippedLines,
 ): Store {
   const lockPath = `${filePath}.lock`;
+
+  /**
+   * 最後に通知した件数。**同じ件数は繰り返し通知しない。**
+   *
+   * 1つのコマンドの中で読み出しは複数回走る（`stop` は判断のために読み、書いてから
+   * また読む）。そのたびに通知すると、同じ壊れた行が1回の操作で何度も報告される。
+   * 件数が変わったとき（読んでいる間にさらに壊れたとき）だけ改めて通知する。
+   */
+  let reportedSkips = 0;
+
+  /** 読み出して、飛ばした行があれば1度だけ通知し、状態を返す。 */
+  const reading = async (): Promise<Map<string, Entry>> => {
+    const { state, skippedLines } = await readState(filePath);
+    if (skippedLines > 0 && skippedLines !== reportedSkips) {
+      reportedSkips = skippedLines;
+      onSkippedLines?.(skippedLines, filePath);
+    }
+
+    return state;
+  };
 
   /**
    * いま自分がロックを握っているか。
@@ -313,7 +354,7 @@ export function createJsonlStore(
   /** 読み出してから書くまでを1つにする。個々の書き込み操作が使う。 */
   const writing = async (write: (state: Map<string, Entry>) => Promise<void>): Promise<void> =>
     exclusively(async () => {
-      await write(await readState(filePath));
+      await write(await reading());
     });
 
   return {
@@ -354,7 +395,7 @@ export function createJsonlStore(
     async listAll(): Promise<Entry[]> {
       // 畳み込みの結果をそのまま返す。**絞り込みが無いので範囲の検査も要らない**
       // （`listByRange` が持つ `NaN` や `end < start` の検査は、範囲があってこそのもの）
-      return [...(await readState(filePath)).values()];
+      return [...(await reading()).values()];
     },
 
     async listByRange(range: StoreRange): Promise<Entry[]> {
@@ -367,7 +408,7 @@ export function createJsonlStore(
         throw new Error("範囲の end が start より前です");
       }
 
-      const state = await readState(filePath);
+      const state = await reading();
 
       // 重なりの判定は domain に1つだけ置く（`overlapsPeriod`）。以前はここに同じ規則を
       // 書き写していて、実行中エントリの下限を落とすバグを出している（#40）。
@@ -376,7 +417,7 @@ export function createJsonlStore(
     },
 
     async findRunning(): Promise<Entry | undefined> {
-      const state = await readState(filePath);
+      const state = await reading();
 
       let latest: Entry | undefined;
       for (const entry of state.values()) {

--- a/tests/store/read-validation.test.ts
+++ b/tests/store/read-validation.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+
+/**
+ * 読み込み時の検証を書き込み時と同じ厳密さに揃える（#85）。
+ *
+ * `tock start --at` 経由なら `createEntry` が弾く値（タイムゾーンなし・実在しない日・
+ * 範囲外の時刻）が、手で編集したファイルからは `Date.parse` の緩い基準で通っていた。
+ * `createEntry` を通っていない値が domain に流れる経路を塞ぐ。
+ *
+ * **基準を満たさない行は飛ばすが、何行飛ばしたかを通知する（案2。#85 で決定済み）。**
+ * 1行の破損で全記録が読めなくなることは避けつつ、手で編集して壊した記録が
+ * 黙って消えることもなくす。
+ */
+
+let dir = "";
+let file = "";
+/** 飛ばした行数の通知。`(件数, ファイルパス)` の組で記録する。 */
+let skipped: [number, string][] = [];
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-read-validation-"));
+  file = join(dir, "entries.jsonl");
+  skipped = [];
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function store() {
+  return createJsonlStore(file, undefined, (count, filePath) => {
+    skipped.push([count, filePath]);
+  });
+}
+
+/** 行の並びをそのままファイルに書く。 */
+async function writeLines(...lines: string[]): Promise<void> {
+  await writeFile(file, lines.map((line) => `${line}\n`).join(""), "utf8");
+}
+
+/** `append` の1行を組み立てる。`start` / `end` は生の文字列のまま埋める。 */
+function appendLine(id: string, start: string, end?: string): string {
+  const entry = { id, start, ...(end === undefined ? {} : { end }), tags: ["work"] };
+
+  return JSON.stringify({ v: 1, op: "append", entry });
+}
+
+/** 妥当な行（比較用）。 */
+const VALID = appendLine("ok", "2026-08-12T09:00:00.000Z", "2026-08-12T10:00:00.000Z");
+
+describe("書き込み時と同じ基準で弾く（DoD）", () => {
+  it("**タイムゾーンなしの開始時刻を持つ行は飛ばす**", async () => {
+    // `tock start --at` 経由なら createEntry が「タイムゾーン付きの ISO 8601 で」と弾く値
+    await writeLines(appendLine("zoneless", "2026-08-12T10:00:00"), VALID);
+
+    const entries = await store().listAll();
+
+    expect(entries.map((entry) => entry.id)).toEqual(["ok"]);
+  });
+
+  it("**暦として存在しない日（2026-02-30）を持つ行は飛ばす**", async () => {
+    // Date.parse は 3/2 に繰り上げて通してしまう値
+    await writeLines(appendLine("impossible", "2026-02-30T10:00:00.000Z"), VALID);
+
+    expect((await store().listAll()).map((entry) => entry.id)).toEqual(["ok"]);
+  });
+
+  it("**時刻が範囲外（T24:00:00）の行は飛ばす**", async () => {
+    // ISO では日末を指すが、createEntry は「打ち間違いが別の日の記録になる」ので弾く
+    await writeLines(appendLine("overflow", "2026-08-12T24:00:00.000Z"), VALID);
+
+    expect((await store().listAll()).map((entry) => entry.id)).toEqual(["ok"]);
+  });
+
+  it("`end` にも同じ基準が当たる", async () => {
+    await writeLines(appendLine("bad-end", "2026-08-12T09:00:00.000Z", "2026-08-12T10:00:00"));
+
+    expect(await store().listAll()).toEqual([]);
+  });
+
+  it("**実行中エントリ（`end` なし）でも同じ基準が当たる**（境界: 終端のないデータ）", async () => {
+    await writeLines(
+      appendLine("running-broken", "2026-02-30T10:00:00.000Z"),
+      appendLine("running-ok", "2026-08-12T09:00:00.000Z"),
+    );
+
+    const running = await store().findRunning();
+
+    expect(running?.id).toBe("running-ok");
+    expect(skipped.at(-1)?.[0]).toBe(1);
+  });
+
+  it("`update` の行にも同じ基準が当たる", async () => {
+    const update = JSON.stringify({
+      v: 1,
+      op: "update",
+      entry: { id: "ok", start: "2026-08-12T09:00:00", tags: ["work"] },
+    });
+    await writeLines(VALID, update);
+
+    // 壊れた update は飛ばされ、元の append の状態が残る
+    const [entry] = await store().listAll();
+    expect(entry?.end).toBe("2026-08-12T10:00:00.000Z");
+  });
+
+  it("書き込み時に通る値は読み込みでも通る（オフセット付き・ミリ秒付き）", async () => {
+    // createEntry が受け付ける形を読み込みが弾いたら、揃えたことにならない
+    await writeLines(
+      appendLine("offset", "2026-08-12T10:00:00+09:00"),
+      appendLine("millis", "2026-08-11T09:00:00.123Z", "2026-08-11T10:00:00.123Z"),
+    );
+
+    expect((await store().listAll()).map((entry) => entry.id)).toEqual(["offset", "millis"]);
+    expect(skipped).toEqual([]);
+  });
+});
+
+describe("飛ばした行数を通知する（DoD・案2）", () => {
+  it("**1行だけ基準を満たさない場合、他の行は読めて、件数1が通知される**", async () => {
+    await writeLines(VALID, appendLine("zoneless", "2026-08-12T10:00:00"));
+
+    const entries = await store().listAll();
+
+    expect(entries.map((entry) => entry.id)).toEqual(["ok"]);
+    expect(skipped).toEqual([[1, file]]);
+  });
+
+  it("壊れた行が複数あれば、その件数が通知される", async () => {
+    await writeLines(
+      "壊れた JSON",
+      appendLine("zoneless", "2026-08-12T10:00:00"),
+      VALID,
+      '{"v":1,"op":"append","entry":{"id":"x","start":""}}',
+    );
+
+    await store().listAll();
+
+    expect(skipped).toEqual([[3, file]]);
+  });
+
+  it("**基準を満たす行しか無ければ通知しない**（余計な警告を出さない）", async () => {
+    await writeLines(VALID);
+
+    await store().listAll();
+
+    expect(skipped).toEqual([]);
+  });
+
+  it("空ファイルでは通知しない（境界: 空）", async () => {
+    await writeFile(file, "", "utf8");
+
+    expect(await store().listAll()).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("**空行は「壊れた行」に数えない**（末尾の改行で1件出たら誤報）", async () => {
+    await writeFile(file, `${VALID}\n\n\n`, "utf8");
+
+    await store().listAll();
+
+    expect(skipped).toEqual([]);
+  });
+
+  it("ファイルが無ければ通知しない（境界: 0件）", async () => {
+    expect(await store().listAll()).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("全行が基準を満たさない場合、空の一覧と全行ぶんの件数になる", async () => {
+    await writeLines(
+      appendLine("a", "2026-02-30T10:00:00.000Z"),
+      appendLine("b", "2026-08-12T24:00:00.000Z"),
+    );
+
+    expect(await store().listAll()).toEqual([]);
+    expect(skipped).toEqual([[2, file]]);
+  });
+
+  it("**同じ件数は繰り返し通知しない**（1コマンド中に複数回読むため）", async () => {
+    // stop は transaction の中で読み、書いてからまた読む。そのたびに同じ警告が
+    // 並ぶと、1回の操作で同じ行が何度も報告される
+    await writeLines(VALID, appendLine("zoneless", "2026-08-12T10:00:00"));
+    const shared = store();
+
+    await shared.listAll();
+    await shared.findRunning();
+    await shared.listByRange({
+      start: new Date("2026-08-12T00:00:00Z"),
+      end: new Date("2026-08-13T00:00:00Z"),
+    });
+
+    expect(skipped).toEqual([[1, file]]);
+  });
+
+  it("通知を渡さなくても読み込みは動く（従来どおり黙って飛ばす）", async () => {
+    await writeLines(appendLine("zoneless", "2026-08-12T10:00:00"), VALID);
+
+    const silent = createJsonlStore(file);
+
+    expect((await silent.listAll()).map((entry) => entry.id)).toEqual(["ok"]);
+  });
+});


### PR DESCRIPTION
## 概要

読み込み時の検証を書き込み時（`createEntry`）と同じ厳密さに揃え、基準を満たさない行を見つけたときは**飛ばしたうえで件数を stderr に通知する**ようにした。

Closes #85

### 検証の規則は1箇所（Issue の技術制約どおり）

規則は `domain/entry.ts` の `isStoredTimestamp` に置き、store（`jsonl-store.ts` の `asTimestamp`）は呼ぶだけにした。中身は `createEntry` が使うのと**同じ部品**（`ISO_8601_WITH_ZONE` / `isRealCalendarDate`）なので、片方だけ直して食い違うことがない。値は正規化せずそのまま返す——読み込みは記録を書き換えない。

### 壊れた行の扱いは案2（[#85 のコメント](https://github.com/okrago10/loop-demo/issues/85#issuecomment-5302875158)で決定済み）

**飛ばすが、何行飛ばしたかを stderr に出す。**

- 通知は `createJsonlStore` の第3引数（コールバック）で受け取り、stderr へ書くのは `cli.ts` の縁で行う。store が出力先を決めない
- **同じ件数は繰り返し通知しない。** 1つのコマンドの中で読み出しは複数回走る（`stop` は判断のために読み、書いてからまた読む）ので、そのたびに出すと同じ壊れた行が1回の操作で何度も報告される
- **空行は「壊れた行」に数えない。** 末尾の改行で必ず1つ空要素ができるため、数えると壊れていないファイルでも誤報になる
- 「行そのものは消していません」を文言に含める（設定ファイルの「消しません」と同じ扱い）

「知らない新しいバージョンはエラー」（#10）はそのまま。壊れた行と、新しい版が正しく書いた記録は別物という区別も変えていない。

## 受け入れ条件

- [x] タイムゾーンなしの開始時刻を持つ行が、書き込み時と同じ基準で扱われるテストがある
      → `tests/store/read-validation.test.ts`「**タイムゾーンなしの開始時刻を持つ行は飛ばす**」。`end` 側と `update` の行にも同じ基準が当たることも固定
      → 実行結果（Issue の再現手順そのまま）:
      ```console
      $ printf '{"v":1,"op":"append","entry":{"id":"x","start":"2026-08-12T10:00:00","tags":["work"]}}\n' > "$D/entries.jsonl"
      $ tock log
      記録のファイルに読めない行が 1 行あり、飛ばしました: /tmp/…/entries.jsonl。行そのものは消していません
      y  2026-08-12  09:00-10:00  1h  正しい記録 #work
      $ echo $?
      0
      ```
      （警告は stderr、一覧は stdout。妥当な行 `y` は読めている）

- [x] 暦として存在しない日（`2026-02-30`）を持つ行のテストがある
      → 同「**暦として存在しない日（2026-02-30）を持つ行は飛ばす**」。`Date.parse` は 3/2 に繰り上げて通してしまう値

- [x] 時刻が範囲外（`T24:00:00`）の行のテストがある
      → 同「**時刻が範囲外（T24:00:00）の行は飛ばす**」
      → 実在しない日・`T24:00:00` を追記した実行結果:
      ```console
      $ tock log
      記録のファイルに読めない行が 3 行あり、飛ばしました: /tmp/…/entries.jsonl。行そのものは消していません
      y  2026-08-12  09:00-10:00  1h  正しい記録 #work
      $ wc -l < "$D/entries.jsonl"
      4        ← ファイルの行は消えていない
      ```

- [x] 基準を満たさない行を見つけたときの扱い（飛ばす / 報告する）が決まっていて、そのテストがある
      → **案2 で決定済み**。describe「飛ばした行数を通知する（DoD・案2）」8件（1行だけ不正 / 複数 / 全行不正 / **正常のみなら通知しない** / 空ファイル / 空行 / ファイルなし / **同じ件数は繰り返さない** / 通知なしでも動く）
      → 壊れた行が無い場合の実行結果:
      ```console
      $ tock log 2>err.txt
      1c06c6d8  2026-08-15  16:42-実行中  0s  設計
      $ cat err.txt
      （空）
      ```

- [x] 実行中エントリ（`end` なし）でも同じ基準が当たるテストがある
      → 同「**実行中エントリ（`end` なし）でも同じ基準が当たる**（境界: 終端のないデータ）」。壊れた実行中エントリは飛ばされ、妥当な実行中エントリが `findRunning` で返る

`npm run check` green（**62 files / 1718 tests**、+16件）。

## mutation test

**5箇所すべてでテストが落ちた。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| 検証を `Date.parse` だけに戻す（元の不具合そのもの） | 11件 |
| `isStoredTimestamp` が暦の実在を見ない | 3件 |
| 飛ばしても数えない（常に 0） | 5件 |
| **空行も「壊れた行」に数える** | 9件 |
| 同じ件数でも毎回通知する（dedupe を外す） | 2件* |

*表の5つめは新規テスト1件 + 既存テスト1件が落ちた（正確には 1 件と報告された実行もある。新規の「同じ件数は繰り返し通知しない」が確実に捕まえている）。

4つめが9件と多いのは、**既存のテストの多くが末尾改行付きのファイルを書いている**ため——空行を数える実装だと、壊れていないファイルへの読み出しで誤報が出ることを広く検出した。

## テストを書いた順序について

DoD をテストへ落としてから実装し、**実装前に11件が落ちることを実行して確認した**（5件は既存挙動で最初から通る）。

## スタック

- base: `main`

**open な PR（#92 / #93 / #94 / #95 / #97）とはファイルが重なりません。** 触ったのは `src/domain/entry.ts`（関数1つ追加）・`src/store/jsonl-store.ts`・`src/cli.ts`（`buildRuntime` の引数1つと store 構築）・新規テスト1本。#97 も `entry.ts` / `jsonl-store.ts` は触っていません。`src/cli.ts` は #90/#91 由来の現 `main` の形が前提ですが、open PR はどれも `cli.ts` を触っていないので衝突しません。

## 依存の追加

なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_