### PR TITLE
[E7-3][P3] readme.test.ts が src/cli.ts をソースの文字列として突き合わせている

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,12 @@ import { createInterface } from "node:readline/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import type { CommandDeps } from "./commands/args.js";
 import { createConfigCommand } from "./commands/config.js";
 import { createEditCommand } from "./commands/edit.js";
 import { createExportCommand } from "./commands/export.js";
 import { createLogCommand } from "./commands/log.js";
-import { createRmCommand } from "./commands/rm.js";
+import { type Confirm, createRmCommand } from "./commands/rm.js";
 import { createStartCommand } from "./commands/start.js";
 import { createStatusCommand } from "./commands/status.js";
 import { createStopCommand } from "./commands/stop.js";
@@ -18,6 +19,7 @@ import { createWeekCommand } from "./commands/week.js";
 import { type CommandUsage, formatCommandHelp } from "./format/help.js";
 import { randomId } from "./id.js";
 import {
+  type ConfigStore,
   createJsonConfigStore,
   type LoadConfig,
   loadEffectiveConfig,
@@ -330,6 +332,53 @@ async function confirmOnStdin(question: string): Promise<boolean> {
 }
 
 /**
+ * サブコマンドの組み立てに要るもの一式。**すべて引数で受け取る。**
+ *
+ * 保存先も端末も確認の取り方もここに現れるので、`buildCommands` 自身は
+ * 実行環境（`process.env` / `homedir()` / `process.stdout` / 標準入力）を読まない。
+ */
+export interface CommandParts {
+  readonly deps: CommandDeps;
+  readonly configStore: ConfigStore;
+  readonly loadConfig: LoadConfig;
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly terminal: Terminal;
+  readonly confirm: Confirm;
+}
+
+/**
+ * 登録するサブコマンドを組み立てる。**この一覧が `tock` の全機能。**
+ *
+ * **`buildRuntime` から切り出して公開している。** `buildRuntime` は保存先を
+ * `resolveStorePath(process.env, homedir())` で決めるので、テストから呼ぶと実ユーザーの
+ * `~/.tock` を指してしまう（`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を
+ * 読み書きしないこと」）。行き先を引数にしたこちらなら、一時ディレクトリを渡して
+ * 同じ一覧を得られる。
+ *
+ * README の検証（`tests/docs/readme.test.ts`）は、テスト側で別に組み立てた一式で
+ * 実行例を走らせる。その一式と本物が食い違っていないかを、この関数を呼んで突き合わせる。
+ * **以前はソースを文字列として読んでいたため、書き方を変えただけで落ちた**（#102）。
+ */
+export function buildCommands(parts: CommandParts): readonly Command[] {
+  const { deps, configStore, loadConfig, env, terminal, confirm } = parts;
+
+  return [
+    createStartCommand(deps),
+    createStopCommand(deps, loadConfig),
+    createStatusCommand(deps),
+    createSwitchCommand(deps),
+    createTodayCommand(deps, loadConfig, terminal),
+    createSummaryCommand(deps, loadConfig, terminal),
+    createLogCommand(deps, loadConfig),
+    createWeekCommand(deps, loadConfig, terminal),
+    createEditCommand(deps),
+    createRmCommand(deps, confirm),
+    createExportCommand(deps, loadConfig),
+    createConfigCommand(configStore, env),
+  ];
+}
+
+/**
  * 実際に使うサブコマンドと、実行前の警告を組み立てる。
  *
  * 保存先の決定と現在時刻・採番の取得はここでだけ行う。`run` と各コマンドは注入された
@@ -346,23 +395,16 @@ function buildRuntime(): Pick<CliDeps, "commands" | "noticesBeforeRun"> {
   // 設定を使わない打刻まで設定ファイルの状態に引きずられる
   const configStore = createJsonConfigStore(resolveConfigPath(process.env, homedir()));
   const loadConfig = () => loadEffectiveConfig(configStore, process.env);
-  const terminal = resolveTerminal(process.stdout);
 
   return {
-    commands: [
-      createStartCommand(deps),
-      createStopCommand(deps, loadConfig),
-      createStatusCommand(deps),
-      createSwitchCommand(deps),
-      createTodayCommand(deps, loadConfig, terminal),
-      createSummaryCommand(deps, loadConfig, terminal),
-      createLogCommand(deps, loadConfig),
-      createWeekCommand(deps, loadConfig, terminal),
-      createEditCommand(deps),
-      createRmCommand(deps, confirmOnStdin),
-      createExportCommand(deps, loadConfig),
-      createConfigCommand(configStore, process.env),
-    ],
+    commands: buildCommands({
+      deps,
+      configStore,
+      loadConfig,
+      env: process.env,
+      terminal: resolveTerminal(process.stdout),
+      confirm: confirmOnStdin,
+    }),
     noticesBeforeRun: () => overrunNotices(deps.store, loadConfig, deps.now()),
   };
 }

--- a/tests/docs/readme.test.ts
+++ b/tests/docs/readme.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { type Command, EXIT_OK, run, UserError } from "../../src/cli.js";
+import { buildCommands, type Command, EXIT_OK, run, UserError } from "../../src/cli.js";
 import { createConfigCommand } from "../../src/commands/config.js";
 import { createEditCommand } from "../../src/commands/edit.js";
 import { createExportCommand } from "../../src/commands/export.js";
@@ -17,6 +17,7 @@ import { createSummaryCommand, createTodayCommand } from "../../src/commands/sum
 import { createSwitchCommand } from "../../src/commands/switch.js";
 import { createWeekCommand } from "../../src/commands/week.js";
 import { CONFIG_KEYS } from "../../src/domain/config.js";
+import { PLAIN_TERMINAL } from "../../src/format/terminal.js";
 import { parsePeriodExpression } from "../../src/domain/period-expression.js";
 import { createJsonConfigStore, loadEffectiveConfig } from "../../src/store/config-store.js";
 import { createJsonlStore } from "../../src/store/jsonl-store.js";
@@ -94,21 +95,64 @@ function steppingClock(base: Date): () => Date {
   };
 }
 
-/** `src/cli.ts` の `buildCommands` が組み立てる 12 個に対応する生成関数。 */
-const FACTORIES = [
-  "createStartCommand",
-  "createStopCommand",
-  "createStatusCommand",
-  "createSwitchCommand",
-  "createTodayCommand",
-  "createSummaryCommand",
-  "createLogCommand",
-  "createWeekCommand",
-  "createEditCommand",
-  "createRmCommand",
-  "createExportCommand",
-  "createConfigCommand",
-];
+/**
+ * コマンド一覧の突き合わせ。**`tock <name>` の名前だけを見る。**
+ *
+ * 以前はここで `src/cli.ts` をソースの文字列として読み、生成関数の名前
+ * （`create*Command`）を正規表現で拾っていた。**一覧の中身が正しくても書き方を
+ * 変えると落ちる**ので、`buildCommands` の改名と戻り値の形の変更だけで実際に落ちた（#102）。
+ *
+ * 名前の並びなら、関数名・戻り値の形・整形のどれにも現れない。
+ */
+function commandNames(commands: readonly Command[]): string[] {
+  return commands.map((command) => command.name).toSorted();
+}
+
+/**
+ * 本物（`src/cli.ts`）とこのテストが組み立てた一覧が一致することを主張する。
+ *
+ * **空同士で素通しさせない。** 一覧の取り出し方を間違えて両方が空になっても
+ * 突き合わせ自体は通ってしまい、検査が何も見ていない状態に気づけない。
+ */
+function expectSameCommands(real: readonly Command[], registry: readonly Command[]): void {
+  expect(commandNames(real)).not.toEqual([]);
+  expect(commandNames(real)).toEqual(commandNames(registry));
+}
+
+/**
+ * `src/cli.ts` が実際に組み立てる一覧を、一時ディレクトリの上で得る。
+ *
+ * **`buildRuntime` は呼べない。** 内部で `resolveStorePath(process.env, homedir())` を
+ * 呼ぶので、テストから呼ぶと実ユーザーの `~/.tock` を指すパスが組み立てられる
+ * （`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を読み書きしないこと」）。
+ * 一覧の組み立てだけを切り出した `buildCommands` に、行き先を渡して呼ぶ。
+ */
+function realCommandsIn(dir: string): readonly Command[] {
+  const configStore = createJsonConfigStore(join(dir, "config.json"));
+
+  return buildCommands({
+    deps: {
+      store: createJsonlStore(join(dir, "entries.jsonl")),
+      now: () => new Date(),
+      newId: () => "real",
+    },
+    configStore,
+    loadConfig: () => loadEffectiveConfig(configStore, {}),
+    env: {},
+    terminal: PLAIN_TERMINAL,
+    confirm: refuseConfirm,
+  });
+}
+
+/** 名前だけを持つコマンド。突き合わせの検査で、増減と並び替えを作るために使う。 */
+function fake(name: string): Command {
+  return {
+    name,
+    summary: `${name} のダミー`,
+    usage: { options: [] },
+    run: () => undefined,
+  };
+}
 
 interface Registry {
   readonly commands: readonly Command[];
@@ -504,23 +548,77 @@ describe("実装されていない機能が書かれていない（DoD）", () =
   });
 
   it("`src/cli.ts` が組み立てるコマンドと、このテストが組み立てるコマンドが一致する", async () => {
-    // **コマンド一覧は `commands: [ ... ]` として読む。** `buildRuntime` は
-    // コマンドと実行前の警告（#24）をまとめて返すので、`return` の直後が配列とは限らない。
-    // 名前で位置を決めているぶん、`cli.ts` の書き方を変えるとここも直す必要がある
-    const source = await readFile(join(ROOT, "src", "cli.ts"), "utf8");
-    const from = source.indexOf("function buildRuntime(");
-    expect(from).toBeGreaterThan(-1);
+    // **本物を呼んで一覧を得る。** README の実行例は下の `buildRegistry` が組み立てた
+    // 一式で走らせる（一時ディレクトリを使うため）ので、本物との食い違いをここで見張る。
+    // これが無いと、コマンドを1つ足しても README の検証がそれを見ないまま通る
+    const dir = await mkdtemp(join(tmpdir(), "tock-readme-"));
+    try {
+      expectSameCommands(
+        realCommandsIn(dir),
+        buildRegistry(dir, steppingClock(LATE_IN_DAY)).commands,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
 
-    const listStart = source.indexOf("commands: [", from);
-    const listEnd = source.indexOf("],", listStart);
-    expect(listStart).toBeGreaterThan(-1);
-    expect(listEnd).toBeGreaterThan(listStart);
+/**
+ * コマンド一覧の突き合わせそのものの検査（#102）。
+ *
+ * 上の1件は「実装とテストが一致している」ことしか言わない。**一致していないときに
+ * 落ちるか**は、それだけでは分からない。増減の両方向と、空同士で素通ししないことを
+ * ここで固定する。
+ */
+describe("コマンド一覧の突き合わせ（#102）", () => {
+  it("並び順だけが違う場合は一致とみなす", () => {
+    const real = [fake("start"), fake("stop"), fake("status")];
+    const registry = [fake("status"), fake("start"), fake("stop")];
 
-    const used = [
-      ...new Set(source.slice(listStart, listEnd).match(/create[A-Za-z]*Command/g) ?? []),
-    ];
+    expect(() => {
+      expectSameCommands(real, registry);
+    }).not.toThrow();
+  });
 
-    expect(used.toSorted()).toEqual(FACTORIES.toSorted());
+  it("実装側に1つ多いと落ちる（境界: コマンドを1つ足した）", () => {
+    const registry = [fake("start"), fake("stop")];
+    const real = [...registry, fake("switch")];
+
+    expect(() => {
+      expectSameCommands(real, registry);
+    }).toThrow();
+  });
+
+  it("実装側に1つ足りないと落ちる（境界: コマンドを1つ減らした）", () => {
+    const registry = [fake("start"), fake("stop"), fake("switch")];
+    const real = [fake("start"), fake("stop")];
+
+    expect(() => {
+      expectSameCommands(real, registry);
+    }).toThrow();
+  });
+
+  it("両方が空だと素通しせずに落ちる（境界: 検査対象ゼロで合格しない）", () => {
+    expect(() => {
+      expectSameCommands([], []);
+    }).toThrow();
+  });
+
+  it("生成関数の名前・戻り値の形・整形が違っても、名前が同じなら落ちない", () => {
+    // 本物は配列で、テスト側はオブジェクトに包んだうえで並びも違う。
+    // ソースを読んでいたころはこの形の違いだけで落ちた（#102 の再現）
+    const asArray = [fake("start"), fake("stop")];
+    const wrapped = { commands: [fake("stop"), fake("start")] };
+
+    expect(() => {
+      expectSameCommands(asArray, wrapped.commands);
+    }).not.toThrow();
+  });
+
+  it("この検査が `src/cli.ts` をソースの文字列として読んでいない（#102 の回帰）", async () => {
+    const self = await readFile(join(ROOT, "tests", "docs", "readme.test.ts"), "utf8");
+
+    expect(/readFile\([^;]*\bsrc\b[^;]*cli/.test(self)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 概要

`tests/docs/readme.test.ts` の「コマンド一覧の一致」の検査を、**`src/cli.ts` をテキストとして読む形から、実物を呼んで名前で突き合わせる形に置き換えた。**

`src/cli.ts` から一覧の組み立てだけを **`buildCommands`** として切り出し、行き先（保存先・設定・端末・確認の取り方）を引数で受け取る形にした。`buildRuntime` はそこへ実物を渡すだけになる。

**`buildRuntime` をそのまま呼ぶ形は採れない**（Issue の「実装上の制約」）。内部で `resolveStorePath(process.env, homedir())` を呼ぶので、テストから呼ぶと実ユーザーの `~/.tock` を指すパスが組み立てられる。切り出したほうなら一時ディレクトリを渡せる。

突き合わせは **`tock <name>` の名前の並び**で行う。関数名・戻り値の形・整形はそこに現れないので、書き方を変えただけでは落ちない。

Closes #102

## 受け入れ条件

- [x] `tests/docs/readme.test.ts` が `src/cli.ts` を**文字列として読んでいない**（`readFile` で `cli.ts` を開く箇所が無い）
      → 該当箇所を削除し、回帰も固定した。`tests/docs/readme.test.ts` の「**この検査が `src/cli.ts` をソースの文字列として読んでいない（#102 の回帰）**」がテストファイル自身を読んで確認する
      → 実行結果:
      ```console
      $ grep -n 'readFile(join(ROOT, "src"' tests/docs/readme.test.ts
      $ echo $?
      1
      ```

- [x] `src/cli.ts` の関数名・戻り値の形・整形を変えても、コマンド一覧が同じならこのテストが落ちないことを確認したテストがある
      → 「**生成関数の名前・戻り値の形・整形が違っても、名前が同じなら落ちない**」。本物は配列、テスト側はオブジェクトに包んだうえで並びも変えて、一致とみなされることを固定する
      → 加えて「並び順だけが違う場合は一致とみなす」

- [x] **`src/cli.ts` のコマンド一覧を1つ増やす／減らすと、このテストが落ちる**（検査の目的が保たれていること。mutation test で確認する）
      → 下の mutation test の 1・2 で確認（実物を壊して両方向とも落ちた）。合成データ側も「実装側に1つ多いと落ちる」「実装側に1つ足りないと落ちる」で固定

- [x] テストが実ユーザーの `~/.tock` を読み書きしない（`TOCK_DIR` か一時ディレクトリを使う。既存の方針どおり）
      → `realCommandsIn(dir)` は `mkdtemp` で作った一時ディレクトリの `entries.jsonl` / `config.json` を渡す。`homedir()` は呼ばない（`buildCommands` は実行環境を一切読まない）

- [x] `npm run check` が通る
      → **61 files / 1708 tests** green

### 境界値（Issue の指定）

| 境界 | テスト |
| --- | --- |
| コマンドを1つ足した | 「実装側に1つ多いと落ちる（境界: コマンドを1つ足した）」 |
| コマンドを1つ減らした | 「実装側に1つ足りないと落ちる（境界: コマンドを1つ減らした）」 |
| 並び順だけが違う | 「並び順だけが違う場合は一致とみなす」 |
| **0個で素通ししない** | 「両方が空だと素通しせずに落ちる（境界: 検査対象ゼロで合格しない）」 |

0個の扱いは `expectSameCommands` に `expect(...).not.toEqual([])` として入れてある。一覧の取り出し方を間違えて両方が空になると突き合わせ自体は通ってしまい、**検査が何も見ていない状態に気づけない**ため。

### 振る舞いが変わっていないこと

```console
$ tock --help
使い方: tock <command> [args]

コマンド:
  start    作業を開始する
  stop     作業を終了する
  status   実行中の作業を表示する
  switch   実行中の作業を終了して次の作業を開始する
  today    今日のタグ別合計を表示する
  summary  指定した日のタグ別合計を表示する
  log      記録を新しい順に一覧表示する
  week     週のタグ別・曜日別の集計を表示する
  edit     記録を修正する
  rm       記録を削除する
  export   記録を CSV / JSON で書き出す
  config   設定を読み書きする
```

`confirm` の注入点も配り方を変えたので、実際に叩いて確認した。

```console
$ tock rm 9829864f
確認の入力を受け取れません（対話端末ではありません）。--yes を付けて実行してください: 削除しますか: 打ち間違い #work（id: 9829864f）
$ echo $?
1
$ tock rm 9829864f --yes
削除しました: 打ち間違い #work
id: 9829864f
$ echo $?
0
```

## mutation test

**5箇所すべてでテストが落ちた。**

| 壊した内容 | 落ちたテスト |
| --- | --- |
| `buildCommands` から `config` を1つ削る | 1件 |
| `buildCommands` に1つ足す（`status` を2回） | 1件 |
| `buildCommands` が空配列を返す | 1件 |
| `today` の配線を `summary` に取り違える | 1件 |
| **`buildRuntime` が `buildCommands` を使わず自前で組み立て、`config` を落とす** | **2件（e2e）** |

### 5つ目について（この検査の守備範囲）

**この PR の検査が見ているのは `buildCommands` であって、`buildRuntime` が実際に何を積んだかではない。** 気になったので確かめたところ、`buildRuntime` が `buildCommands` を使わず自前で組み立てて1つ落とす形は、**`readme.test.ts` では落ちなかった**。落としたのは e2e のほうだった。

```
FAIL  tests/e2e/cli.test.ts > --help が登録されているコマンドを列挙する（配線の抜けを見つける）
FAIL  tests/e2e/cli.test.ts > 設定ファイルも TOCK_DIR の中に書く
```

`tests/e2e/cli.test.ts` はビルド済みの CLI を起動して `--help` の出力に12個の名前が並ぶことを見ているので、**`buildRuntime` が実際に配ったもの**はそちらが押さえている。2つ合わせて、一覧の食い違いは両側から見張られる。

**ただし e2e が見るのは名前の存在なので、`buildRuntime` 側だけでコマンドが「増えた」場合は落ちない。** `buildCommands` が唯一の一覧である限り起きないが、検査の限界として書いておく。置き換え前のテストは `buildRuntime` のソースを読んでいたぶんここを見ていたので、**守備範囲は同じではない**（見る対象が「書いてある文字」から「返る値」に変わった）。

## スタック

- base: `main`

**`src/cli.ts` を触るので PR #97（#64 タイムゾーン注入）と衝突する。** #97 は `buildRuntime` の中の `loadConfig` の配り方を変えており、この PR はその部分を `buildCommands` の呼び出しへ移している。先に入った側を後続が取り込む形になる（どちらの順でも解ける）。Issue #102 の備考には「#97 のマージ後に着手するほうが解消が1回で済む」と書いたが、**`main` が12時間動いておらず他の open Issue はすべて PR 済み**だったため、衝突を承知で着手した。順番を待つべきというご判断なら閉じます。

## 依存の追加

なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_