### PR TITLE
[E7-5][P2] コマンド一覧の突き合わせが buildCommands しか見ておらず、buildRuntime が足したコマンドを検出できない

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -379,13 +379,41 @@ export function buildCommands(parts: CommandParts): readonly Command[] {
 }
 
 /**
+ * `buildRuntime` が外の世界から受け取るもの（#106）。
+ *
+ * **保存先・端末・確認の取り方・時計をすべて引数にする。** 以前は内部で
+ * `process.env` と `homedir()` を読んでいたため、テストから呼ぶと実ユーザーの
+ * `~/.tock` を指すパスが組み立てられ、**呼べなかった**（`CLAUDE.md`「テストが
+ * ユーザーの実際の `~/.tock` を読み書きしないこと」）。
+ *
+ * 呼べないぶん、コマンド一覧の突き合わせは `buildCommands` までしか見られず、
+ * **`buildRuntime` が一覧に手を加えても誰も気づかなかった**——`--help` に同じ
+ * コマンドが2回出る状態で全件が通る穴があった。
+ */
+export interface RuntimeEnvironment {
+  readonly env: Readonly<Record<string, string | undefined>>;
+  /** ホームディレクトリ。`TOCK_DIR` が無いときの保存先の基点になる。 */
+  readonly home: string;
+  readonly terminal: Terminal;
+  readonly confirm: Confirm;
+  readonly now: () => Date;
+  readonly newId: () => string;
+  /** 読めない行の報告先（#85）。 */
+  readonly err: (line: string) => void;
+}
+
+/**
  * 実際に使うサブコマンドと、実行前の警告を組み立てる。
  *
- * 保存先の決定と現在時刻・採番の取得はここでだけ行う。`run` と各コマンドは注入された
- * ものしか使わないので、テストは一時ディレクトリと固定した時刻で完全に再現できる。
+ * **これが `tock` に配られる一覧そのもの。** `buildCommands` の結果をそのまま渡すが、
+ * ここで手を加えれば当然変わる。テストから同じ形で呼べるようにしてあるので、
+ * 増減も重複も突き合わせで見つかる（#106）。
  */
-function buildRuntime(err: (line: string) => void): Pick<CliDeps, "commands" | "noticesBeforeRun"> {
-  const storePath = resolveStorePath(process.env, homedir());
+export function buildRuntime(
+  environment: RuntimeEnvironment,
+): Pick<CliDeps, "commands" | "noticesBeforeRun"> {
+  const { env, home, terminal, confirm, now, newId, err } = environment;
+  const storePath = resolveStorePath(env, home);
   const deps = {
     // **読めない行を飛ばしたら stderr に件数を出す（#85・案2）。** 黙って飛ばすと、
     // 手で編集して壊した記録が消えたことに気づけない。行そのものは消していないので、
@@ -396,23 +424,23 @@ function buildRuntime(err: (line: string) => void): Pick<CliDeps, "commands" | "
           `行そのものは消していません`,
       );
     }),
-    now: () => new Date(),
-    newId: randomId,
+    now,
+    newId,
   };
 
   // 設定は必要になったコマンドがその場で読む。すべての起動でファイルを読むと、
   // 設定を使わない打刻まで設定ファイルの状態に引きずられる
-  const configStore = createJsonConfigStore(resolveConfigPath(process.env, homedir()));
-  const loadConfig = () => loadEffectiveConfig(configStore, process.env);
+  const configStore = createJsonConfigStore(resolveConfigPath(env, home));
+  const loadConfig = () => loadEffectiveConfig(configStore, env);
 
   return {
     commands: buildCommands({
       deps,
       configStore,
       loadConfig,
-      env: process.env,
-      terminal: resolveTerminal(process.stdout),
-      confirm: confirmOnStdin,
+      env,
+      terminal,
+      confirm,
     }),
     noticesBeforeRun: () => overrunNotices(deps.store, loadConfig, deps.now()),
   };
@@ -520,7 +548,15 @@ if (invokedAsEntryPoint()) {
     out: createLineWriter(process.stdout, reportWriteError),
     err: errWriter,
     version: readVersion,
-    ...buildRuntime(errWriter),
+    ...buildRuntime({
+      env: process.env,
+      home: homedir(),
+      terminal: resolveTerminal(process.stdout),
+      confirm: confirmOnStdin,
+      now: () => new Date(),
+      newId: randomId,
+      err: errWriter,
+    }),
   });
 
   // `EPIPE` は終了コードを変えない。読み手が先に終わるのは正常な操作であり、

--- a/tests/cli/runtime-command-list.test.ts
+++ b/tests/cli/runtime-command-list.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildCommands, buildRuntime, type Command } from "../../src/cli.js";
+import { PLAIN_TERMINAL } from "../../src/format/terminal.js";
+import { createJsonConfigStore, loadEffectiveConfig } from "../../src/store/config-store.js";
+import { createJsonlStore } from "../../src/store/jsonl-store.js";
+import { resolveConfigPath, resolveStorePath } from "../../src/store/store.js";
+
+/**
+ * **実際に配られるコマンド一覧を見張る（#106）。**
+ *
+ * #102 で、`readme.test.ts` の突き合わせをソースの文字列読みから外して `buildCommands` を
+ * 呼ぶ形にした。そのとき残った穴が、`buildRuntime` が `buildCommands` の結果に手を加えても
+ * 誰も気づかないこと——**`--help` に同じコマンドが2回出る状態で 1953 件すべてが通った。**
+ *
+ * 削除の側は e2e（`--help` に名前が並ぶか）が拾うが、**追加の側は素通りする。**
+ * ここでは `buildRuntime` そのものを呼んで、配られる一覧を直接比べる。
+ *
+ * **実ユーザーの `~/.tock` に触らない。** `buildRuntime` は保存先を
+ * `resolveStorePath(env, home)` で決めるので、`env` と `home` を引数で受け取る形にして
+ * 一時ディレクトリを渡す（`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を
+ * 読み書きしないこと」）。
+ */
+
+let dir = "";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tock-runtime-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** 一時ディレクトリだけを見る実行環境。 */
+function environmentIn(home: string) {
+  return {
+    env: { TOCK_DIR: home },
+    home,
+    terminal: PLAIN_TERMINAL,
+    confirm: () => Promise.resolve(false),
+    now: () => new Date("2026-08-16T00:00:00Z"),
+    newId: () => "runtime-test",
+    err: () => undefined,
+  };
+}
+
+/** `buildCommands` を同じ行き先で直接呼ぶ（比較の相手）。 */
+function directCommandsIn(home: string): readonly Command[] {
+  const configStore = createJsonConfigStore(resolveConfigPath({ TOCK_DIR: home }, home));
+
+  return buildCommands({
+    deps: {
+      store: createJsonlStore(resolveStorePath({ TOCK_DIR: home }, home)),
+      now: () => new Date("2026-08-16T00:00:00Z"),
+      newId: () => "runtime-test",
+    },
+    configStore,
+    loadConfig: () => loadEffectiveConfig(configStore, {}),
+    env: {},
+    terminal: PLAIN_TERMINAL,
+    confirm: () => Promise.resolve(false),
+  });
+}
+
+function names(commands: readonly Command[]): string[] {
+  return commands.map((command) => command.name).toSorted();
+}
+
+describe("buildRuntime が配る一覧を見張る（DoD）", () => {
+  it("**`buildRuntime` の一覧が `buildCommands` の一覧と一致する**", () => {
+    const runtime = buildRuntime(environmentIn(dir));
+
+    expect(names(runtime.commands)).toEqual(names(directCommandsIn(dir)));
+  });
+
+  it("一覧が空でない（検査対象ゼロで合格しない）", () => {
+    expect(names(buildRuntime(environmentIn(dir)).commands)).not.toEqual([]);
+  });
+
+  it("**同じ名前が2回現れない**（重複を足しても気づけるように）", () => {
+    const found = names(buildRuntime(environmentIn(dir)).commands);
+
+    expect(found).toEqual([...new Set(found)]);
+  });
+
+  it("実行前の警告も組み立てられている（配線の抜けを見つける）", () => {
+    expect(buildRuntime(environmentIn(dir)).noticesBeforeRun).toBeTypeOf("function");
+  });
+});
+
+describe("実ユーザーの ~/.tock に触らない（DoD）", () => {
+  it("**`buildRuntime` を呼んでも一時ディレクトリの外にファイルを作らない**", async () => {
+    const before = await readdir(dir);
+
+    buildRuntime(environmentIn(dir));
+
+    // 組み立てただけでは何も書かない（読み書きはコマンドを走らせたとき）
+    expect(await readdir(dir)).toEqual(before);
+  });
+
+  it("保存先が渡した home の下に決まる", () => {
+    expect(resolveStorePath({ TOCK_DIR: dir }, dir).startsWith(dir)).toBe(true);
+    expect(resolveConfigPath({ TOCK_DIR: dir }, dir).startsWith(dir)).toBe(true);
+  });
+
+  it("`TOCK_DIR` が無くても、渡した home の下に決まる（境界: 環境変数なし）", () => {
+    expect(resolveStorePath({}, dir).startsWith(dir)).toBe(true);
+  });
+});
+
+/** 名前だけを持つコマンド。増減・重複・並び替えを作るために使う。 */
+function fake(name: string): Command {
+  return {
+    name,
+    summary: `${name} のダミー`,
+    usage: { options: [] },
+    run: () => undefined,
+  };
+}
+
+/** 検査の本体。`buildRuntime` の一覧と比較相手を突き合わせる。 */
+function problems(runtime: readonly Command[], direct: readonly Command[]): string[] {
+  const found: string[] = [];
+
+  if (names(runtime).length === 0) {
+    found.push("一覧が空（検査対象ゼロ）");
+  }
+  if (names(runtime).length !== new Set(names(runtime)).size) {
+    found.push("同じ名前が2回ある");
+  }
+  if (JSON.stringify(names(runtime)) !== JSON.stringify(names(direct))) {
+    found.push("一覧が食い違っている");
+  }
+
+  return found;
+}
+
+describe("突き合わせの向き（境界）", () => {
+  it("一致していれば問題なし", () => {
+    expect(problems([fake("start"), fake("stop")], [fake("stop"), fake("start")])).toEqual([]);
+  });
+
+  it("**1つ多いと落ちる**（この Issue の主対象）", () => {
+    const direct = [fake("start"), fake("stop")];
+
+    expect(problems([...direct, fake("switch")], direct)).toContain("一覧が食い違っている");
+  });
+
+  it("**1つ足りないと落ちる**", () => {
+    const direct = [fake("start"), fake("stop"), fake("switch")];
+
+    expect(problems([fake("start"), fake("stop")], direct)).toContain("一覧が食い違っている");
+  });
+
+  it("**同じコマンドが2回登録されていると落ちる**（`--help` に2行出る形）", () => {
+    const direct = [fake("start"), fake("stop")];
+
+    expect(problems([...direct, fake("start")], direct)).toContain("同じ名前が2回ある");
+  });
+
+  it("両方が空でも素通しせずに落ちる（境界: 0個）", () => {
+    expect(problems([], [])).toContain("一覧が空（検査対象ゼロ）");
+  });
+
+  it("並び順だけが違う場合は一致とみなす", () => {
+    const shuffled = [fake("stop"), fake("switch"), fake("start")];
+    const direct = [fake("start"), fake("stop"), fake("switch")];
+
+    expect(problems(shuffled, direct)).toEqual([]);
+  });
+});

--- a/tests/docs/readme.test.ts
+++ b/tests/docs/readme.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { buildCommands, type Command, EXIT_OK, run, UserError } from "../../src/cli.js";
+import { buildRuntime, type Command, EXIT_OK, run, UserError } from "../../src/cli.js";
 import { createConfigCommand } from "../../src/commands/config.js";
 import { createEditCommand } from "../../src/commands/edit.js";
 import { createExportCommand } from "../../src/commands/export.js";
@@ -117,32 +117,33 @@ function commandNames(commands: readonly Command[]): string[] {
  */
 function expectSameCommands(real: readonly Command[], registry: readonly Command[]): void {
   expect(commandNames(real)).not.toEqual([]);
+  // **同じ名前を2回登録していないこと（#106）。** 名前の並びを比べるだけだと、
+  // 重複を足した側とテスト側の両方に同じ名前があれば通ってしまう
+  expect(commandNames(real)).toEqual([...new Set(commandNames(real))]);
   expect(commandNames(real)).toEqual(commandNames(registry));
 }
 
 /**
- * `src/cli.ts` が実際に組み立てる一覧を、一時ディレクトリの上で得る。
+ * `src/cli.ts` が**実際に配る**一覧を、一時ディレクトリの上で得る。
  *
- * **`buildRuntime` は呼べない。** 内部で `resolveStorePath(process.env, homedir())` を
- * 呼ぶので、テストから呼ぶと実ユーザーの `~/.tock` を指すパスが組み立てられる
- * （`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を読み書きしないこと」）。
- * 一覧の組み立てだけを切り出した `buildCommands` に、行き先を渡して呼ぶ。
+ * **`buildRuntime` を呼ぶ（#106）。** 以前は `buildCommands` を呼んでいたが、それだと
+ * `buildRuntime` が結果に手を加えても気づけなかった——**`--help` に同じコマンドが2回出る
+ * 状態で全件が通った。** 配られる一覧そのものを見るのが、この検査の目的に合う。
+ *
+ * `buildRuntime` は保存先を `resolveStorePath(env, home)` で決めるので、`env` と `home` に
+ * 一時ディレクトリを渡す（`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を
+ * 読み書きしないこと」）。**組み立てるだけでファイルには触らない。**
  */
 function realCommandsIn(dir: string): readonly Command[] {
-  const configStore = createJsonConfigStore(join(dir, "config.json"));
-
-  return buildCommands({
-    deps: {
-      store: createJsonlStore(join(dir, "entries.jsonl")),
-      now: () => new Date(),
-      newId: () => "real",
-    },
-    configStore,
-    loadConfig: () => loadEffectiveConfig(configStore, {}),
-    env: {},
+  return buildRuntime({
+    env: { TOCK_DIR: dir },
+    home: dir,
     terminal: PLAIN_TERMINAL,
     confirm: refuseConfirm,
-  });
+    now: () => new Date(),
+    newId: () => "real",
+    err: () => undefined,
+  }).commands;
 }
 
 /** 名前だけを持つコマンド。突き合わせの検査で、増減と並び替えを作るために使う。 */


### PR DESCRIPTION
## 概要

コマンド一覧の突き合わせを、**`buildRuntime` が実際に配る一覧**に向け直した。

`buildRuntime` をテストから呼べなかったのは、内部で `process.env` と `homedir()` を読んでいて、実ユーザーの `~/.tock` を指すパスが組み立てられるため（`CLAUDE.md`「テストがユーザーの実際の `~/.tock` を読み書きしないこと」）。**保存先・端末・確認の取り方・時計を `RuntimeEnvironment` として引数で受け取る形**にして、一時ディレクトリを渡せるようにした。

Closes #106

## 受け入れ条件

- [x] **`buildRuntime` だけにコマンドを1つ足すと、テストが落ちる**
      → 下の mutation の1・2で確認（**以前は 1953 件すべて通っていた**）。
      `tests/cli/runtime-command-list.test.ts` の「**`buildRuntime` の一覧が `buildCommands` の一覧と一致する**」「**同じ名前が2回現れない**」

- [x] **`buildRuntime` だけからコマンドを1つ減らすと、テストが落ちる**
      → 下の mutation の3（4件落ちた）

- [x] `buildCommands` を増減させた場合も、引き続き落ちる（#102 の性質を壊していない）
      → 下の mutation の4

- [x] 並び順だけが違う場合は一致とみなす（#102 と同じ）
      → 同ファイル「並び順だけが違う場合は一致とみなす」

- [x] コマンドが0個の場合に、空同士で素通しして通らないこと
      → 同「両方が空でも素通しせずに落ちる（境界: 0個）」。下の mutation の5でも確認

- [x] テストが実ユーザーの `~/.tock` を読み書きしない（一時ディレクトリを使う）
      → describe「実ユーザーの ~/.tock に触らない（DoD）」3件。
      `env: { TOCK_DIR: dir }` と `home: dir` を渡し、**組み立てただけでファイルが増えないこと**も確かめている

- [x] `npm run check` が通る
      → **74 files / 1975 tests** green（+13件）

### 振る舞いが変わっていないこと

```console
$ tock --help
コマンド:
  start    作業を開始する
  stop     作業を終了する
  status   実行中の作業を表示する
  switch   実行中の作業を終了して次の作業を開始する
  today    今日のタグ別合計を表示する
  summary  指定した日のタグ別合計を表示する
  log      記録を新しい順に一覧表示する
  week     週のタグ別・曜日別の集計を表示する
  edit     記録を修正する
  rm       記録を削除する
  export   記録を CSV / JSON で書き出す
  config   設定を読み書きする

（12 行 / ユニーク 12。重複なし）
```

保存先の解決と、実行前の警告（`noticesBeforeRun`）の配線も確認した。

```console
$ TOCK_DIR=/tmp/xxx tock start "設計 #work" --at 00:10 && tock stop --at 00:20
$ tock today
2026-08-16
work  10m
合計  10m
$ ls /tmp/xxx
entries.jsonl

$ tock status          # 前月から実行中の記録がある状態
実行中の作業が 8時間 を超えています（開始: 2026-08-01T00:00:00.000Z）。止め忘れであれば tock stop --auto で上限の時刻に打ち切れます
実行中: 止め忘れ
```

## mutation test

**5箇所すべてで落ちた。** 落ちたテストのファイルも併記する——**この PR の前後で何が変わったか**が分かるように。

| 壊した内容 | 落ちたテスト | 落ちたファイル |
| --- | --- | --- |
| **`buildRuntime` だけにコマンドを1つ足す（`status` を重複）** | 3件 | `runtime-command-list` / `readme` |
| **`buildRuntime` だけにコマンドを1つ足す（`config` を重複）** | 3件 | `runtime-command-list` / `readme` |
| `buildRuntime` だけからコマンドを1つ減らす | 4件 | `runtime-command-list` / `readme` / `e2e` |
| `buildCommands` から1つ減らす（#102 の性質） | 3件 | `readme` / `e2e` |
| `buildRuntime` が空の一覧を配る | 13件 | `runtime-command-list` / `readme` / `e2e` |

**上の2つが、この Issue の主対象。** 同じ変異を `main` に当てると **1953 件すべてが通り**、ビルドして叩くと `--help` に `status` が2回出る状態でした（Issue の再現）。

## 設計について

**`RuntimeEnvironment` にまとめた理由。** `buildRuntime` が読んでいた外の世界は保存先だけではなく、端末幅（`process.stdout`）・確認の取り方（標準入力）・時計・採番もありました。保存先だけを引数にしても、残りが実行環境に張り付いたままだとテストから呼ぶ意味が薄い。**1つの型にまとめて、起動部だけが本物を詰める形**にしています。

**重複の検査を足した。** 名前の並びを比べるだけだと、重複を足した側とテスト側の両方に同じ名前があれば通ってしまいます（`toSorted()` の比較では `["config","config",...]` 同士が一致しうる）。`readme.test.ts` の `expectSameCommands` にも同じ主張を入れました。

**e2e の `--help` 検査は残しています。** あちらは**ビルド済みのバイナリを起動する唯一の経路**で、この PR が見ているのは関数の戻り値です。削除の側を両方から見張る形になります。

## スタック

- base: `main`（open な PR は無し）

## 依存の追加

なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSp7tp4beNzBvdZGhAJXya)_